### PR TITLE
Fix 1507: Logs are duplicated in jdiEvents.log

### DIFF
--- a/jdi-light-bdd-no-po-tests/src/test/resources/log4j2.xml
+++ b/jdi-light-bdd-no-po-tests/src/test/resources/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="INFO">
+    <Logger name="JDI" additivity="FALSE" level="INFO">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/jdi-light-bdd-tests/src/test/resources/log4j2.xml
+++ b/jdi-light-bdd-tests/src/test/resources/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="INFO">
+    <Logger name="JDI" additivity="FALSE" level="INFO">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/jdi-light-bootstrap-tests/log4j2.xml
+++ b/jdi-light-bootstrap-tests/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="INFO">
+    <Logger name="JDI" additivity="FALSE" level="INFO">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/jdi-light-bootstrap-tests/src/test/resources/log4j2.xml
+++ b/jdi-light-bootstrap-tests/src/test/resources/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="DEBUG">
+    <Logger name="JDI" additivity="FALSE" level="DEBUG">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/jdi-light-examples/log4j2.xml
+++ b/jdi-light-examples/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="INFO">
+    <Logger name="JDI" additivity="FALSE" level="INFO">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/jdi-light-html-tests/log4j2.xml
+++ b/jdi-light-html-tests/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="INFO">
+    <Logger name="JDI" additivity="FALSE" level="INFO">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/jdi-light-html-tests/src/test/resources/log4j2.xml
+++ b/jdi-light-html-tests/src/test/resources/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="DEBUG">
+    <Logger name="JDI" additivity="FALSE" level="DEBUG">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/jdi-performance/src/test/resources/log4j2.xml
+++ b/jdi-performance/src/test/resources/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="INFO">
+    <Logger name="JDI" additivity="FALSE" level="INFO">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>

--- a/log4j2.xml
+++ b/log4j2.xml
@@ -68,9 +68,10 @@
     </Root>
 
     <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
-    <Logger name="JDI" additivity="TRUE" level="DEBUG">
+    <Logger name="JDI" additivity="FALSE" level="DEBUG">
       <AppenderRef ref="fileAppender"/>
       <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
     </Logger>
 
   </Loggers>


### PR DESCRIPTION
#1507 
Root and JDI loggers use the same Appenders.
The additivity attribute on JDI logger is set to false.