### PR TITLE
Fix/macos kill drivers plus pom parent added

### DIFF
--- a/jdi-light-examples/pom.xml
+++ b/jdi-light-examples/pom.xml
@@ -9,9 +9,17 @@
     <artifactId>jdi-light-examples</artifactId>
     <name>JDI Web Tests</name>
 
+    <parent>
+        <groupId>com.epam.jdi</groupId>
+        <version>2.0.21</version>
+        <artifactId>jdi-2</artifactId>
+    </parent>
+
     <properties>
-        <aspectj.version>1.8.5</aspectj.version>
+        <!--<aspectj.version>1.8.5</aspectj.version>-->
         <driver>chrome</driver>
+        <jetty.version>9.4.12.RC2</jetty.version>
+
     </properties>
 
 
@@ -35,10 +43,25 @@
         <plugins>
 
             <!--Allure reporting -->
+
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+                <configuration>
+                    <webAppSourceDirectory>${project.build.directory}/site/allure-maven-plugin</webAppSourceDirectory>
+
+                    <scanIntervalSeconds>10</scanIntervalSeconds>
+                    <supportedPackagings>
+                        <supportedPackaging>jar</supportedPackaging>
+                    </supportedPackagings>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>${surefire.version}</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
@@ -60,7 +83,7 @@
             <plugin>
                 <groupId>ru.yandex.qatools.allure</groupId>
                 <artifactId>allure-maven-plugin</artifactId>
-                <version>2.5</version>
+                <version>${allure.maven.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -75,10 +98,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+                <!-- not needed because of <maven.compiler.source> and <maven.compiler.target> properties-->
+                <!--                <configuration>
+                                    <source>${java.version}</source>
+                                    <target>${java.version}</target>
+                                </configuration>-->
             </plugin>
         </plugins>
         <!-- For using properties from pom -->
@@ -97,7 +121,7 @@
             <plugin>
                 <groupId>ru.yandex.qatools.allure</groupId>
                 <artifactId>allure-maven-plugin</artifactId>
-                <version>RELEASE</version>
+                <version>${allure.maven.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/jdi-light-examples/pom.xml
+++ b/jdi-light-examples/pom.xml
@@ -30,7 +30,7 @@
             <artifactId>jdi-light</artifactId>
             <version>1.0.4</version>
         </dependency>
-		
+
         <!--Allure-->
         <dependency>
             <groupId>ru.yandex.qatools.allure</groupId>
@@ -97,12 +97,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.2</version>
-                <!-- not needed because of <maven.compiler.source> and <maven.compiler.target> properties-->
-                <!--                <configuration>
-                                    <source>${java.version}</source>
-                                    <target>${java.version}</target>
-                                </configuration>-->
+                <version>3.2
+                </version>
+              <configuration>
+                <source>${java.version}</source>
+                <target>${java.version}</target>
+              </configuration>
             </plugin>
         </plugins>
         <!-- For using properties from pom -->

--- a/jdi-light-examples/src/test/java/io/github/epam/TestsInit.java
+++ b/jdi-light-examples/src/test/java/io/github/epam/TestsInit.java
@@ -1,6 +1,8 @@
 package io.github.epam;
 
 import com.epam.jdi.light.driver.WebDriverFactory;
+import com.epam.jdi.light.driver.WebDriverUtils;
+import com.epam.jdi.light.settings.WebSettings;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 
@@ -12,14 +14,22 @@ import static io.github.epam.EpamGithubSite.homePage;
 public class TestsInit {
     @BeforeSuite(alwaysRun = true)
     public static void setUp() {
+      /*  if (WebSettings.KILL_BROWSER.toLowerCase().contains("before")) {
+            WebDriverUtils.killAllBrowsersStartedBySelenium();
+        }*/
         logger.setLogLevel(STEP);
         initElements(EpamGithubSite.class);
         homePage.open();
         logger.toLog("Run Tests");
+
     }
 
     @AfterSuite(alwaysRun = true)
     public static void tearDown() {
+
+      /*  if (WebSettings.KILL_BROWSER.toLowerCase().contains("after")) {
+            WebDriverUtils.killAllBrowsersStartedBySelenium();
+        }*/
         WebDriverFactory.close();
     }
 }

--- a/jdi-light-examples/src/test/java/io/github/epam/TestsInit.java
+++ b/jdi-light-examples/src/test/java/io/github/epam/TestsInit.java
@@ -1,22 +1,21 @@
 package io.github.epam;
 
-import com.epam.jdi.light.driver.WebDriverFactory;
-import com.epam.jdi.light.driver.WebDriverUtils;
-import com.epam.jdi.light.settings.WebSettings;
-import org.testng.annotations.AfterSuite;
-import org.testng.annotations.BeforeSuite;
-
 import static com.epam.jdi.light.elements.init.PageFactory.initElements;
 import static com.epam.jdi.light.logger.LogLevels.STEP;
 import static com.epam.jdi.light.settings.WebSettings.logger;
 import static io.github.epam.EpamGithubSite.homePage;
 
+import com.epam.jdi.light.driver.WebDriverFactory;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+
 public class TestsInit {
-    @BeforeSuite(alwaysRun = true)
+
+    @BeforeMethod
+
+    //  @BeforeSuite(alwaysRun = true)
     public static void setUp() {
-      /*  if (WebSettings.KILL_BROWSER.toLowerCase().contains("before")) {
-            WebDriverUtils.killAllBrowsersStartedBySelenium();
-        }*/
+
         logger.setLogLevel(STEP);
         initElements(EpamGithubSite.class);
         homePage.open();
@@ -24,12 +23,10 @@ public class TestsInit {
 
     }
 
-    @AfterSuite(alwaysRun = true)
-    public static void tearDown() {
+    @AfterMethod(alwaysRun = true)
 
-      /*  if (WebSettings.KILL_BROWSER.toLowerCase().contains("after")) {
-            WebDriverUtils.killAllBrowsersStartedBySelenium();
-        }*/
+    //   @AfterSuite(alwaysRun = true)
+    public static void tearDown() {
         WebDriverFactory.close();
     }
 }

--- a/jdi-light-examples/src/test/java/io/github/epam/tests/epam/FormsTests.java
+++ b/jdi-light-examples/src/test/java/io/github/epam/tests/epam/FormsTests.java
@@ -11,7 +11,7 @@ import static io.github.epam.tests.epam.steps.Preconditions.shouldBeLoggedOut;
 
 public class FormsTests extends TestsInit {
 
-    @Test
+    @Test(enabled =true)
     public void loginTest() {
         shouldBeLoggedOut();
         header.userIcon.click();
@@ -19,7 +19,7 @@ public class FormsTests extends TestsInit {
         homePage.checkOpened();
     }
 
-    @Test
+    @Test(enabled =true)
     public void fillContactFormTest() {
         shouldBeLoggedIn();
         contactFormPage.shouldBeOpened();

--- a/jdi-light-examples/src/test/resources/general.xml
+++ b/jdi-light-examples/src/test/resources/general.xml
@@ -2,6 +2,9 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Test suite" parallel="methods" thread-count="1">
     <test name="Tests" preserve-order="true">
+        <packages>
+            <package name="io.github.epam.tests"></package>
+        </packages>
         <classes>
             <class name="io.github.epam.tests.epam.FormsTests"/>
         </classes>

--- a/jdi-light-examples/src/test/resources/general.xml
+++ b/jdi-light-examples/src/test/resources/general.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Test suite" parallel="methods" thread-count="1">
     <test name="Tests" preserve-order="true">
-        <packages>
+<!--        <packages>
             <package name="io.github.epam.tests"></package>
-        </packages>
+        </packages>-->
         <classes>
             <class name="io.github.epam.tests.epam.FormsTests"/>
         </classes>

--- a/jdi-light-examples/src/test/resources/general.xml
+++ b/jdi-light-examples/src/test/resources/general.xml
@@ -2,9 +2,9 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
 <suite name="Test suite" parallel="methods" thread-count="1">
     <test name="Tests" preserve-order="true">
-<!--        <packages>
+        <packages>
             <package name="io.github.epam.tests"></package>
-        </packages>-->
+        </packages>
         <classes>
             <class name="io.github.epam.tests.epam.FormsTests"/>
         </classes>

--- a/jdi-light-html-tests/pom.xml
+++ b/jdi-light-html-tests/pom.xml
@@ -9,6 +9,14 @@
     <artifactId>jdi-light-html-tests</artifactId>
     <name>JDI Html Tests</name>
 
+
+    <parent>
+        <groupId>com.epam.jdi</groupId>
+        <version>2.0.21</version>
+        <artifactId>jdi-2</artifactId>
+    </parent>
+
+
     <properties>
         <aspectj.version>1.8.5</aspectj.version>
         <driver>chrome</driver>
@@ -38,7 +46,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>${surefire.version}</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
@@ -60,7 +68,7 @@
             <plugin>
                 <groupId>ru.yandex.qatools.allure</groupId>
                 <artifactId>allure-maven-plugin</artifactId>
-                <version>2.5</version>
+                <version>${allure.maven.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -75,10 +83,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
-                <configuration>
+       <!--         <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                </configuration>
+                </configuration> -->
             </plugin>
         </plugins>
         <!-- For using properties from pom -->
@@ -97,7 +105,7 @@
             <plugin>
                 <groupId>ru.yandex.qatools.allure</groupId>
                 <artifactId>allure-maven-plugin</artifactId>
-                <version>RELEASE</version>
+                <version>${allure.maven.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/jdi-light-html/pom.xml
+++ b/jdi-light-html/pom.xml
@@ -14,8 +14,13 @@
         <project.build.sourceEncoding>utf8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>utf8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <aspectj.version>1.8.3</aspectj.version>
-    </properties-->
+    </properties>
+-->
+    <parent>
+        <groupId>com.epam.jdi</groupId>
+        <version>2.0.21</version>
+        <artifactId>jdi-2</artifactId>
+    </parent>
 
     <dependencies>
         <dependency>

--- a/jdi-light-template/pom.xml
+++ b/jdi-light-template/pom.xml
@@ -9,9 +9,15 @@
     <version>1.0</version>
     <name>JDI Test project Template</name>
 
+
+    <parent>
+        <groupId>com.epam.jdi</groupId>
+        <version>2.0.21</version>
+        <artifactId>jdi-2</artifactId>
+    </parent>
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <aspectj.version>1.8.5</aspectj.version>
+        <!--<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>-->
+        <!--<aspectj.version>1.8.5</aspectj.version>-->
         <driver>chrome</driver>
     </properties>
 
@@ -22,7 +28,7 @@
             <artifactId>jdi-light</artifactId>
             <version>RELEASE</version>
         </dependency>
-		
+
         <!--Allure-->
         <dependency>
             <groupId>ru.yandex.qatools.allure</groupId>
@@ -38,7 +44,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.19.1</version>
+                <version>${surefire.version}</version>
                 <configuration>
                     <suiteXmlFiles>
                         <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
@@ -60,7 +66,7 @@
             <plugin>
                 <groupId>ru.yandex.qatools.allure</groupId>
                 <artifactId>allure-maven-plugin</artifactId>
-                <version>2.5</version>
+                <version>${allure.maven.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -75,10 +81,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.2</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
+                <!--      <configuration>
+                          <source>1.8</source>
+                          <target>1.8</target>
+                      </configuration>-->
             </plugin>
         </plugins>
         <!-- For using properties from pom -->
@@ -97,7 +103,7 @@
             <plugin>
                 <groupId>ru.yandex.qatools.allure</groupId>
                 <artifactId>allure-maven-plugin</artifactId>
-                <version>LATEST</version>
+                <version>${allure.maven.version}</version>
             </plugin>
         </plugins>
     </reporting>

--- a/jdi-light/pom.xml
+++ b/jdi-light/pom.xml
@@ -10,11 +10,19 @@
     <packaging>jar</packaging>
     <version>1.0.4</version>
 
+    <parent>
+        <groupId>com.epam.jdi</groupId>
+        <version>2.0.21</version>
+        <artifactId>jdi-2</artifactId>
+    </parent>
+
     <properties>
-        <project.build.sourceEncoding>utf8</project.build.sourceEncoding>
+   <!-- <project.build.sourceEncoding>utf8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>utf8</project.reporting.outputEncoding>
         <java.version>1.8</java.version>
-        <aspectj.version>1.8.3</aspectj.version>
+        <aspectj.maven>1.4</aspectj.maven>
+        -->
+        <!--<aspectj.version>1.8.3</aspectj.version>-->
     </properties>
 
     <dependencies>
@@ -73,10 +81,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
-                <configuration>
+          <!--      <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
-                </configuration>
+                </configuration>-->
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/jdi-light/src/main/java/com/epam/jdi/light/common/UnixProcessUtils.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/common/UnixProcessUtils.java
@@ -1,0 +1,122 @@
+package com.epam.jdi.light.common;
+
+import com.epam.jdi.light.logger.JDILogger;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class UnixProcessUtils {
+
+    private static JDILogger logger=JDILogger.instance(UnixProcessUtils.class.getName());
+
+    public static void main(String[] args) {
+
+        killProcessesTree("chromedriver");
+        return;
+
+
+    }
+
+    /**
+     *
+     * @param rootNamePart
+     */
+    public static void killProcessesTree(String rootNamePart) {
+
+        List<String> chrome = null;
+
+        try {
+            chrome = getPIDsByNamePart(rootNamePart);
+
+            for (String s : chrome) {
+
+                int pid = Integer.parseInt(s);
+                killChildProcesses(pid);
+            }
+            killProcessesByNamePart(rootNamePart);
+
+            logger.info("Process: "+rootNamePart);
+
+
+        } catch (InterruptedException | IOException e) {
+
+            JDILogger.instance(UnixProcessUtils.class.getName())
+                .error(e.getMessage());
+        }
+
+        return;
+    }
+
+    /**
+     *
+     * @param name
+     * @return
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public static List<String> getPIDsByNamePart(String name) throws IOException, InterruptedException {
+        Process process = new ProcessBuilder(
+            "/usr/bin/pgrep",
+            "-afi",
+            name)
+            .start();
+        process.waitFor();
+
+        List<String> list = new ArrayList<>();
+
+        BufferedReader reader =
+            new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+        String line = null;
+        while ((line = reader.readLine()) != null) {
+            list.add(line);
+        }
+        logger.info("Parent Pids: "+list);
+        return list;
+
+    }
+
+    /**
+     *
+     * @param pid
+     */
+    public static void killChildProcesses(int pid) {
+        String ppid = String.valueOf("-P "+pid);
+        killProcessWithArgs(Collections.singletonList(ppid));
+    }
+
+    /**
+     *
+     * @param args
+     */
+    private static void killProcessWithArgs(List<String> args) {
+
+        List<String> list = new ArrayList<>();
+        list.add("/usr/bin/pkill" );
+        list.addAll(args );
+
+        try {
+            Process child = new ProcessBuilder(list.toArray(new String[list.size()]))
+                .start();
+
+            child.waitFor();
+        } catch (InterruptedException | IOException e) {
+
+            JDILogger.instance(UnixProcessUtils.class.getName())
+                .error(e.getMessage());
+        }
+    }
+
+    /**
+     *
+     * @param name
+     */
+    public static void killProcessesByNamePart(String name) {
+        killProcessWithArgs(Arrays.asList("-aif", name));
+    }
+
+}

--- a/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverFactory.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverFactory.java
@@ -16,7 +16,8 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 import static com.epam.jdi.light.common.Exceptions.exception;
-import static com.epam.jdi.light.driver.WebDriverUtils.killAllRunWebBrowsers;
+
+
 import static com.epam.jdi.light.driver.get.DriverData.DRIVER_NAME;
 import static com.epam.jdi.light.driver.get.DriverData.DRIVER_SETTINGS;
 import static com.epam.jdi.light.driver.get.DriverInfos.*;
@@ -184,7 +185,7 @@ public class WebDriverFactory {
         } else {
             throw exception("None Driver has been found for current thread. Probably Fixture configuration is wrong.");
         }
-        killAllRunWebBrowsers();
+       // WebDriverUtils.killAllBrowsersStartedBySelenium();
     }
 
     public static void quit() {

--- a/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverFactory.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverFactory.java
@@ -185,7 +185,7 @@ public class WebDriverFactory {
         } else {
             throw exception("None Driver has been found for current thread. Probably Fixture configuration is wrong.");
         }
-       // WebDriverUtils.killAllBrowsersStartedBySelenium();
+       WebDriverUtils.killAllBrowsersStartedBySelenium();
     }
 
     public static void quit() {

--- a/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverUtils.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverUtils.java
@@ -4,11 +4,13 @@ package com.epam.jdi.light.driver;
  * Created by Roman Iovlev on 14.02.2018 Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
  */
 
-import java.io.IOException;
-
 import static org.openqa.selenium.os.WindowsUtils.killByName;
 
+import com.epam.jdi.light.common.UnixProcessUtils;
+import java.io.IOException;
+
 public final class WebDriverUtils {
+
 
     private WebDriverUtils() {
     }
@@ -64,24 +66,7 @@ public final class WebDriverUtils {
      * @param driverName
      */
     private static void killAllMacOSDriverProcessesByName(String driverName) {
-        try {
-            Process child = new ProcessBuilder(
-                "pkill ",
-                "-9 -P | pgrep ",
-                driverName)
-                .start();
-            child.waitFor();
-
-            Process process = new ProcessBuilder(
-                "pkill -9",
-                "-afi",
-                driverName)
-                .start();
-            process.waitFor();
-
-        } catch (IOException | InterruptedException e1) {
-            e1.printStackTrace();
-        }
+            UnixProcessUtils.killProcessesTree(driverName);
     }
 
 }

--- a/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverUtils.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/driver/WebDriverUtils.java
@@ -1,11 +1,11 @@
 package com.epam.jdi.light.driver;
 
 /**
- * Created by Roman Iovlev on 14.02.2018
- * Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
+ * Created by Roman Iovlev on 14.02.2018 Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
  */
 
-import static com.epam.jdi.light.settings.WebSettings.logger;
+import java.io.IOException;
+
 import static org.openqa.selenium.os.WindowsUtils.killByName;
 
 public final class WebDriverUtils {
@@ -13,13 +13,75 @@ public final class WebDriverUtils {
     private WebDriverUtils() {
     }
 
-    // TODO Add OS type and current user check.
-    public static void killAllRunWebBrowsers() {
-        try {
-            killByName("chromedriver.exe");
-            killByName("geckodriver.exe");
-            killByName("IEDriverServer.exe");
-            killByName("MicrosoftWebDriver.exe");
-        } catch (Throwable ex) { logger.error("Can't kill drivers: ", ex.getMessage()); }
+    /**
+     * @throws IOException
+     */
+    public static void killAllBrowsersStartedBySelenium() {
+        String os = System.getProperty("os.name");
+        if (os.contains("Mac")) {
+            killAllMacOSDriverProcesses();
+        } else {
+            killAllWindowsDriverProcesses();
+        }
     }
+
+    public static void killAllMacOSDriverProcesses() {
+        killMacOSDriverProcesses("firefox");
+        killMacOSDriverProcesses("chrome");
+        killMacOSDriverProcesses("gecko");
+
+    }
+
+    /**
+     *
+     */
+    private static void killAllWindowsDriverProcesses() {
+        killByName("chromedriver.exe");
+        killByName("geckodriver.exe");
+        killByName("IEDriverServer.exe");
+        killByName("MicrosoftWebDriver.exe");
+    }
+
+    private static void killMacOSDriverProcesses(String driverName) {
+
+        String name = null;
+        switch (driverName.toLowerCase()) {
+            case "firefox":
+            case "gecko":
+                name = "geckodriver";
+                break;
+            case "chrome":
+                name = "chromedriver";
+                break;
+
+        }
+        if (name != null) {
+            killAllMacOSDriverProcessesByName(name);
+        }
+    }
+
+    /**
+     * @param driverName
+     */
+    private static void killAllMacOSDriverProcessesByName(String driverName) {
+        try {
+            Process child = new ProcessBuilder(
+                "pkill ",
+                "-9 -P | pgrep ",
+                driverName)
+                .start();
+            child.waitFor();
+
+            Process process = new ProcessBuilder(
+                "pkill -9",
+                "-afi",
+                driverName)
+                .start();
+            process.waitFor();
+
+        } catch (IOException | InterruptedException e1) {
+            e1.printStackTrace();
+        }
+    }
+
 }

--- a/pom.xml
+++ b/pom.xml
@@ -10,17 +10,26 @@
     <name>JDI UI 2.0</name>
     <packaging>pom</packaging>
 
-	
+    <properties>
+        <surefire.version>2.20</surefire.version>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <java.version>1.8</java.version>
+        <allure.maven.version>2.6</allure.maven.version>
+        <aspectj.version>1.9.1</aspectj.version>
+        <aspectj.maven>1.11</aspectj.maven>
+
+    </properties>
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
-                <configuration>
+           <!--     <configuration>
                     <source>1.8</source>
                     <target>1.8</target>
-                </configuration>
+                </configuration>-->
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Killing browsers is successful now on Mac Os. But there was need to change TestsInit before BeforeSuite annotation to @BeforeMethod. The same for the after annotation. Need investigation.