### PR TITLE
Spelling fix

### DIFF
--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/FileAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/FileAssert.java
@@ -42,7 +42,7 @@ public class FileAssert extends BaseAssert {
      * @param text to compare
      * @return FileAssert
      */
-    @JDIAction("Assert that file '{name}' text {0}")
+    @JDIAction("Assert that file '{name}' text is {0}")
     public FileAssert text(Matcher<String> text) {
         boolean result = timer().wait(() -> {
             assertThat(readFileToString(file, "UTF-8"), text); return true; }

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/IsAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/IsAssert.java
@@ -30,7 +30,7 @@ public class IsAssert<A extends IsAssert> extends BaseAssert implements CommonAs
      * Match passed value with the element text
      * @param condition to compare
      */
-    @JDIAction("Assert that '{name}' text {0}")
+    @JDIAction("Assert that '{name}' text is {0}")
     public A text(Matcher<String> condition) {
         jdiAssert(toBaseUIElement("text").getText(), condition);
         return (A) this;

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/IsAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/IsAssert.java
@@ -43,7 +43,7 @@ public class IsAssert<A extends IsAssert> extends BaseAssert implements CommonAs
      * @param attrName
      * @param condition to compare
      */
-    @JDIAction("Assert that '{name}' attribute '{0}' {1}")
+    @JDIAction("Assert that '{name}' attribute '{0}' is {1}")
     public A attr(String attrName, Matcher<String> condition) {
         jdiAssert(element.getAttribute(attrName), condition);
         return (A) this;
@@ -57,7 +57,7 @@ public class IsAssert<A extends IsAssert> extends BaseAssert implements CommonAs
      * @param css
      * @param condition to compare
      */
-    @JDIAction("Assert that '{name}' css '{0}' {1}")
+    @JDIAction("Assert that '{name}' css '{0}' is {1}")
     public A css(String css, Matcher<String> condition) {
         jdiAssert(element.getCssValue(css), condition);
         return (A) this;
@@ -70,7 +70,7 @@ public class IsAssert<A extends IsAssert> extends BaseAssert implements CommonAs
      * Match passed value with the element tag
      * @param condition to compare
      */
-    @JDIAction("Assert that '{name}' tag {0}")
+    @JDIAction("Assert that '{name}' tag is {0}")
     public A tag(Matcher<String> condition) {
         jdiAssert(element.getTagName(), condition);
         return (A) this;

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/ListAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/ListAssert.java
@@ -27,7 +27,7 @@ public class ListAssert<T extends BaseUIElement> extends SelectAssert {
      * @param condition to compare
      * @return ListAssert
      */
-    @JDIAction("Assert that all '{name}' texts {0}") @Override
+    @JDIAction("Assert that all '{name}' texts are {0}") @Override
     public ListAssert<T> texts(Matcher<Collection<? extends String>> condition) {
         jdiAssert(map(elements.execute(), WebElement::getText), condition);
         return this;
@@ -39,7 +39,7 @@ public class ListAssert<T extends BaseUIElement> extends SelectAssert {
      * @param condition to compare
      * @return ListAssert
      */
-    @JDIAction("Assert that all '{name}' attributes {0}") @Override
+    @JDIAction("Assert that all '{name}' attributes are {0}") @Override
     public ListAssert<T> attrs(String attrName, Matcher<Collection<? extends String>> condition) {
         jdiAssert(map(elements.execute(), el -> el.getAttribute(attrName)), condition);
         return this;
@@ -51,7 +51,7 @@ public class ListAssert<T extends BaseUIElement> extends SelectAssert {
      * @param condition to compare
      * @return ListAssert
      */
-    @JDIAction("Assert that all '{name}' elements css '{0}' {1}") @Override
+    @JDIAction("Assert that all '{name}' elements css '{0}' is {1}") @Override
     public ListAssert<T> allCss(String css, Matcher<Collection<? extends String>> condition) {
         jdiAssert(map(elements.execute(), el -> el.getCssValue(css)), condition);
         return this;
@@ -62,7 +62,7 @@ public class ListAssert<T extends BaseUIElement> extends SelectAssert {
      * @param condition to compare
      * @return ListAssert
      */
-    @JDIAction("Assert that all '{name}' tags {0}") @Override
+    @JDIAction("Assert that all '{name}' tags are {0}") @Override
     public ListAssert<T> allTags(Matcher<Collection<? extends String>> condition) {
         jdiAssert(map(elements.execute(), WebElement::getTagName), condition);
         return this;

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/SelectAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/SelectAssert.java
@@ -43,7 +43,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' selected option {0}")
+    @JDIAction("Assert that '{name}' selected option is {0}")
     public SelectAssert selected(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().checked(), condition);
         return this;
@@ -54,7 +54,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' values is {0}")
+    @JDIAction("Assert that '{name}' values are {0}")
     public SelectAssert values(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().values(), condition);
         return this;
@@ -65,7 +65,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' values is {0}")
+    @JDIAction("Assert that '{name}' values are {0}")
     public SelectAssert innerValues(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().innerValues(), condition);
         return this;
@@ -76,7 +76,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' enabled items is {0}")
+    @JDIAction("Assert that '{name}' enabled items are {0}")
     public SelectAssert enabled(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().listEnabled(), condition);
         return this;
@@ -87,7 +87,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' disabled items is {0}")
+    @JDIAction("Assert that '{name}' disabled items are {0}")
     public SelectAssert disabled(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().listDisabled(), condition);
         return this;
@@ -98,7 +98,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that all '{name}' texts is {0}")
+    @JDIAction("Assert that all '{name}' texts are {0}")
     public SelectAssert texts(Matcher<Collection<? extends String>> condition) {
         jdiAssert(selector.execute().values(), condition);
         return this;
@@ -109,7 +109,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that all '{name}' attributes is {0}")
+    @JDIAction("Assert that all '{name}' attributes are {0}")
     public SelectAssert attrs(String attrName, Matcher<Collection<? extends String>> condition) {
         jdiAssert(selector.execute().getAllAttributes().keys(), condition);
         return this;
@@ -120,7 +120,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that all '{name}' elements css '{0}' {1}")
+    @JDIAction("Assert that all '{name}' elements css '{0}' is {1}")
     public SelectAssert allCss(String css, Matcher<Collection<? extends String>> condition) {
         jdiAssert(map(selector.execute().allUI(), el -> el.getCssValue(css)), condition);
         return this;
@@ -131,7 +131,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that all '{name}' tags {0}")
+    @JDIAction("Assert that all '{name}' tags are {0}")
     public SelectAssert allTags(Matcher<Collection<? extends String>> condition) {
         jdiAssert(map(selector.execute().allUI(), UIElement::getTagName), condition);
         return this;
@@ -152,7 +152,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that all '{name}' css classes {0}")
+    @JDIAction("Assert that all '{name}' css classes are {0}")
     public SelectAssert cssClasses(Matcher<Iterable<String>> condition) {
         jdiAssert(selector.execute().classes(), condition);
         return this;
@@ -229,7 +229,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' size {0}")
+    @JDIAction("Assert that '{name}' size is {0}")
     public SelectAssert size(Matcher<Integer> condition) {
         jdiAssert(selector.execute().size(), condition);
         return this;
@@ -240,7 +240,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param size to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' size {0}")
+    @JDIAction("Assert that '{name}' size is {0}")
     public SelectAssert size(int size) {
         return size(is(size));
     }

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/SelectAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/SelectAssert.java
@@ -54,7 +54,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' values {0}")
+    @JDIAction("Assert that '{name}' values is {0}")
     public SelectAssert values(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().values(), condition);
         return this;
@@ -65,7 +65,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' values {0}")
+    @JDIAction("Assert that '{name}' values is {0}")
     public SelectAssert innerValues(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().innerValues(), condition);
         return this;
@@ -76,7 +76,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' enabled items {0}")
+    @JDIAction("Assert that '{name}' enabled items is {0}")
     public SelectAssert enabled(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().listEnabled(), condition);
         return this;
@@ -87,7 +87,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that '{name}' disabled items {0}")
+    @JDIAction("Assert that '{name}' disabled items is {0}")
     public SelectAssert disabled(Matcher<? super List<String>> condition) {
         jdiAssert(selector.execute().listDisabled(), condition);
         return this;
@@ -98,7 +98,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that all '{name}' texts {0}")
+    @JDIAction("Assert that all '{name}' texts is {0}")
     public SelectAssert texts(Matcher<Collection<? extends String>> condition) {
         jdiAssert(selector.execute().values(), condition);
         return this;
@@ -109,7 +109,7 @@ public class SelectAssert extends IsAssert<SelectAssert> {
      * @param condition to compare
      * @return SelectAssert
      */
-    @JDIAction("Assert that all '{name}' attributes {0}")
+    @JDIAction("Assert that all '{name}' attributes is {0}")
     public SelectAssert attrs(String attrName, Matcher<Collection<? extends String>> condition) {
         jdiAssert(selector.execute().getAllAttributes().keys(), condition);
         return this;

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/TableAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/TableAssert.java
@@ -48,7 +48,7 @@ public class TableAssert extends BaseTableAssert<Table, TableAssert> {
          * Make sure that the table has at least a certain number of the specified line
          * @param matchers to compare
          */
-        @JDIAction("Assert that '{name}' has at least '{0}' rows that {0}")
+        @JDIAction("Assert that '{name}' has at least '{0}' rows that are {0}")
         public TableAssert rows(TableMatcher... matchers) {
             jdiAssert(TABLE_MATCHER.execute(table, matchers).size(),
                     greaterThan(table().header().size()*count-1));

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/UIListAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/UIListAssert.java
@@ -82,7 +82,7 @@ public class UIListAssert<T extends Section, E> extends IsAssert<UIListAssert<T,
      * @param item to compare
      * @return UIListAssert
      */
-    @JDIAction("Assert that '{name}' text {0}")
+    @JDIAction("Assert that '{name}' text is {0}")
     public UIListAssert<T, E> value(E item) {
         return and(hasItem(item));
     }
@@ -92,7 +92,7 @@ public class UIListAssert<T extends Section, E> extends IsAssert<UIListAssert<T,
      * @param condition to compare
      * @return UIListAssert
      */
-    @JDIAction("Assert that '{name}' text {0}")
+    @JDIAction("Assert that '{name}' text is {0}")
     public UIListAssert<T, E> value(Matcher<String> condition) {
         jdiAssert(print(data.execute(), Object::toString), condition);
         return this;
@@ -103,7 +103,7 @@ public class UIListAssert<T extends Section, E> extends IsAssert<UIListAssert<T,
      * @param text to compare
      * @return UIListAssert
      */
-    @JDIAction("Assert that '{name}' text {0}")
+    @JDIAction("Assert that '{name}' text is {0}")
     public UIListAssert<T, E> value(String text) {
         elements.clear();
         jdiAssert(select(data.execute(), Object::toString), hasItem(text));
@@ -175,7 +175,7 @@ public class UIListAssert<T extends Section, E> extends IsAssert<UIListAssert<T,
      * @param condition to compare
      * @return UIListAssert
      */
-    @JDIAction("Assert that '{name}' size {0}")
+    @JDIAction("Assert that '{name}' size is {0}")
     public UIListAssert<T, E> size(Matcher<Integer> condition) {
         elements.clear();
         jdiAssert(elements.size(), condition);
@@ -187,7 +187,7 @@ public class UIListAssert<T extends Section, E> extends IsAssert<UIListAssert<T,
      * @param size to compare
      * @return UIListAssert
      */
-    @JDIAction("Assert that '{name}' size {0}")
+    @JDIAction("Assert that '{name}' size is {0}")
     public UIListAssert<T, E> size(int size) {
         return size(equalTo(size));
     }


### PR DESCRIPTION
This doesn't make any sense without 'is' verb. E.g. getting "Assert that '[Element]' text a string containing..."