### PR TITLE
1299 - Links to example for bootstrap elements are provided

### DIFF
--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Alert.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Alert.java
@@ -9,6 +9,10 @@ import com.epam.jdi.light.elements.interfaces.common.IsText;
 
 import static com.epam.jdi.light.common.TextTypes.TEXT;
 
+/**
+ * To see an example of Alert web element please visit https://getbootstrap.com/docs/4.3/components/alerts/
+ */
+
 public class Alert extends UIBaseElement<TextAssert> implements IsText, HasClick, IBaseElement {
 
     public String abLocator = "#dismissible-alert-close-button";

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Badge.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Badge.java
@@ -4,6 +4,10 @@ import com.epam.jdi.light.asserts.generic.UIAssert;
 import com.epam.jdi.light.elements.base.UIBaseElement;
 import com.epam.jdi.light.elements.interfaces.common.IsText;
 
+/**
+ * To see an example of Badge web element please visit https://getbootstrap.com/docs/4.3/components/badge/
+ */
+
 public class Badge extends UIBaseElement<UIAssert> implements IsText {
 
 }

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/BaseImage.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/BaseImage.java
@@ -7,6 +7,10 @@ import com.epam.jdi.light.ui.bootstrap.asserts.BaseImageAssert;
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 import static com.epam.jdi.light.ui.bootstrap.BootstrapUtils.getInt;
 
+/**
+ * To see an example of Image in bootstrap please visit https://getbootstrap.com/docs/4.3/content/images/
+ */
+
 public abstract class BaseImage<A extends BaseImageAssert> extends UIBaseElement<BaseImageAssert> {
     @JDIAction(value = "Get '{name}' image height", level = DEBUG)
     public int height() { return getInt("height", uiElement); }

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Breadcrumb.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Breadcrumb.java
@@ -6,6 +6,8 @@ import com.epam.jdi.light.elements.complex.WebList;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.Css;
 
 /**
+ * To see an example of Breadcrumb web element please visit https://getbootstrap.com/docs/4.3/components/breadcrumb/
+ *
  * Created by Olga Ivanova on 16.09.2019
  * Email: olga_ivanova@epam.com
  */

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Button.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Button.java
@@ -7,6 +7,10 @@ import com.epam.jdi.light.elements.interfaces.common.IsButton;
 
 import static com.epam.jdi.light.common.TextTypes.TEXT;
 
+/**
+ * To see an example of Button web element please visit https://getbootstrap.com/docs/4.3/components/buttons/
+ */
+
 public class Button extends UIBaseElement<TextAssert> implements IsButton, HasBadge {
     public String getText() { return text(TEXT); }
 

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Checkbox.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Checkbox.java
@@ -11,6 +11,10 @@ import com.epam.jdi.light.elements.interfaces.base.SetValue;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 import com.epam.jdi.light.ui.bootstrap.asserts.CheckboxAssert;
 
+/**
+ * To see an example of Checkbox web element as form please visit https://getbootstrap.com/docs/4.3/components/forms/#default-stacked
+ */
+
 public class Checkbox extends UIBaseElement<CheckboxAssert>
         implements HasLabel, SetValue, HasClick, HasCheck {
 

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/ColorSpinner.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/ColorSpinner.java
@@ -6,6 +6,10 @@ import com.epam.jdi.light.ui.bootstrap.asserts.SpinnerColorAssert;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * To see an example of Color Spinner web element please visit https://getbootstrap.com/docs/4.3/components/spinners/#colors
+ */
+
 public class ColorSpinner extends UIBaseElement<SpinnerColorAssert> {
 
     public String getColor(){

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Image.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Image.java
@@ -9,6 +9,10 @@ import com.epam.jdi.light.ui.bootstrap.asserts.ImageAssert;
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 import static com.epam.jdi.light.ui.bootstrap.BootstrapUtils.getInt;
 
+/**
+ * To see an example of Image in bootstrap please visit https://getbootstrap.com/docs/4.3/content/images/
+ */
+
 public class Image extends UIBaseElement<ImageAssert>
         implements HasClick, HasValue {
     // region Actions

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Link.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Link.java
@@ -14,6 +14,10 @@ import static com.epam.jdi.light.common.Exceptions.exception;
 import static com.epam.jdi.light.common.Exceptions.safeException;
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 
+/**
+ * To see an example of Link web element please visit https://getbootstrap.com/docs/4.3/utilities/stretched-link/
+ */
+
 public class Link extends UIBaseElement<LinkAssert>
         implements HasValue, HasClick, IsText {
     // region Actions

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/MultipleInputs.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/MultipleInputs.java
@@ -15,6 +15,10 @@ import org.openqa.selenium.By;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * To see an example of Multiple Inputs web element please visit https://getbootstrap.com/docs/4.3/components/input-group/#multiple-inputs
+ */
+
 public class MultipleInputs extends UIBaseElement<MultipleInputsAssert>
         implements IsInput, HasLabel, HasValue, SetValue {
 

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Progress.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Progress.java
@@ -4,6 +4,10 @@ import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.base.UIBaseElement;
 import com.epam.jdi.light.ui.bootstrap.asserts.ProgressAssert;
 
+/**
+ * To see an example of bootstrap Progress bar please visit https://getbootstrap.com/docs/4.3/components/progress/
+ */
+
 public class Progress extends UIBaseElement<ProgressAssert> {
     @JDIAction(value = "Get '{name}' background color")
     public String getColor() {

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Range.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Range.java
@@ -11,6 +11,11 @@ import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 import static com.epam.jdi.light.ui.bootstrap.BootstrapUtils.asDouble;
 import static com.epam.jdi.light.ui.bootstrap.BootstrapUtils.getDouble;
 
+/**
+ * To see an example of Range web element please visit https://getbootstrap.com/docs/4.3/components/forms/#range-inputs
+ * or https://getbootstrap.com/docs/4.3/components/forms/#range
+ */
+
 public class Range extends UIBaseElement<UIAssert> implements HasLabel, SetValue {
 
     @JDIAction(value = "Get '{name}' thumbValue", level = DEBUG)

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/SelectMenu.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/SelectMenu.java
@@ -6,6 +6,10 @@ import com.epam.jdi.light.elements.complex.WebList;
 import com.epam.jdi.light.elements.composite.Section;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 
+/**
+ * To see an example of Select Menu web element please visit https://getbootstrap.com/docs/4.3/components/forms/#select-menu
+ */
+
 public class SelectMenu extends Section implements ISelector {
 
     @UI("option")

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Spinner.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Spinner.java
@@ -3,6 +3,10 @@ package com.epam.jdi.light.ui.bootstrap.elements.common;
 import com.epam.jdi.light.elements.common.UIElement;
 import com.epam.jdi.tools.Timer;
 
+/**
+ * To see an example of Spinner web element please visit https://getbootstrap.com/docs/4.3/components/spinners/
+ */
+
 public class Spinner extends UIElement {
     public Spinner disappearAfter(int timeoutSec) {
         assertThat().displayed();

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Text.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Text.java
@@ -7,6 +7,10 @@ import com.epam.jdi.light.elements.interfaces.common.IsText;
 
 import static com.epam.jdi.light.common.TextTypes.TEXT;
 
+/**
+ * To see an example of Text in bootstrap please visit https://getbootstrap.com/docs/4.3/utilities/text/
+ */
+
 public class Text extends UIBaseElement<TextAssert>
         implements HasValue, IsText {
 

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/TextArea.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/TextArea.java
@@ -15,6 +15,10 @@ import static com.epam.jdi.light.ui.bootstrap.BootstrapUtils.getInt;
 import static com.epam.jdi.tools.PrintUtils.print;
 import static java.util.Arrays.asList;
 
+/**
+ * To see an example of Text area web element please visit https://getbootstrap.com/docs/4.3/components/forms/#form-controls
+ */
+
 public class TextArea extends UIBaseElement<TextAreaAssert>
         implements HasLabel, SetValue, HasPlaceholder, IsInput {
     // region Actions

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/TextField.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/TextField.java
@@ -9,6 +9,10 @@ import com.epam.jdi.light.ui.bootstrap.asserts.TextFieldAssert;
 
 import static com.epam.jdi.light.common.TextTypes.VALUE;
 
+/**
+ * To see an example of Textfield web element please visit https://getbootstrap.com/docs/4.3/components/forms/
+ */
+
 public class TextField extends UIBaseElement<TextFieldAssert>
         implements HasLabel, SetValue, HasPlaceholder, IsInput {
 

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Tooltip.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/Tooltip.java
@@ -7,6 +7,10 @@ import com.epam.jdi.light.ui.bootstrap.asserts.TooltipAssert;
 
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 
+/**
+ * To see an example of Tooltip web element please visit https://getbootstrap.com/docs/4.3/components/tooltips/#examples
+ */
+
 public class Tooltip extends UIBaseElement<TooltipAssert> implements IsButton {
 
     @JDIAction(value = "Get '{name}' tooltip text", level = DEBUG)

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/VectorImage.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/VectorImage.java
@@ -8,6 +8,10 @@ import org.openqa.selenium.By;
 
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 
+/**
+ * To see an example of Vector Image in bootstrap please visit https://getbootstrap.com/docs/4.3/components/card/#example
+ */
+
 public class VectorImage extends BaseImage<VectorImageAssert> {
 
     @JDIAction(value = "Get '{name}' vector image internal element", level = DEBUG)

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/VectorImage.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/common/VectorImage.java
@@ -9,7 +9,7 @@ import org.openqa.selenium.By;
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 
 /**
- * To see an example of Vector Image in bootstrap please visit https://getbootstrap.com/docs/4.3/components/card/#example
+ * To see an example of Vector Image in bootstrap please visit https://getbootstrap.com/docs/4.3/components/card/#image-overlays
  */
 
 public class VectorImage extends BaseImage<VectorImageAssert> {

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/ButtonGroup.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/ButtonGroup.java
@@ -2,5 +2,9 @@ package com.epam.jdi.light.ui.bootstrap.elements.complex;
 
 import com.epam.jdi.light.elements.composite.Section;
 
+/**
+ * To see an example of Button Group web element please visit https://getbootstrap.com/docs/4.3/components/button-group/
+ */
+
 public class ButtonGroup extends Section {
 }

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/ButtonWithSpinner.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/ButtonWithSpinner.java
@@ -6,6 +6,10 @@ import com.epam.jdi.light.ui.bootstrap.elements.common.Button;
 import com.epam.jdi.light.ui.bootstrap.elements.common.Spinner;
 import com.epam.jdi.light.ui.bootstrap.elements.common.TextField;
 
+/**
+ * To see an example of Button With Spinner web element please visit https://getbootstrap.com/docs/4.3/components/spinners/#buttons
+ */
+
 public class ButtonWithSpinner extends Button implements PageObject {
     public @UI("[class*='spinner']") Spinner spinner;
     public @UI("[class*='spinner'] + span")  TextField span;

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Card.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Card.java
@@ -2,5 +2,9 @@ package com.epam.jdi.light.ui.bootstrap.elements.complex;
 
 import com.epam.jdi.light.elements.composite.Section;
 
+/**
+ * To see an example of Card in bootstrap please visit https://getbootstrap.com/docs/4.3/components/card/#example
+ */
+
 public class Card extends Section {
 }

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/CardImageCaps.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/CardImageCaps.java
@@ -5,6 +5,10 @@ import com.epam.jdi.light.ui.bootstrap.asserts.CardImageCapsAssert;
 import com.epam.jdi.light.ui.bootstrap.elements.common.Image;
 import com.epam.jdi.light.ui.bootstrap.elements.common.Text;
 
+/**
+ * To see an example of Card Image Caps in bootstrap please visit https://getbootstrap.com/docs/4.3/components/card/#images
+ */
+
 public class CardImageCaps extends Card {
     @UI(".card-img-top")
     public Image image;

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Carousel.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Carousel.java
@@ -11,6 +11,10 @@ import com.epam.jdi.light.elements.interfaces.common.IsText;
 import static com.epam.jdi.light.common.Exceptions.exception;
 import static com.epam.jdi.light.common.TextTypes.TEXT;
 
+/**
+ * To see an example of Carousel web element please visit https://getbootstrap.com/docs/4.3/components/carousel/#example
+ */
+
 public class Carousel extends UIBaseElement<TextAssert> implements IsText, IsButton {
 	public String currentSlideLocator = "//div[contains(@class,'carousel-item active')]";
 	public String nextLocator = ".carousel-control-next";

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Collapse.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Collapse.java
@@ -6,6 +6,10 @@ import com.epam.jdi.light.elements.complex.dropdown.DropdownExpand;
 
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 
+/**
+ * To see an example of Collapse web element please visit https://getbootstrap.com/docs/4.3/components/collapse/#example
+ */
+
 public class Collapse extends DropdownExpand {
 
     @JDIAction(level = DEBUG)

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/ListGroup.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/ListGroup.java
@@ -7,6 +7,8 @@ import com.epam.jdi.light.elements.interfaces.common.IsButton;
 import com.epam.jdi.light.ui.bootstrap.asserts.ListGroupAssert;
 
 /**
+ * To see an example of List Group web element please visit https://getbootstrap.com/docs/4.3/components/list-group/
+ *
  * Created by Dmitrii Pavlov on 25.09.2019
  * Email: delnote@gmail.com; Skype: Dmitrii Pavlov
  */

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Pagination.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Pagination.java
@@ -6,6 +6,8 @@ import com.epam.jdi.light.elements.common.UIElement;
 import com.epam.jdi.light.ui.bootstrap.asserts.PaginationAssert;
 
 /**
+ * To see an example of Pagination web element please visit https://getbootstrap.com/docs/4.3/components/pagination/
+ *
  * Created by Dmitrii Pavlov on 26.09.2019
  * Email: delnote@gmail.com; Skype: Dmitrii Pavlov
  */

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Popover.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/Popover.java
@@ -9,6 +9,8 @@ import com.epam.jdi.light.ui.bootstrap.elements.composite.MediaObject;
 import static com.epam.jdi.light.logger.LogLevels.DEBUG;
 
 /**
+ * To see an example of Popover web element please visit https://getbootstrap.com/docs/4.3/components/popovers/#example
+ *
  * Created by Dmitrii Pavlov on 04.10.2019
  * Email: delnote@gmail.com; Skype: Dmitrii Pavlov
  */

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/RadioButtons.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/complex/RadioButtons.java
@@ -12,6 +12,9 @@ import static com.epam.jdi.light.common.ElementArea.ACTION_CLICK;
 import static com.epam.jdi.light.common.TextTypes.LABEL;
 import static com.epam.jdi.light.settings.WebSettings.ANY_ELEMENT;
 
+/**
+ * To see an example of RadioButtons in bootstrap please visit https://getbootstrap.com/docs/4.3/components/forms/#default-stacked
+ */
 
 public class RadioButtons extends UIListBase<UISelectAssert> {
 

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/BootstrapDropdown.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/BootstrapDropdown.java
@@ -9,6 +9,10 @@ import com.epam.jdi.light.ui.bootstrap.elements.common.Button;
 
 import static com.epam.jdi.light.asserts.core.SoftAssert.assertSoft;
 
+/**
+ * To see an example of Dropdown web element in bootstrap please visit https://getbootstrap.com/docs/4.3/components/dropdowns/#examples
+ */
+
 public class BootstrapDropdown extends Section {
     @UI(".dropdown-toggle")
     private Button dropdownToggle;

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/DropdownMenu.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/DropdownMenu.java
@@ -10,6 +10,10 @@ import java.util.List;
 
 import static com.epam.jdi.light.asserts.core.SoftAssert.assertSoft;
 
+/**
+ * To see an example of Dropdown Menu web element please visit https://getbootstrap.com/docs/4.3/components/dropdowns/#menu-items
+ */
+
 public class DropdownMenu extends BootstrapDropdown {
     @UI(".dropdown-item,.dropdown-item-text")
     private WebList items;

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/Form.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/Form.java
@@ -16,6 +16,10 @@ import java.util.Map;
 
 import static com.epam.jdi.light.elements.pageobjects.annotations.WebAnnotationsUtil.getElementName;
 
+/**
+ * To see an example of different Forms in bootstrap please visit https://getbootstrap.com/docs/4.3/components/forms/
+ */
+
 public class Form<T> extends com.epam.jdi.light.elements.composite.Form<T> {
 
     private final static String VALID_FEEDBACK_LOCATOR = "./following-sibling::*[contains(concat(' ',normalize-space(@class),' '),' valid-feedback ')]";

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/MediaObject.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/MediaObject.java
@@ -2,5 +2,9 @@ package com.epam.jdi.light.ui.bootstrap.elements.composite;
 
 import com.epam.jdi.light.elements.composite.Section;
 
+/**
+ * To see an example of Media Object in bootstrap please visit https://getbootstrap.com/docs/4.3/components/media-object/#example
+ */
+
 public class MediaObject extends Section {
 }

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/Modal.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/elements/composite/Modal.java
@@ -4,6 +4,10 @@ import com.epam.jdi.light.elements.composite.Section;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 import com.epam.jdi.light.ui.bootstrap.elements.common.Text;
 
+/**
+ * To see an example of Modal web element please visit https://getbootstrap.com/docs/4.3/components/modal/#examples
+ */
+
 public class Modal extends Section {
 
     @UI(".modal-header .modal-title")


### PR DESCRIPTION
Bootstrap element classes are updated with description with links to corresponding examples on getbootstrap.com
https://github.com/jdi-testing/jdi-light/issues/1299