### PR TITLE
1313 Fix maven warnings during build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ jobs:
     name: Compile jdi code
     script:
     - mvn install -DskipTests
+    - mvn versions:use-latest-releases
 
   - stage: test
     name: Run tests - no po

--- a/jdi-light-bdd-no-po-tests/pom.xml
+++ b/jdi-light-bdd-no-po-tests/pom.xml
@@ -28,7 +28,7 @@
         <dependency>
             <groupId>io.qameta.allure</groupId>
             <artifactId>allure-cucumber-jvm</artifactId>
-            <version>2.12.1</version>
+            <version>2.13.0</version>
         </dependency>
     </dependencies>
 

--- a/jdi-light-bdd-no-po-tests/pom.xml
+++ b/jdi-light-bdd-no-po-tests/pom.xml
@@ -111,6 +111,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/jdi-light-bdd-tests/pom.xml
+++ b/jdi-light-bdd-tests/pom.xml
@@ -112,6 +112,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/jdi-light-bdd/pom.xml
+++ b/jdi-light-bdd/pom.xml
@@ -23,27 +23,27 @@
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-testng</artifactId>
-            <version>RELEASE</version>
+            <version>1.2.6</version>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-junit</artifactId>
-            <version>RELEASE</version>
+            <version>1.2.6</version>
         </dependency>
         <dependency>
             <groupId>info.cukes</groupId>
             <artifactId>cucumber-java</artifactId>
-            <version>RELEASE</version>
+            <version>1.2.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>RELEASE</version>
+            <version>4.13-rc-2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.8.5</version>
+            <version>2.8.6</version>
         </dependency>
     </dependencies>
     <build>

--- a/jdi-light-bdd/pom.xml
+++ b/jdi-light-bdd/pom.xml
@@ -72,6 +72,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jdi-light-bootstrap-tests/pom.xml
+++ b/jdi-light-bootstrap-tests/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0-beta1</version>
+            <version>7.0.0</version>
             <!--version>6.14.3</version-->
         </dependency>
         <dependency>

--- a/jdi-light-bootstrap-tests/pom.xml
+++ b/jdi-light-bootstrap-tests/pom.xml
@@ -100,6 +100,16 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/jdi-light-bootstrap/pom.xml
+++ b/jdi-light-bootstrap/pom.xml
@@ -78,6 +78,15 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jdi-light-bootstrap/pom.xml
+++ b/jdi-light-bootstrap/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0-beta1</version>
+            <version>7.0.0</version>
             <scope>compile</scope>
         </dependency>
      </dependencies>

--- a/jdi-light-examples/pom.xml
+++ b/jdi-light-examples/pom.xml
@@ -35,7 +35,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0-beta1</version>
+            <version>7.0.0</version>
         </dependency>
     </dependencies>
 

--- a/jdi-light-html-tests/pom.xml
+++ b/jdi-light-html-tests/pom.xml
@@ -94,6 +94,15 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/jdi-light-html-tests/pom.xml
+++ b/jdi-light-html-tests/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0-beta1</version>
+            <version>7.0.0</version>
             <!--version>6.14.3</version-->
         </dependency>
     </dependencies>

--- a/jdi-light-html/pom.xml
+++ b/jdi-light-html/pom.xml
@@ -72,6 +72,15 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/jdi-light/pom.xml
+++ b/jdi-light/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>com.epam.jdi.tools</groupId>
             <artifactId>jdi-light-saber</artifactId>
-            <version>2.0.57</version>
+            <version>2.0.62</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
@@ -59,17 +59,17 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>RELEASE</version>
+            <version>3.141.59</version>
         </dependency>
         <dependency>
             <groupId>net.lingala.zip4j</groupId>
             <artifactId>zip4j</artifactId>
-            <version>RELEASE</version>
+            <version>2.2.7</version>
         </dependency>
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>RELEASE</version>
+            <version>3.7.1</version>
         </dependency>
 
         <!--AOP Spring -->
@@ -82,20 +82,20 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>RELEASE</version>
+            <version>2.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>RELEASE</version>
+            <version>3.9</version>
         </dependency>
 
         <!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
-            <version>1.8.4</version>
+            <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jdi-light/pom.xml
+++ b/jdi-light/pom.xml
@@ -176,6 +176,16 @@
                     <check/>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 

--- a/jdi-performance/pom.xml
+++ b/jdi-performance/pom.xml
@@ -32,7 +32,7 @@
         <dependency>
             <groupId>org.influxdb</groupId>
             <artifactId>influxdb-java</artifactId>
-            <version>RELEASE</version>
+            <version>2.17</version>
         </dependency>
         <!--Allure-->
         <dependency>
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-collections4</artifactId>
-            <version>4.2</version>
+            <version>4.4</version>
         </dependency>
 
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.0.0-beta1</version>
+            <version>7.0.0</version>
         </dependency>
     </dependencies>
 

--- a/jdi-performance/pom.xml
+++ b/jdi-performance/pom.xml
@@ -107,6 +107,15 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
 
         <resources>

--- a/maven-version-rules.xml
+++ b/maven-version-rules.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0
+  http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+    <ignoreVersions>
+        <ignoreVersion type="regex">.*-beta.*</ignoreVersion>
+        <ignoreVersion type="regex">.*-alpha.*</ignoreVersion>
+    </ignoreVersions>
+</ruleset>

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,15 @@
                 <artifactId>coveralls-maven-plugin</artifactId>
                 <version>4.3.0</version>
             </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
#1313 
Unreleased versions in dependencies were discovered besides main issue. I added rule set to avoid pulling alpha and beta versions. Latest release versions can be updated with "mvn versions:use-latest-releases" command.