### PR TITLE
#1562 - divide test suites in allure report

### DIFF
--- a/jdi-light-applitools-tests/src/test/resources/general.xml
+++ b/jdi-light-applitools-tests/src/test/resources/general.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="WINDOWS-1251"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Test suite" parallel="classes" thread-count="1">
+<suite name="JDI-Light Applitools Tests" parallel="classes" thread-count="1">
     <test name="Tests">
         <packages>
             <package name="org.mytests.tests.example"/>

--- a/jdi-light-examples/src/test/resources/general.xml
+++ b/jdi-light-examples/src/test/resources/general.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="WINDOWS-1251"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Test suite" parallel="methods" thread-count="1">
+<suite name="JDI-Light Examples" parallel="methods" thread-count="1">
     <listeners>
         <listener class-name="io.github.epam.testng.TestNGListener" />
     </listeners>

--- a/jdi-light-html-tests/src/test/resources/general.xml
+++ b/jdi-light-html-tests/src/test/resources/general.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="WINDOWS-1251"?>
         <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Test suite" parallel="methods" thread-count="1">
+<suite name="JDI-Light HTML Tests" parallel="methods" thread-count="1">
     <test name="Tests">
         <packages>
             <package name="io.github.epam.html.tests.elements.common"/>

--- a/jdi-performance/src/test/resources/general.xml
+++ b/jdi-performance/src/test/resources/general.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="WINDOWS-1251"?>
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
-<suite name="Test suite" parallel="classes" thread-count="1">
+<suite name="JDI-Light Perfomance" parallel="classes" thread-count="1">
     <test name="Tests">
         <packages>
             <package name="org.mytests.tests.example"/>


### PR DESCRIPTION
[#1562](https://github.com/jdi-testing/jdi-light/issues/1562) - Divide each test project in allure reports for better usability - Rename available projects test suites