### PR TITLE
#1451 - research logs

### DIFF
--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -5,6 +5,7 @@ package io.github.epam.testng;
  * Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
  */
 
+import com.epam.jdi.light.logger.AllureLoggerHelper;
 import com.epam.jdi.tools.Safe;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
@@ -30,6 +31,7 @@ public class TestNGListener implements IInvokedMethodListener {
                 TEST_NAME.set(tr.getTestClass().getRealClass().getSimpleName()+"."+testMethod.getName());
                 start.set(currentTimeMillis());
                 logger.step("== Test '%s' START ==", TEST_NAME.get());
+                AllureLoggerHelper.startStep(Integer.toString(m.hashCode()), testMethod.getName());
             }
         }
     }
@@ -38,11 +40,16 @@ public class TestNGListener implements IInvokedMethodListener {
     public void afterInvocation(IInvokedMethod method, ITestResult r) {
         if (method.isTestMethod()) {
             String result = getTestResult(r);
-            logger.step("=== Test '%s' %s [%s] ===", TEST_NAME.get(), result,
-                    new SimpleDateFormat("mm:ss.SS").format(new Date(currentTimeMillis()-start.get())));
-            if ("FAILED".equals(result)) {
-                takeScreen();
+            if (r.isSuccess()) {
+                logger.step("=== Test '%s' %s [%s] ===", TEST_NAME.get(), result,
+                        new SimpleDateFormat("mm:ss.SS").format(new Date(currentTimeMillis()-start.get())));
+                AllureLoggerHelper.passStep(Integer.toString(method.hashCode()));
+            }
+            else
+            {
+                String screenName = takeScreen();
                 logger.step("ERROR: " + r.getThrowable().getMessage());
+                AllureLoggerHelper.failStep(Integer.toString(method.hashCode()), screenName);
             }
             logger.step("");
         }

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -5,7 +5,6 @@ package io.github.epam.testng;
  * Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
  */
 
-import com.epam.jdi.light.logger.AllureLoggerHelper;
 import com.epam.jdi.tools.Safe;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
@@ -16,7 +15,6 @@ import java.lang.reflect.Method;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
-import static com.epam.jdi.light.driver.ScreenshotMaker.takeScreen;
 import static com.epam.jdi.light.settings.WebSettings.TEST_NAME;
 import static com.epam.jdi.light.settings.WebSettings.logger;
 import static java.lang.System.currentTimeMillis;

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -31,7 +31,6 @@ public class TestNGListener implements IInvokedMethodListener {
                 TEST_NAME.set(tr.getTestClass().getRealClass().getSimpleName()+"."+testMethod.getName());
                 start.set(currentTimeMillis());
                 logger.step("== Test '%s' START ==", TEST_NAME.get());
-                AllureLoggerHelper.startStep(Integer.toString(m.hashCode()), testMethod.getName());
             }
         }
     }
@@ -40,17 +39,8 @@ public class TestNGListener implements IInvokedMethodListener {
     public void afterInvocation(IInvokedMethod method, ITestResult r) {
         if (method.isTestMethod()) {
             String result = getTestResult(r);
-            if (r.isSuccess()) {
-                logger.step("=== Test '%s' %s [%s] ===", TEST_NAME.get(), result,
+            logger.step("=== Test '%s' %s [%s] ===", TEST_NAME.get(), result,
                         new SimpleDateFormat("mm:ss.SS").format(new Date(currentTimeMillis()-start.get())));
-                AllureLoggerHelper.passStep(Integer.toString(method.hashCode()));
-            }
-            else
-            {
-                String screenName = takeScreen();
-                logger.step("ERROR: " + r.getThrowable().getMessage());
-                AllureLoggerHelper.failStep(Integer.toString(method.hashCode()), screenName);
-            }
             logger.step("");
         }
     }

--- a/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/actions/BSActions.java
+++ b/jdi-light-bootstrap/src/main/java/com/epam/jdi/light/ui/bootstrap/actions/BSActions.java
@@ -45,7 +45,7 @@ public class BSActions {
                 getDriver().manage().timeouts().implicitlyWait(TIMEOUT.get(), TimeUnit.SECONDS);
             return AFTER_JDI_ACTION.execute(jp, result);
         } catch (Throwable ex) {
-            throw exception(ex, ACTION_FAILED.execute(getObjAround(jp), getExceptionAround(ex, aroundCount() == 1)));
+            throw exception(ex, ACTION_FAILED.execute(getObjAround(jp), jp, getExceptionAround(ex, aroundCount() == 1)));
         }
     }
 

--- a/jdi-light-examples/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-examples/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -5,7 +5,6 @@ package io.github.epam.testng;
  * Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
  */
 
-import com.epam.jdi.light.logger.AllureLoggerHelper;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestResult;
@@ -13,7 +12,6 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 
-import static com.epam.jdi.light.driver.ScreenshotMaker.takeScreen;
 import static com.epam.jdi.light.settings.WebSettings.TEST_NAME;
 import static com.epam.jdi.light.settings.WebSettings.logger;
 

--- a/jdi-light-examples/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-examples/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -25,7 +25,6 @@ public class TestNGListener implements IInvokedMethodListener {
             if (testMethod.isAnnotationPresent(Test.class)) {
                 TEST_NAME.set(iTestResult.getInstanceName()+"."+testMethod.getName());
                 logger.step("== Test '%s' START ==", TEST_NAME.get());
-                AllureLoggerHelper.startStep(Integer.toString(iInvokedMethod.hashCode()), testMethod.getName());
             }
         }
     }
@@ -35,13 +34,6 @@ public class TestNGListener implements IInvokedMethodListener {
         if (iInvokedMethod.isTestMethod()) {
             String result = getTestResult(iTestResult);
             logger.step("=== Test '%s' %s ===", TEST_NAME.get(), result);
-            if (iTestResult.isSuccess()) {
-                AllureLoggerHelper.passStep(Integer.toString(iInvokedMethod.hashCode()));
-            }
-            else {
-                String screenName = takeScreen();
-                AllureLoggerHelper.failStep(Integer.toString(iInvokedMethod.hashCode()), screenName);
-            }
         }
     }
 

--- a/jdi-light-examples/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-examples/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -5,6 +5,7 @@ package io.github.epam.testng;
  * Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
  */
 
+import com.epam.jdi.light.logger.AllureLoggerHelper;
 import org.testng.IInvokedMethod;
 import org.testng.IInvokedMethodListener;
 import org.testng.ITestResult;
@@ -12,6 +13,7 @@ import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
 
+import static com.epam.jdi.light.driver.ScreenshotMaker.takeScreen;
 import static com.epam.jdi.light.settings.WebSettings.TEST_NAME;
 import static com.epam.jdi.light.settings.WebSettings.logger;
 
@@ -23,6 +25,7 @@ public class TestNGListener implements IInvokedMethodListener {
             if (testMethod.isAnnotationPresent(Test.class)) {
                 TEST_NAME.set(iTestResult.getInstanceName()+"."+testMethod.getName());
                 logger.step("== Test '%s' START ==", TEST_NAME.get());
+                AllureLoggerHelper.startStep(Integer.toString(iInvokedMethod.hashCode()), testMethod.getName());
             }
         }
     }
@@ -31,12 +34,13 @@ public class TestNGListener implements IInvokedMethodListener {
     public void afterInvocation(IInvokedMethod iInvokedMethod, ITestResult iTestResult) {
         if (iInvokedMethod.isTestMethod()) {
             String result = getTestResult(iTestResult);
-            if ("FAILED".equals(result)) {
-                logger.error("=== Test '%s' %s ===", TEST_NAME.get(), result);
+            logger.step("=== Test '%s' %s ===", TEST_NAME.get(), result);
+            if (iTestResult.isSuccess()) {
+                AllureLoggerHelper.passStep(Integer.toString(iInvokedMethod.hashCode()));
             }
             else {
-                System.out.println("STEP PASSED");
-                logger.step("=== Test '%s' %s ===", TEST_NAME.get(), result);
+                String screenName = takeScreen();
+                AllureLoggerHelper.failStep(Integer.toString(iInvokedMethod.hashCode()), screenName);
             }
         }
     }

--- a/jdi-light-html/src/main/java/com/epam/jdi/light/ui/html/actions/HtmlActions.java
+++ b/jdi-light-html/src/main/java/com/epam/jdi/light/ui/html/actions/HtmlActions.java
@@ -45,7 +45,7 @@ public class HtmlActions {
                 getDriver().manage().timeouts().implicitlyWait(TIMEOUT.get(), TimeUnit.SECONDS);
             return AFTER_JDI_ACTION.execute(jp, result);
         } catch (Throwable ex) {
-            throw exception(ex, ACTION_FAILED.execute(getObjAround(jp), getExceptionAround(ex, aroundCount() == 1)));
+            throw exception(ex, ACTION_FAILED.execute(getObjAround(jp), jp, getExceptionAround(ex, aroundCount() == 1)));
         }
     }
 

--- a/jdi-light/src/main/java/com/epam/jdi/light/actions/ActionHelper.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/actions/ActionHelper.java
@@ -108,15 +108,9 @@ public class ActionHelper {
         return ex;
     };
 
-    private static void logFailure (ProceedingJoinPoint jp, Object el) {
+    private static void logFailure(ProceedingJoinPoint jp, Object el) {
         logger.toLog(">>> " + el.toString(), ERROR);
-        String screenName = null;
-        try {
-            screenName = takeScreenOnFailure();
-        }
-        catch (Exception screenEx) {
-            logger.toLog(">>> " + screenEx.getMessage());
-        }
+        String screenName = takeScreenOnFailure();
         AllureLoggerHelper.failStep(Integer.toString(jp.hashCode()), screenName);
     }
 

--- a/jdi-light/src/main/java/com/epam/jdi/light/actions/ActionProcessor.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/actions/ActionProcessor.java
@@ -74,7 +74,7 @@ public class ActionProcessor {
                 getDriver().manage().timeouts().implicitlyWait(TIMEOUT.get(), TimeUnit.SECONDS);
             return AFTER_JDI_ACTION.execute(jp, result);
         } catch (Throwable ex) {
-            throw exception(ex, ACTION_FAILED.execute(getObjAround(jp), getExceptionAround(ex, aroundCount() == 1)));
+            throw exception(ex, ACTION_FAILED.execute(getObjAround(jp), (aroundCount() > 1) ? null : jp, getExceptionAround(ex, aroundCount() == 1)));
         }
     }
 
@@ -192,7 +192,7 @@ public class ActionProcessor {
             return AFTER_STEP_ACTION.execute(jp, result);
         } catch (Throwable ex) {
             Object element = jp.getThis() != null ? jp.getThis() : new Object();
-            throw exception(ex, ACTION_FAILED.execute(element, safeException(ex)));
+            throw exception(ex, ACTION_FAILED.execute(element, jp, safeException(ex)));
         }
     }
 }

--- a/jdi-light/src/main/java/com/epam/jdi/light/driver/ScreenshotMaker.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/driver/ScreenshotMaker.java
@@ -28,6 +28,20 @@ public class ScreenshotMaker {
     public static String SCREEN_PATH = LOGS_PATH + "\\screens";
     public static String SCREEN_NAME = "screen";
     public static String SCREEN_FILE_SUFFIX = ".jpg";
+    public static ScreenshotStrategy SCREENSHOT_STRATEGY = ScreenshotStrategy.ON_FAIL;
+
+    public enum ScreenshotStrategy {
+        ON_FAIL, OFF
+    }
+
+    public static String takeScreenOnFailure() {
+        if (SCREENSHOT_STRATEGY == ScreenshotStrategy.ON_FAIL) {
+            return takeScreen();
+        }
+        else {
+            throw exception("Screenshot Strategy is off");
+        }
+    }
 
     public static String takeScreen() {
         return new ScreenshotMaker().takeScreenshot();

--- a/jdi-light/src/main/java/com/epam/jdi/light/driver/ScreenshotMaker.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/driver/ScreenshotMaker.java
@@ -38,9 +38,7 @@ public class ScreenshotMaker {
         if (SCREENSHOT_STRATEGY == ScreenshotStrategy.ON_FAIL) {
             return takeScreen();
         }
-        else {
-            throw exception("Screenshot Strategy is off");
-        }
+        return null;
     }
 
     public static String takeScreen() {

--- a/jdi-light/src/main/java/com/epam/jdi/light/logger/AllureLoggerHelper.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/logger/AllureLoggerHelper.java
@@ -1,0 +1,51 @@
+package com.epam.jdi.light.logger;
+
+import io.qameta.allure.model.StepResult;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static com.epam.jdi.light.common.Exceptions.exception;
+import static io.qameta.allure.aspects.StepsAspects.getLifecycle;
+import static io.qameta.allure.model.Status.PASSED;
+import static io.qameta.allure.model.Status.FAILED;
+
+public class AllureLoggerHelper {
+    public static boolean writeToAllure = true;
+
+    public static void startStep(String uuid, String message){
+        if (!writeToAllure) return;
+
+        StepResult step = new StepResult().withName(message).withStatus(PASSED);
+        getLifecycle().startStep(uuid, step);
+    }
+
+    public static void passStep(String uuid) {
+        if (!writeToAllure) return;
+
+        getLifecycle().updateStep(uuid, s -> s.withStatus(PASSED));
+        getLifecycle().stopStep(uuid);
+    }
+
+    public static void failStep(String uuid, String screenName) {
+        if (!writeToAllure) return;
+
+        getLifecycle().updateStep(uuid, s -> s.withStatus(FAILED));
+        if (screenName != null) {
+            try {
+                attachScreenshot(screenName);
+            } catch (IOException ex) {
+                throw exception(ex, ex.getMessage());
+            }
+        }
+
+        getLifecycle().stopStep(uuid);
+    }
+
+    private static void attachScreenshot(String screenName) throws IOException {
+        if (!writeToAllure) return;
+        getLifecycle().addAttachment("Page screenshot", "image", "jpg", Files.readAllBytes(Paths.get(screenName)));
+    }
+
+}

--- a/jdi-light/src/main/java/com/epam/jdi/light/logger/AllureLoggerHelper.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/logger/AllureLoggerHelper.java
@@ -1,7 +1,9 @@
 package com.epam.jdi.light.logger;
 
+import io.qameta.allure.Allure;
 import io.qameta.allure.model.StepResult;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -45,7 +47,7 @@ public class AllureLoggerHelper {
 
     private static void attachScreenshot(String screenName) throws IOException {
         if (!writeToAllure) return;
-        getLifecycle().addAttachment("Page screenshot", "image", "jpg", Files.readAllBytes(Paths.get(screenName)));
+        Allure.addAttachment("Page screenshot", new ByteArrayInputStream(Files.readAllBytes(Paths.get(screenName))));
     }
 
 }

--- a/jdi-light/src/main/java/com/epam/jdi/light/logger/ILogger.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/logger/ILogger.java
@@ -22,6 +22,4 @@ public interface ILogger {
     void toLog(String msg);
     void setLogLevel(LogLevels levels);
     LogLevels getLogLevel();
-    void setScreenshotStrategy(String screenshotStrategy);
-    String getScreenshotStrategy();
 }

--- a/jdi-light/src/main/java/com/epam/jdi/light/logger/JDILogger.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/logger/JDILogger.java
@@ -9,21 +9,13 @@ import com.epam.jdi.tools.Safe;
 import com.epam.jdi.tools.func.JAction;
 import com.epam.jdi.tools.func.JFunc;
 import com.epam.jdi.tools.map.MapArray;
-import io.qameta.allure.Allure;
-import io.qameta.allure.model.Status;
-import io.qameta.allure.model.StepResult;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.Marker;
 import org.apache.logging.log4j.MarkerManager;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 import static com.epam.jdi.light.common.Exceptions.exception;
 import static com.epam.jdi.light.driver.WebDriverFactory.INIT_THREAD_ID;
@@ -34,14 +26,10 @@ import static com.epam.jdi.light.logger.LogLevels.STEP;
 import static com.epam.jdi.light.logger.LogLevels.TRACE;
 import static com.epam.jdi.light.logger.LogLevels.getLog4j2Level;
 import static com.epam.jdi.tools.StringUtils.format;
-import static io.qameta.allure.aspects.StepsAspects.getLifecycle;
-import static io.qameta.allure.model.Status.PASSED;
-import static io.qameta.allure.model.Status.FAILED;
 import static java.lang.Thread.currentThread;
 import static org.apache.logging.log4j.LogManager.getLogger;
 import static org.apache.logging.log4j.core.config.Configurator.setLevel;
 import static org.apache.logging.log4j.core.config.Configurator.setRootLevel;
-import static com.epam.jdi.light.driver.ScreenshotMaker.takeScreen;
 
 public class JDILogger implements ILogger {
     private Safe<Integer> logOffDeepness = new Safe<>(0);
@@ -50,9 +38,7 @@ public class JDILogger implements ILogger {
     private List<Long> multiThread = new ArrayList<>();
     private static MapArray<String, JDILogger> loggers = new MapArray<>();
     private static Marker jdiMarker = MarkerManager.getMarker("JDI");
-    public static boolean writeToAllure = true;
     private Safe<LogLevels> logLevel = new Safe<>(INFO);
-    private static String screenshotStrategy = "on fail";
 
     public static JDILogger instance(String name) {
 
@@ -79,13 +65,6 @@ public class JDILogger implements ILogger {
         logLevel = new Safe<>(level);
         setRootLevel(getLog4j2Level(level));
         setLevel(name, getLog4j2Level(level));
-    }
-
-    public String getScreenshotStrategy() {
-        return screenshotStrategy;
-    }
-    public void setScreenshotStrategy(String strategy) {
-        screenshotStrategy = strategy;
     }
 
     public void logOff() {
@@ -138,31 +117,9 @@ public class JDILogger implements ILogger {
         return name;
     }
 
-    private static void writeToAllure(String message, Status status) {
-        if (!writeToAllure) return;
-        final String uuid = UUID.randomUUID().toString();
-        StepResult step = new StepResult().withName(message).withStatus(status);
-        getLifecycle().startStep(uuid, step);
-        if (FAILED.equals(status) && ("on fail".equals(screenshotStrategy))) {
-            try {
-                takeScreenshot();
-            } catch (IOException ex) {
-                throw exception(ex, ex.getMessage());
-            }
-        }
-        getLifecycle().stopStep(uuid);
-    }
-
-    private static void takeScreenshot() throws IOException {
-        String screenName = takeScreen();
-        if (!writeToAllure) return;
-        Allure.addAttachment("Page screenshot", new ByteArrayInputStream(Files.readAllBytes(Paths.get(screenName))));
-    }
-
     public void step(String s, Object... args) {
         if (logLevel.get().equalOrLessThan(STEP)) {
             logger.log(Level.forName("STEP", 350), jdiMarker, getRecord(s, args));
-            writeToAllure(getRecord(s, args), PASSED);
         }
     }
 
@@ -183,7 +140,6 @@ public class JDILogger implements ILogger {
     }
     public void error(String s, Object... args) {
         logger.error(jdiMarker, getRecord(s, args));
-        writeToAllure(getRecord(s, args), FAILED);
     }
 
     public void toLog(String msg) {

--- a/jdi-light/src/main/java/com/epam/jdi/light/settings/WebSettings.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/settings/WebSettings.java
@@ -56,6 +56,8 @@ import static com.epam.jdi.light.common.Property.TIMEOUT_WAIT_PAGE_PROPERTY;
 import static com.epam.jdi.light.common.PropertyValidationUtils.validateProperties;
 import static com.epam.jdi.light.common.TextTypes.SMART_TEXT;
 import static com.epam.jdi.light.driver.ScreenshotMaker.SCREEN_PATH;
+import static com.epam.jdi.light.driver.ScreenshotMaker.SCREENSHOT_STRATEGY;
+import static com.epam.jdi.light.driver.ScreenshotMaker.ScreenshotStrategy;
 import static com.epam.jdi.light.driver.WebDriverFactory.INIT_THREAD_ID;
 import static com.epam.jdi.light.driver.get.DriverData.BROWSER_SIZE;
 import static com.epam.jdi.light.driver.get.DriverData.CAPABILITIES_FOR_CHROME;
@@ -147,7 +149,7 @@ public class WebSettings {
                 ? PRELATEST_VERSION : p, DRIVERS_VERSION_PROPERTY.getName());
         fillAction(p -> DRIVERS_FOLDER = p, DRIVERS_FOLDER_PROPERTY.getName());
         fillAction(p -> SCREEN_PATH = p, SCREENS_FOLDER_PROPERTY.getName());
-        fillAction(p -> logger.setScreenshotStrategy(p), SCREENSHOT_STRATEGY_PROPERTY.getName());
+        fillAction(p -> SCREENSHOT_STRATEGY = getScreenshotStrategy(p), SCREENSHOT_STRATEGY_PROPERTY.getName());
         fillAction(p -> KILL_BROWSER = p, KILL_BROWSER_PROPERTY.getName());
         fillAction(WebSettings::setSearchStrategy, ELEMENT_SEARCH_STRATEGY_PROPERTY.getName());
         fillAction(p -> BROWSER_SIZE = p, BROWSER_SIZE_PROPERTY.getName());
@@ -256,5 +258,11 @@ public class WebSettings {
         // TODO use mergePath macos and windows
         Properties p = PropertyReader.getProperties("/../../target/classes/" + path);
         return p.size() > 0 ? p : PropertyReader.getProperties(path);
+    }
+    private static ScreenshotStrategy getScreenshotStrategy(String strategy) {
+        switch (strategy.toLowerCase()) {
+            case "off": return ScreenshotStrategy.OFF;
+            default: return ScreenshotStrategy.ON_FAIL;
+        }
     }
 }


### PR DESCRIPTION
[#1451](https://github.com/jdi-testing/jdi-light/issues/1451) - fix logging problems: 
- add loging in failure method, 
- move allure logs to separate class, 
- add allure logs to before and after handlers - so, in allure report every step has correct execution time, - move screenshot.strategy parameter to ScreenshotMaker and add method takeScreenOnFailure.