### PR TITLE
2038::Specifying multiple jdks in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,6 @@ env:
     - JDI_LIGHT_UNIT_TESTS="jdi-light"
     - CHROME_ARGS="--headless"
     - PATH="$JAVA_HOME/bin:$PATH"
-    - USED_JDK_VERSIONS="" #We'll store set of used jdk versions here
 stages:
   - prepare
   - compile
@@ -168,8 +167,6 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
-  - ([[ !"$USED_JDK_VERSIONS" == *"$TRAVIS_JDK_VERSION"* ]] && USED_JDK_VERSIONS="$USED_JDK_VERSIONS $TRAVIS_JDK_VERSION")
-  - echo "List of JDK versions used so far $TRAVIS_JDK_VERSION"
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
   - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,14 +75,14 @@ testsunit: &testsunit
     - mvn -ntp install -DskipTests
     - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
-testsangular: &testsangular
-  stage: test
-  name: Run tests - angular
-  script:
-    - mvn -ntp install -DskipTests
-    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
+#testsangular: &testsangular
+#  stage: test
+#  name: Run tests - angular
+#  script:
+#    - mvn -ntp install -DskipTests
+#    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+#
 testshtml: &testshtml
   stage: test
   name: Run tests - html
@@ -140,23 +140,12 @@ jobs:
       env:
         - JDK_VER="OpenJDK11"
 
-    - <<: *testsangular
-      name: "Run tests - angular JDK8"
-      jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
-
-    - <<: *testsangular
-      name: "Run tests - angular JDK10"
-      jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
-
-    - <<: *testsangular
-      name: "Run tests - angular JDK11"
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
+    - stage: test
+      name: Run tests - angular
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 
     - <<: *testshtml
       name: "Run tests - html JDK8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,12 +112,12 @@ jobs:
 #    - <<: *testsbootstrap
 #      name: "Run tests - bootstrap JDK11"
 #      jdk: openjdk11
-#    - stage: test
-#      name: Run tests - angular
-#      jdk: openjdk8
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - stage: test
+      name: Run tests - angular
+      jdk: openjdk8
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
 #    - <<: *testshtml
 #      name: "Run tests - html JDK8"
 #      jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,9 @@ addons:
     packages:
       - openjdk-8-jdk
 env:
+  - JAVA_VER=openjdk8
+  - JAVA_VER=openjdk10
+  - JAVA_VER=openjdk11
   global:
     - CHROME_PROPERTIES="chrome.properties"
     - WITH_PARAMS="-Ddriver=chrome -Dchrome.capabilities.path=$CHROME_PROPERTIES" #add -ntp when maven will be >=3.6.1 on travis
@@ -28,7 +31,7 @@ env:
     - JDI_LIGHT_UNIT_TESTS="jdi-light"
     - CHROME_ARGS="--headless"
     - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
-#    - PATH="$JAVA_HOME/bin:$PATH"
+    - PATH="$JAVA_HOME/bin:$PATH"
 
 stages:
   - prepare
@@ -50,172 +53,52 @@ jobs:
         - mvn install -DskipTests
 
     - stage: test
-      name: Run tests - bdd - jdk8
-      jdk: openjdk8
+      name: Run tests - bdd
       script:
-        - java -version
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
     - stage: test
-      name: Run tests - bdd - jdk10
-      jdk: openjdk10
-      script:
-        - java -version
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-
-    - stage: test
-      name: Run tests - bdd - jdk11
-      jdk: openjdk11
-      script:
-        - java -version
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-
-    - stage: test
-      name: Run tests - bootstrap - jdk8
-      jdk: openjdk8
+      name: Run tests - bootstrap
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
 
     - stage: test
-      name: Run tests - bootstrap - jdk10
-      jdk: openjdk10
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-
-    - stage: test
-      name: Run tests - bootstrap - jdk11
-      jdk: openjdk11
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-
-    - stage: test
-      name: Run tests - angular - jdk8
-      jdk: openjdk8
+      name: Run tests - angular
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 
     - stage: test
-      name: Run tests - angular - jdk10
-      jdk: openjdk10
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
-    - stage: test
-      name: Run tests - angular - jdk11
-      jdk: openjdk11
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
-    - stage: test
-      name: Run tests - html - jdk8
-      jdk: openjdk8
+      name: Run tests - html
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
 
     - stage: test
-      name: Run tests - html - jdk10
-      jdk: openjdk10
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-
-    - stage: test
-      name: Run tests - html - jdk11
-      jdk: openjdk11
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-
-    - stage: test
-      name: Run tests - examples - jdk8
-      jdk: openjdk8
+      name: Run tests - examples
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
 
     - stage: test
-      name: Run tests - examples - jdk10
-      jdk: openjdk10
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-
-    - stage: test
-      name: Run tests - examples - jdk11
-      jdk: openjdk11
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-
-    - stage: test
-      name: Run tests - performance - jdk8
-      jdk: openjdk8
+      name: Run tests - performance
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
 
     - stage: test
-      name: Run tests - performance - jdk10
-      jdk: openjdk10
+      name: Run tests - jdi-light-unit-tests
       script:
         - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-
-    - stage: test
-      name: Run tests - performance - jdk11
-      jdk: openjdk11
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-
-    - stage: test
-      name: Run tests - jdi-light-unit-tests - jdk8
-      jdk: openjdk8
-      script:
-          - mvn -ntp install -DskipTests
-          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
-
-    - stage: test
-      name: Run tests - jdi-light-unit-tests - jdk10
-      jdk: openjdk10
-      script:
-          - mvn -ntp install -DskipTests
-          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
-
-    - stage: test
-      name: Run tests - jdi-light-unit-tests - jdk11
-      jdk: openjdk11
-      script:
-          - mvn -ntp install -DskipTests
-          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,53 +44,53 @@ tests-bdd: &tests-bdd
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
-tests-bootstrap: &tests-bootstrap
-      stage: test
-      name: Run tests - bootstrap
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-
-tests-angular: &tests-angular
-      stage: test
-      name: Run tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
-tests-html: &tests-html
-      stage: test
-      name: Run tests - html
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-
-tests-examples: &tests-examples
-      stage: test
-      name: Run tests - examples
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-
-tests-performance: &tests-performance
-      stage: test
-      name: Run tests - performance
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-
-tests-unit: &tests-unit
-      stage: test
-      name: Run tests - jdi-light-unit-tests
-      script:
-        - mvn -ntp install -DskipTests
-        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
-
+#tests-bootstrap: &tests-bootstrap
+#      stage: test
+#      name: Run tests - bootstrap
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+#
+#tests-angular: &tests-angular
+#      stage: test
+#      name: Run tests - angular
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+#
+#tests-html: &tests-html
+#      stage: test
+#      name: Run tests - html
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+#
+#tests-examples: &tests-examples
+#      stage: test
+#      name: Run tests - examples
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+#
+#tests-performance: &tests-performance
+#      stage: test
+#      name: Run tests - performance
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+#
+#tests-unit: &tests-unit
+#      stage: test
+#      name: Run tests - jdi-light-unit-tests
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+#
 jobs:
   include:
     - stage: prepare
@@ -119,95 +119,95 @@ jobs:
       env:
         - JDK_VER="OpenJDK11"
 
-    - <<: *tests-bootstrap
-      jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
-
-    - <<: *tests-bootstrap
-      jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
-
-    - <<: *tests-bootstrap
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
-
-    - <<: *tests-angular
-      jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
-
-    - <<: *tests-angular
-      jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
-
-    - <<: *tests-angular
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
-
-    - <<: *tests-html
-      jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
-
-    - <<: *tests-html
-      jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
-
-    - <<: *tests-html
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
-
-    - <<: *tests-examples
-      jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
-
-    - <<: *tests-examples
-      jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
-
-    - <<: *tests-examples
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
-
-    - <<: *tests-performance
-      jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
-
-    - <<: *tests-performance
-      jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
-
-    - <<: *tests-performance
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
-
-    - <<: *tests-unit
-      jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
-
-    - <<: *tests-unit
-      jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
-
-    - <<: *tests-unit
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
+#    - <<: *tests-bootstrap
+#      jdk: openjdk8
+#      env:
+#        - JDK_VER="OpenJDK8"
+#
+#    - <<: *tests-bootstrap
+#      jdk: openjdk10
+#      env:
+#        - JDK_VER="OpenJDK10"
+#
+#    - <<: *tests-bootstrap
+#      jdk: openjdk11
+#      env:
+#        - JDK_VER="OpenJDK11"
+#
+#    - <<: *tests-angular
+#      jdk: openjdk8
+#      env:
+#        - JDK_VER="OpenJDK8"
+#
+#    - <<: *tests-angular
+#      jdk: openjdk10
+#      env:
+#        - JDK_VER="OpenJDK10"
+#
+#    - <<: *tests-angular
+#      jdk: openjdk11
+#      env:
+#        - JDK_VER="OpenJDK11"
+#
+#    - <<: *tests-html
+#      jdk: openjdk8
+#      env:
+#        - JDK_VER="OpenJDK8"
+#
+#    - <<: *tests-html
+#      jdk: openjdk10
+#      env:
+#        - JDK_VER="OpenJDK10"
+#
+#    - <<: *tests-html
+#      jdk: openjdk11
+#      env:
+#        - JDK_VER="OpenJDK11"
+#
+#    - <<: *tests-examples
+#      jdk: openjdk8
+#      env:
+#        - JDK_VER="OpenJDK8"
+#
+#    - <<: *tests-examples
+#      jdk: openjdk10
+#      env:
+#        - JDK_VER="OpenJDK10"
+#
+#    - <<: *tests-examples
+#      jdk: openjdk11
+#      env:
+#        - JDK_VER="OpenJDK11"
+#
+#    - <<: *tests-performance
+#      jdk: openjdk8
+#      env:
+#        - JDK_VER="OpenJDK8"
+#
+#    - <<: *tests-performance
+#      jdk: openjdk10
+#      env:
+#        - JDK_VER="OpenJDK10"
+#
+#    - <<: *tests-performance
+#      jdk: openjdk11
+#      env:
+#        - JDK_VER="OpenJDK11"
+#
+#    - <<: *tests-unit
+#      jdk: openjdk8
+#      env:
+#        - JDK_VER="OpenJDK8"
+#
+#    - <<: *tests-unit
+#      jdk: openjdk10
+#      env:
+#        - JDK_VER="OpenJDK10"
+#
+#    - <<: *tests-unit
+#      jdk: openjdk11
+#      env:
+#        - JDK_VER="OpenJDK11"
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -236,7 +236,7 @@ after_success:
   - echo "Build was successful"
 after_script:
   - echo $TRAVIS_JDK_VERSION
-  - ALLURE_RESULTS_DIR=$(find jdi-*/target/ -type d - name "allure-results")
+  - ALLURE_RESULTS_DIR=$(find jdi-*/target/ -type d -name "allure-results")
   - echo $ALLURE_RESULTS_DIR
   - mv $ALLURE_RESULTS_DIR $ALLURE_RESULTS_DIR-$TRAVIS_JDK_VERSION
   - ls jdi-*/target/

--- a/.travis.yml
+++ b/.travis.yml
@@ -107,44 +107,30 @@ jobs:
     - <<: *testsbdd
       name: "Run tests - bdd JDK8"
       jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
 
     - <<: *testsbdd
       name: "Run tests - bdd JDK10"
       jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
 
     - <<: *testsbdd
       name: "Run tests - bdd JDK11"
       jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
 
     - <<: *testsbootstrap
       name: "Run tests - bootstrap JDK8"
       jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
 
     - <<: *testsbootstrap
       name: "Run tests - bootstrap JDK10"
       jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
 
     - <<: *testsbootstrap
       name: "Run tests - bootstrap JDK11"
       jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
 
     - stage: test
       name: Run tests - angular
       jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -153,74 +139,50 @@ jobs:
     - <<: *testshtml
       name: "Run tests - html JDK8"
       jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
 
     - <<: *testshtml
       name: "Run tests - html JDK10"
       jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
 
     - <<: *testshtml
       name: "Run tests - html JDK11"
       jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
 
     - <<: *testsexamples
       name: "Run tests - examples JDK8"
       jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
 
     - <<: *testsexamples
       name: "Run tests - examples JDK10"
       jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
 
     - <<: *testsexamples
       name: "Run tests - examples JDK11"
       jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
 
     - <<: *testsperformance
       name: "Run tests - performance JDK8"
       jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
 
     - <<: *testsperformance
       name: "Run tests - performance JDK10"
       jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
 
     - <<: *testsperformance
       name: "Run tests - performance JDK11"
       jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
 
     - <<: *testsunit
       name: "Run tests - jdi-light-unit-tests JDK8"
       jdk: openjdk8
-      env:
-        - JDK_VER="OpenJDK8"
 
     - <<: *testsunit
       name: "Run tests - jdi-light-unit-tests JDK10"
       jdk: openjdk10
-      env:
-        - JDK_VER="OpenJDK10"
 
     - <<: *testsunit
       name: "Run tests - jdi-light-unit-tests JDK11"
       jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
 
     - stage: reports
       name: Deploy allure reports to netlify
@@ -235,11 +197,12 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
-  - echo $TRAVIS_JDK_VERSION
-  - ALLURE_RESULTS_DIR=$(find jdi-*/target/ -type d -name "allure-results")
-  - echo $ALLURE_RESULTS_DIR
-  - mv $ALLURE_RESULTS_DIR $ALLURE_RESULTS_DIR-$TRAVIS_JDK_VERSION
-  - ls jdi-*/target/
+  # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
+  - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
+  - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
+  - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK
+  - echo "$ALLURE_RESULTS dir has been renamed to $ALLURE_RESULTS_JDK"
+  # further actions
   - source reports.sh
   - grubAllureResults
   - du -d 1 -h ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -115,7 +115,6 @@ jobs:
     - <<: *testsbdd
       name: "Run tests - bdd JDK11"
       jdk: openjdk11
-
 # TODO: Lines below were commented to reduce build time and fine-tune the reporting process
 #    - <<: *testsbootstrap
 #      name: "Run tests - bootstrap JDK8"
@@ -128,14 +127,14 @@ jobs:
 #    - <<: *testsbootstrap
 #      name: "Run tests - bootstrap JDK11"
 #      jdk: openjdk11
-#
-#    - stage: test
-#      name: Run tests - angular
-#      jdk: openjdk8
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+    - stage: test
+      name: Run tests - angular
+      jdk: openjdk8
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 #
 #    - <<: *testshtml
 #      name: "Run tests - html JDK8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
       - openjdk-8-jdk
-
 env:
   global:
     - CHROME_PROPERTIES="chrome.properties"
@@ -30,13 +29,11 @@ env:
     - CHROME_ARGS="--headless"
     - PATH="$JAVA_HOME/bin:$PATH"
     - USED_JDK_VERSIONS="" #We'll store set of used jdk versions here
-
 stages:
   - prepare
   - compile
   - test
   - reports
-
 testsbdd: &testsbdd
   stage: test
   name: "Run tests - bdd"
@@ -44,7 +41,6 @@ testsbdd: &testsbdd
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-
 testsbootstrap: &testsbootstrap
   stage: test
   name: Run tests - bootstrap
@@ -52,7 +48,6 @@ testsbootstrap: &testsbootstrap
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-
 testsexamples: &testsexamples
   stage: test
   name: Run tests - examples
@@ -60,7 +55,6 @@ testsexamples: &testsexamples
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-
 testsperformance: &testsperformance
   stage: test
   name: Run tests - performance
@@ -68,14 +62,12 @@ testsperformance: &testsperformance
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-
 testsunit: &testsunit
   stage: test
   name: Run tests - jdi-light-unit-tests
   script:
     - mvn -ntp install -DskipTests
     - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
-
 testsangular: &testsangular # alias-anchor approach does not work with angular
   stage: test
   name: Run tests - angular
@@ -83,7 +75,6 @@ testsangular: &testsangular # alias-anchor approach does not work with angular
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
 testshtml: &testshtml
   stage: test
   name: Run tests - html
@@ -91,7 +82,6 @@ testshtml: &testshtml
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-
 jobs:
   include:
     - stage: prepare
@@ -99,36 +89,28 @@ jobs:
       script:
         - echo ------------------- WELCOME TO JDI ----------------------
         - mvn --version #it is helpful
-
     - stage: compile
       name: Compile jdi code
       script:
         - mvn install -DskipTests
-
     - <<: *testsbdd
       name: "Run tests - bdd JDK8"
       jdk: openjdk8
-
     - <<: *testsbdd
       name: "Run tests - bdd JDK10"
       jdk: openjdk10
-
     - <<: *testsbdd
       name: "Run tests - bdd JDK11"
       jdk: openjdk11
-
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK8"
-      jdk: openjdk8
-
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK10"
-      jdk: openjdk10
-
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK11"
-      jdk: openjdk11
-
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK8"
+#      jdk: openjdk8
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK10"
+#      jdk: openjdk10
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK11"
+#      jdk: openjdk11
     - stage: test
       name: Run tests - angular
       jdk: openjdk8
@@ -140,51 +122,39 @@ jobs:
 #    - <<: *testshtml
 #      name: "Run tests - html JDK8"
 #      jdk: openjdk8
-#
 #    - <<: *testshtml
 #      name: "Run tests - html JDK10"
 #      jdk: openjdk10
-#
 #    - <<: *testshtml
 #      name: "Run tests - html JDK11"
 #      jdk: openjdk11
-#
 #    - <<: *testsexamples
 #      name: "Run tests - examples JDK8"
 #      jdk: openjdk8
-#
 #    - <<: *testsexamples
 #      name: "Run tests - examples JDK10"
 #      jdk: openjdk10
-#
 #    - <<: *testsexamples
 #      name: "Run tests - examples JDK11"
 #      jdk: openjdk11
-#
 #    - <<: *testsperformance
 #      name: "Run tests - performance JDK8"
 #      jdk: openjdk8
-#
 #    - <<: *testsperformance
 #      name: "Run tests - performance JDK10"
 #      jdk: openjdk10
-#
 #    - <<: *testsperformance
 #      name: "Run tests - performance JDK11"
 #      jdk: openjdk11
-#
 #    - <<: *testsunit
 #      name: "Run tests - jdi-light-unit-tests JDK8"
 #      jdk: openjdk8
-#
 #    - <<: *testsunit
 #      name: "Run tests - jdi-light-unit-tests JDK10"
 #      jdk: openjdk10
-#
 #    - <<: *testsunit
 #      name: "Run tests - jdi-light-unit-tests JDK11"
 #      jdk: openjdk11
-
     - stage: reports
       name: Deploy allure reports to netlify
       script:
@@ -213,5 +183,3 @@ after_script:
 # extra time during long builds
 install:
   - travis_wait
-
-#Things might have been easier with report portal

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,10 +168,10 @@ after_success:
   - echo "Build was successful"
 after_script:
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
-  - ls
-  - find jdi-*/target | grep allure-results
-  - find jdi-*/target | grep examples
-  - find jdi-*/target | grep performance
+  - ls test-examples
+  - ls test-examples/jdi-performance
+  - ls test-examples/jdi-light-examples
+  - find */jdi-*/target | grep allure-results
   - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
   - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,10 +10,8 @@ addons:
   apt:
     packages:
       - openjdk-8-jdk
+
 env:
-  - JAVA_VER=openjdk8
-  - JAVA_VER=openjdk10
-  - JAVA_VER=openjdk11
   global:
     - CHROME_PROPERTIES="chrome.properties"
     - WITH_PARAMS="-Ddriver=chrome -Dchrome.capabilities.path=$CHROME_PROPERTIES" #add -ntp when maven will be >=3.6.1 on travis
@@ -30,7 +28,7 @@ env:
     - PERFORMANCE_PROPERTY="test-examples/jdi-performance"
     - JDI_LIGHT_UNIT_TESTS="jdi-light"
     - CHROME_ARGS="--headless"
-    - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+#    - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
     - PATH="$JAVA_HOME/bin:$PATH"
 
 stages:
@@ -38,6 +36,15 @@ stages:
   - compile
   - test
   - reports
+
+tests-bdd: &tests-bdd
+  stage: test
+  name: Run tests - bdd $JAVA_VER
+  script:
+    - echo "JAVA_VER=$JAVA_VER"
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
 jobs:
   include:
@@ -52,53 +59,61 @@ jobs:
       script:
         - mvn install -DskipTests
 
-    - stage: test
-      name: Run tests - bdd
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+    - <<: *tests-bdd
+      jdk: openjdk8
+      env:
+        - JAVA_VER=JDK8
 
-    - stage: test
-      name: Run tests - bootstrap
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+    - <<: *tests-bdd
+      jdk: openjdk10
+      env:
+        - JAVA_VER=JDK10
 
-    - stage: test
-      name: Run tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+    - <<: *tests-bdd
+      jdk: openjdk11
+      env:
+        - JAVA_VER=JDK11
 
-    - stage: test
-      name: Run tests - html
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-
-    - stage: test
-      name: Run tests - examples
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-
-    - stage: test
-      name: Run tests - performance
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-
-    - stage: test
-      name: Run tests - jdi-light-unit-tests
-      script:
-        - mvn -ntp install -DskipTests
-        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+#    - stage: test
+#      name: Run tests - bootstrap
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+#
+#    - stage: test
+#      name: Run tests - angular
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+#
+#    - stage: test
+#      name: Run tests - html
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+#
+#    - stage: test
+#      name: Run tests - examples
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+#
+#    - stage: test
+#      name: Run tests - performance
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+#
+#    - stage: test
+#      name: Run tests - jdi-light-unit-tests
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -141,7 +141,7 @@ jobs:
         - JDK_VER="OpenJDK11"
 
     - stage: test
-      name: Run tests - angular JDK8
+      name: Run tests - angular
       jdk: openjdk8
       env:
         - JDK_VER="OpenJDK8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,7 +168,7 @@ after_success:
   - echo "Build was successful"
 after_script:
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
-  - find -type d -regex ".*/jdi.*/target/allure-results
+  - find -type d -regex ".*/jdi.*/target/allure-results"
   - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
   - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -147,6 +147,16 @@ jobs:
         - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 
+    - stage: test
+      name: Run tests - angular JDK11
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
     - <<: *testshtml
       name: "Run tests - html JDK8"
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -127,33 +127,33 @@ jobs:
 #    - <<: *testshtml
 #      name: "Run tests - html JDK11"
 #      jdk: openjdk11
-#    - <<: *testsexamples
-#      name: "Run tests - examples JDK8"
-#      jdk: openjdk8
-#    - <<: *testsexamples
-#      name: "Run tests - examples JDK10"
-#      jdk: openjdk10
-#    - <<: *testsexamples
-#      name: "Run tests - examples JDK11"
-#      jdk: openjdk11
-#    - <<: *testsperformance
-#      name: "Run tests - performance JDK8"
-#      jdk: openjdk8
-#    - <<: *testsperformance
-#      name: "Run tests - performance JDK10"
-#      jdk: openjdk10
-#    - <<: *testsperformance
-#      name: "Run tests - performance JDK11"
-#      jdk: openjdk11
-#    - <<: *testsunit
-#      name: "Run tests - jdi-light-unit-tests JDK8"
-#      jdk: openjdk8
-#    - <<: *testsunit
-#      name: "Run tests - jdi-light-unit-tests JDK10"
-#      jdk: openjdk10
-#    - <<: *testsunit
-#      name: "Run tests - jdi-light-unit-tests JDK11"
-#      jdk: openjdk11
+    - <<: *testsexamples
+      name: "Run tests - examples JDK8"
+      jdk: openjdk8
+    - <<: *testsexamples
+      name: "Run tests - examples JDK10"
+      jdk: openjdk10
+    - <<: *testsexamples
+      name: "Run tests - examples JDK11"
+      jdk: openjdk11
+    - <<: *testsperformance
+      name: "Run tests - performance JDK8"
+      jdk: openjdk8
+    - <<: *testsperformance
+      name: "Run tests - performance JDK10"
+      jdk: openjdk10
+    - <<: *testsperformance
+      name: "Run tests - performance JDK11"
+      jdk: openjdk11
+    - <<: *testsunit
+      name: "Run tests - jdi-light-unit-tests JDK8"
+      jdk: openjdk8
+    - <<: *testsunit
+      name: "Run tests - jdi-light-unit-tests JDK10"
+      jdk: openjdk10
+    - <<: *testsunit
+      name: "Run tests - jdi-light-unit-tests JDK11"
+      jdk: openjdk11
     - stage: reports
       name: Deploy allure reports to netlify
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,29 @@ testsbootstrap: &testsbootstrap
     - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
 
+testsexamples: &testsexamples
+  stage: test
+  name: Run tests - examples
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+testsperformance: &testsperformance
+  stage: test
+  name: Run tests - performance
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+
+testsunit: &testsunit
+  stage: test
+  name: Run tests - jdi-light-unit-tests
+  script:
+    - mvn -ntp install -DskipTests
+    - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+
 jobs:
   include:
     - stage: prepare
@@ -115,25 +138,59 @@ jobs:
         - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
 
-    - stage: test
-      name: Run tests - examples
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+    - <<: *testsexamples
+      name: "Run tests - examples JDK8"
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
 
-    - stage: test
-      name: Run tests - performance
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+    - <<: *testsexamples
+      name: "Run tests - examples JDK10"
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
 
-    - stage: test
-      name: Run tests - jdi-light-unit-tests
-      script:
-        - mvn -ntp install -DskipTests
-        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+    - <<: *testsexamples
+      name: "Run tests - examples JDK11"
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+
+    - <<: *testsperformance
+      name: "Run tests - performance JDK8"
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *testsperformance
+      name: "Run tests - performance JDK10"
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *testsperformance
+      name: "Run tests - performance JDK11"
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+
+    - <<: *testsunit
+      name: "Run tests - jdi-light-unit-tests JDK8"
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *testsunit
+      name: "Run tests - jdi-light-unit-tests JDK10"
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *testsunit
+      name: "Run tests - jdi-light-unit-tests JDK11"
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,22 @@ testsunit: &testsunit
     - mvn -ntp install -DskipTests
     - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
+testsangular: &testsangular
+  stage: test
+  name: Run tests - angular
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+testshtml: &testshtml
+  stage: test
+  name: Run tests - html
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
 jobs:
   include:
     - stage: prepare
@@ -124,19 +140,41 @@ jobs:
       env:
         - JDK_VER="OpenJDK11"
 
-    - stage: test
-      name: Run tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+    - <<: *testsangular
+      name: "Run tests - angular JDK8"
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
 
-    - stage: test
-      name: Run tests - html
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+    - <<: *testsangular
+      name: "Run tests - angular JDK10"
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *testsangular
+      name: "Run tests - angular JDK11"
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+
+    - <<: *testshtml
+      name: "Run tests - html JDK8"
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *testshtml
+      name: "Run tests - html JDK10"
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *testshtml
+      name: "Run tests - html JDK11"
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
 
     - <<: *testsexamples
       name: "Run tests - examples JDK8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ testsunit: &testsunit
     - mvn -ntp install -DskipTests
     - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
-testsangular: &testsangular
+testsangular: &testsangular # alias-anchor approach does not work with angular
   stage: test
   name: Run tests - angular
   script:
@@ -141,7 +141,7 @@ jobs:
         - JDK_VER="OpenJDK11"
 
     - stage: test
-      name: Run tests - angular
+      name: Run tests - angular JDK8
       jdk: openjdk8
       env:
         - JDK_VER="OpenJDK8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ stages:
 
 testsbdd: &tests-bdd
       stage: test
-      name: "Run tests - bdd ${JDK_VER}, *jdk" ${JDK_VER} *jdk
+      name: "Run tests - bdd ${JDK_VER}, *jdk"
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: java
-jdk:
-  - openjdk8
-  - openjdk10
-  - openjdk11
 before_install:
   - sudo apt-get -y install jq
   - java -Xmx32m -version
@@ -55,9 +51,31 @@ jobs:
         - mvn install -DskipTests
 
     - stage: test
-      name: Run tests - bdd
-      jdk: openjdk10
+      name: Run tests - bdd jdk8
       script:
+        - export JAVA_HOME=$HOME/openjdk8
+        - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
+        - java -version
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+    - stage: test
+      name: Run tests - bdd jdk10
+      script:
+        - export JAVA_HOME=$HOME/openjdk10
+        - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk10 --target $JAVA_HOME
+        - java -version
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+    - stage: test
+      name: Run tests - bdd jdk11
+      script:
+        - export JAVA_HOME=$HOME/openjdk11
+        - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk11 --target $JAVA_HOME
+        - java -version
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: java
-jdk:
-  - openjdk8
-  - openjdk10
-  - openjdk11
 before_install:
   - sudo apt-get -y install jq
   - java -Xmx32m -version
@@ -40,6 +36,14 @@ stages:
   - test
   - reports
 
+testsbdd: &tests-bdd
+      stage: test
+      name: Run tests - bdd
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
 jobs:
   include:
     - stage: prepare
@@ -53,12 +57,7 @@ jobs:
       script:
         - mvn install -DskipTests
 
-    - stage: test
-      name: Run tests - bdd
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+    - <<: *tests-bdd
 
     - stage: test
       name: Run tests - bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ stages:
 
 testsbdd: &tests-bdd
       stage: test
-      name: "Run tests - bdd ${JDK_VER}, *jdk"
+      name: "Run tests - bdd" ${JDK_VER}
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ stages:
 
 tests-bdd: &tests-bdd
   stage: test
+  name: "Run tests - bdd"
   script:
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,7 @@ env:
     - JDI_LIGHT_UNIT_TESTS="jdi-light"
     - CHROME_ARGS="--headless"
     - PATH="$JAVA_HOME/bin:$PATH"
+    - USED_JDK_VERSIONS="" #We'll store set of used jdk versions here
 
 stages:
   - prepare
@@ -115,18 +116,18 @@ jobs:
     - <<: *testsbdd
       name: "Run tests - bdd JDK11"
       jdk: openjdk11
-# TODO: Lines below were commented to reduce build time and fine-tune the reporting process
-#    - <<: *testsbootstrap
-#      name: "Run tests - bootstrap JDK8"
-#      jdk: openjdk8
-#
-#    - <<: *testsbootstrap
-#      name: "Run tests - bootstrap JDK10"
-#      jdk: openjdk10
-#
-#    - <<: *testsbootstrap
-#      name: "Run tests - bootstrap JDK11"
-#      jdk: openjdk11
+
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK8"
+      jdk: openjdk8
+
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK10"
+      jdk: openjdk10
+
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK11"
+      jdk: openjdk11
 
     - stage: test
       name: Run tests - angular
@@ -135,7 +136,7 @@ jobs:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-#
+# TODO: Lines below were commented to reduce build time and fine-tune the reporting process
 #    - <<: *testshtml
 #      name: "Run tests - html JDK8"
 #      jdk: openjdk8
@@ -197,6 +198,8 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
+  - ([[ !"$USED_JDK_VERSIONS" == *"$TRAVIS_JDK_VERSION"* ]] && USED_JDK_VERSIONS="$USED_JDK_VERSIONS $TRAVIS_JDK_VERSION")
+  - echo "List of JDK versions used so far $TRAVIS_JDK_VERSION"
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
   - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,11 +36,6 @@ stages:
   - test
   - reports
 
-reportscript: &reportscript
-    - echo "REPORT SCRIPT line1 GOES HERE"
-    - echo "REPORT SCRIPT line2 GOES HERE"
-    - echo $JDK_VER
-
 testsbdd: &testsbdd
   stage: test
   name: "Run tests - bdd"
@@ -48,8 +43,6 @@ testsbdd: &testsbdd
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-    - echo "REPORT SCRIPT LINE 0"
-    - *reportscript
 
 testsbootstrap: &testsbootstrap
   stage: test
@@ -242,6 +235,7 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
+  - ls target/allure-results
   - source reports.sh
   - grubAllureResults
   - du -d 1 -h ./
@@ -249,3 +243,5 @@ after_script:
 # extra time during long builds
 install:
   - travis_wait
+
+#Things might have been easier with report portal

--- a/.travis.yml
+++ b/.travis.yml
@@ -168,10 +168,7 @@ after_success:
   - echo "Build was successful"
 after_script:
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
-  - ls test-examples
-  - ls test-examples/jdi-performance
-  - ls test-examples/jdi-light-examples
-  - find */jdi-*/target | grep allure-results
+  - find -type d -regex ".*/jdi.*/target/allure-results
   - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
   - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,50 +56,57 @@ jobs:
     - stage: test
       name: Run tests - bdd
       script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+        - echo ">>>>> Attempt to use different jdks on test phase"
+        - java -version
+        - echo ">>>>> End of Attempt to use different jdks on test phase"
 
-    - stage: test
-      name: Run tests - bootstrap
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-
-    - stage: test
-      name: Run tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
-    - stage: test
-      name: Run tests - html
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-
-    - stage: test
-      name: Run tests - examples
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-
-    - stage: test
-      name: Run tests - performance
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-
-    - stage: test
-      name: Run tests - jdi-light-unit-tests
-      script:
-          - mvn -ntp install -DskipTests
-          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+#    - stage: test
+#      name: Run tests - bdd
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+#
+#    - stage: test
+#      name: Run tests - bootstrap
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+#
+#    - stage: test
+#      name: Run tests - angular
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+#
+#    - stage: test
+#      name: Run tests - html
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+#
+#    - stage: test
+#      name: Run tests - examples
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+#
+#    - stage: test
+#      name: Run tests - performance
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+#
+#    - stage: test
+#      name: Run tests - jdi-light-unit-tests
+#      script:
+#          - mvn -ntp install -DskipTests
+#          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,60 +37,12 @@ stages:
   - reports
 
 tests-bdd: &tests-bdd
-      stage: test
-      name: Run tests - BDD
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+  stage: test
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
-#tests-bootstrap: &tests-bootstrap
-#      stage: test
-#      name: Run tests - bootstrap
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-#
-#tests-angular: &tests-angular
-#      stage: test
-#      name: Run tests - angular
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-#
-#tests-html: &tests-html
-#      stage: test
-#      name: Run tests - html
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-#
-#tests-examples: &tests-examples
-#      stage: test
-#      name: Run tests - examples
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-#
-#tests-performance: &tests-performance
-#      stage: test
-#      name: Run tests - performance
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-#
-#tests-unit: &tests-unit
-#      stage: test
-#      name: Run tests - jdi-light-unit-tests
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
-#
 jobs:
   include:
     - stage: prepare
@@ -105,109 +57,63 @@ jobs:
         - mvn install -DskipTests
 
     - <<: *tests-bdd
+      name: "Run tests - bdd JDK8"
       jdk: openjdk8
       env:
         - JDK_VER="OpenJDK8"
 
     - <<: *tests-bdd
+      name: "Run tests - bdd JDK10"
       jdk: openjdk10
       env:
         - JDK_VER="OpenJDK10"
 
     - <<: *tests-bdd
+      name: "Run tests - bdd JDK11"
       jdk: openjdk11
       env:
         - JDK_VER="OpenJDK11"
 
-#    - <<: *tests-bootstrap
-#      jdk: openjdk8
-#      env:
-#        - JDK_VER="OpenJDK8"
-#
-#    - <<: *tests-bootstrap
-#      jdk: openjdk10
-#      env:
-#        - JDK_VER="OpenJDK10"
-#
-#    - <<: *tests-bootstrap
-#      jdk: openjdk11
-#      env:
-#        - JDK_VER="OpenJDK11"
-#
-#    - <<: *tests-angular
-#      jdk: openjdk8
-#      env:
-#        - JDK_VER="OpenJDK8"
-#
-#    - <<: *tests-angular
-#      jdk: openjdk10
-#      env:
-#        - JDK_VER="OpenJDK10"
-#
-#    - <<: *tests-angular
-#      jdk: openjdk11
-#      env:
-#        - JDK_VER="OpenJDK11"
-#
-#    - <<: *tests-html
-#      jdk: openjdk8
-#      env:
-#        - JDK_VER="OpenJDK8"
-#
-#    - <<: *tests-html
-#      jdk: openjdk10
-#      env:
-#        - JDK_VER="OpenJDK10"
-#
-#    - <<: *tests-html
-#      jdk: openjdk11
-#      env:
-#        - JDK_VER="OpenJDK11"
-#
-#    - <<: *tests-examples
-#      jdk: openjdk8
-#      env:
-#        - JDK_VER="OpenJDK8"
-#
-#    - <<: *tests-examples
-#      jdk: openjdk10
-#      env:
-#        - JDK_VER="OpenJDK10"
-#
-#    - <<: *tests-examples
-#      jdk: openjdk11
-#      env:
-#        - JDK_VER="OpenJDK11"
-#
-#    - <<: *tests-performance
-#      jdk: openjdk8
-#      env:
-#        - JDK_VER="OpenJDK8"
-#
-#    - <<: *tests-performance
-#      jdk: openjdk10
-#      env:
-#        - JDK_VER="OpenJDK10"
-#
-#    - <<: *tests-performance
-#      jdk: openjdk11
-#      env:
-#        - JDK_VER="OpenJDK11"
-#
-#    - <<: *tests-unit
-#      jdk: openjdk8
-#      env:
-#        - JDK_VER="OpenJDK8"
-#
-#    - <<: *tests-unit
-#      jdk: openjdk10
-#      env:
-#        - JDK_VER="OpenJDK10"
-#
-#    - <<: *tests-unit
-#      jdk: openjdk11
-#      env:
-#        - JDK_VER="OpenJDK11"
+    - stage: test
+      name: Run tests - bootstrap
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+
+    - stage: test
+      name: Run tests - angular
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+    - stage: test
+      name: Run tests - html
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
+    - stage: test
+      name: Run tests - examples
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+    - stage: test
+      name: Run tests - performance
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+
+    - stage: test
+      name: Run tests - jdi-light-unit-tests
+      script:
+        - mvn -ntp install -DskipTests
+        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,14 +75,14 @@ testsunit: &testsunit
     - mvn -ntp install -DskipTests
     - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
-#testsangular: &testsangular
-#  stage: test
-#  name: Run tests - angular
-#  script:
-#    - mvn -ntp install -DskipTests
-#    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-#
+testsangular: &testsangular
+  stage: test
+  name: Run tests - angular
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
 testshtml: &testshtml
   stage: test
   name: Run tests - html
@@ -140,22 +140,7 @@ jobs:
       env:
         - JDK_VER="OpenJDK11"
 
-    - stage: test
-      name: Run tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
-    - stage: test
-      name: Run tests - angular JDK11
-      jdk: openjdk11
-      env:
-        - JDK_VER="OpenJDK11"
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+    - <<: *testsangular
 
     - <<: *testshtml
       name: "Run tests - html JDK8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,15 +101,15 @@ jobs:
     - <<: *testsbdd
       name: "Run tests - bdd JDK11"
       jdk: openjdk11
-#    - <<: *testsbootstrap
-#      name: "Run tests - bootstrap JDK8"
-#      jdk: openjdk8
-#    - <<: *testsbootstrap
-#      name: "Run tests - bootstrap JDK10"
-#      jdk: openjdk10
-#    - <<: *testsbootstrap
-#      name: "Run tests - bootstrap JDK11"
-#      jdk: openjdk11
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK8"
+      jdk: openjdk8
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK10"
+      jdk: openjdk10
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK11"
+      jdk: openjdk11
     - stage: test
       name: Run tests - angular
       jdk: openjdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,4 @@
 language: java
-jdk:
-  - openjdk8
-  - openjdk10
-  - openjdk11
 before_install:
   - sudo apt-get -y install jq
   - java -Xmx32m -version
@@ -32,6 +28,7 @@ env:
     - PERFORMANCE_PROPERTY="test-examples/jdi-performance"
     - JDI_LIGHT_UNIT_TESTS="jdi-light"
     - CHROME_ARGS="--headless"
+    - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
     - PATH="$JAVA_HOME/bin:$PATH"
 
 stages:
@@ -55,58 +52,79 @@ jobs:
 
     - stage: test
       name: Run tests - bdd
+      jdk:
+        - openjdk8
+        - openjdk10
+        - openjdk11
       script:
-        - echo ">>>>> Attempt to use different jdks on test phase"
-        - java -version
-        - echo ">>>>> End of Attempt to use different jdks on test phase"
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
-#    - stage: test
-#      name: Run tests - bdd
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-#
-#    - stage: test
-#      name: Run tests - bootstrap
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-#
-#    - stage: test
-#      name: Run tests - angular
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-#
-#    - stage: test
-#      name: Run tests - html
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-#
-#    - stage: test
-#      name: Run tests - examples
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-#
-#    - stage: test
-#      name: Run tests - performance
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-#
-#    - stage: test
-#      name: Run tests - jdi-light-unit-tests
-#      script:
-#          - mvn -ntp install -DskipTests
-#          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+    - stage: test
+      name: Run tests - bootstrap
+      jdk:
+        - openjdk8
+        - openjdk10
+        - openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+
+    - stage: test
+      name: Run tests - angular
+      jdk:
+        - openjdk8
+        - openjdk10
+        - openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+    - stage: test
+      name: Run tests - html
+      jdk:
+        - openjdk8
+        - openjdk10
+        - openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
+    - stage: test
+      name: Run tests - examples
+      jdk:
+        - openjdk8
+        - openjdk10
+        - openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+    - stage: test
+      name: Run tests - performance
+      jdk:
+        - openjdk8
+        - openjdk10
+        - openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+
+    - stage: test
+      name: Run tests - jdi-light-unit-tests
+      jdk:
+        - openjdk8
+        - openjdk10
+        - openjdk11
+      script:
+          - mvn -ntp install -DskipTests
+          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -236,7 +236,7 @@ after_success:
   - echo "Build was successful"
 after_script:
   - ls
-  - ls jdi-*/target
+  - ls jdi-*/target/allure-results-*
   - source reports.sh
   - grubAllureResults
   - du -d 1 -h ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ addons:
   apt:
     packages:
       - openjdk-8-jdk
-
 env:
   global:
     - CHROME_PROPERTIES="chrome.properties"
@@ -29,7 +28,7 @@ env:
     - JDI_LIGHT_UNIT_TESTS="jdi-light"
     - CHROME_ARGS="--headless"
     - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
-    - PATH="$JAVA_HOME/bin:$PATH"
+#    - PATH="$JAVA_HOME/bin:$PATH"
 
 stages:
   - prepare
@@ -52,9 +51,8 @@ jobs:
 
     - stage: test
       name: Run tests - bdd jdk8
+      jdk: openjdk8
       script:
-        - export JAVA_HOME=$HOME/openjdk8
-        - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk8 --target $JAVA_HOME
         - java -version
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -62,9 +60,8 @@ jobs:
 
     - stage: test
       name: Run tests - bdd jdk10
+      jdk: openjdk10
       script:
-        - export JAVA_HOME=$HOME/openjdk10
-        - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk10 --target $JAVA_HOME
         - java -version
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -72,9 +69,8 @@ jobs:
 
     - stage: test
       name: Run tests - bdd jdk11
+      jdk: openjdk11
       script:
-        - export JAVA_HOME=$HOME/openjdk11
-        - $TRAVIS_BUILD_DIR/install-jdk.sh --install openjdk11 --target $JAVA_HOME
         - java -version
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
+jdk:
+  - openjdk8
+  - openjdk10
+  - openjdk11
 before_install:
   - sudo apt-get -y install jq
   - java -Xmx32m -version
@@ -28,7 +32,6 @@ env:
     - PERFORMANCE_PROPERTY="test-examples/jdi-performance"
     - JDI_LIGHT_UNIT_TESTS="jdi-light"
     - CHROME_ARGS="--headless"
-#    - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
     - PATH="$JAVA_HOME/bin:$PATH"
 
 stages:
@@ -36,15 +39,6 @@ stages:
   - compile
   - test
   - reports
-
-tests-bdd: &tests-bdd
-  stage: test
-  name: Run tests - bdd $JAVA_VER
-  script:
-    - echo "JAVA_VER=$JAVA_VER"
-    - mvn -ntp install -DskipTests
-    - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
 jobs:
   include:
@@ -59,61 +53,53 @@ jobs:
       script:
         - mvn install -DskipTests
 
-    - <<: *tests-bdd
-      jdk: openjdk8
-      env:
-        - JAVA_VER=JDK8
+    - stage: test
+      name: Run tests - bdd
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
-    - <<: *tests-bdd
-      jdk: openjdk10
-      env:
-        - JAVA_VER=JDK10
+    - stage: test
+      name: Run tests - bootstrap
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
 
-    - <<: *tests-bdd
-      jdk: openjdk11
-      env:
-        - JAVA_VER=JDK11
+    - stage: test
+      name: Run tests - angular
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 
-#    - stage: test
-#      name: Run tests - bootstrap
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
-#
-#    - stage: test
-#      name: Run tests - angular
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-#
-#    - stage: test
-#      name: Run tests - html
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
-#
-#    - stage: test
-#      name: Run tests - examples
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-#
-#    - stage: test
-#      name: Run tests - performance
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
-#
-#    - stage: test
-#      name: Run tests - jdi-light-unit-tests
-#      script:
-#        - mvn -ntp install -DskipTests
-#        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+    - stage: test
+      name: Run tests - html
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
+    - stage: test
+      name: Run tests - examples
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+    - stage: test
+      name: Run tests - performance
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+
+    - stage: test
+      name: Run tests - jdi-light-unit-tests
+      script:
+        - mvn -ntp install -DskipTests
+        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,32 +92,32 @@ jobs:
       name: Compile jdi code
       script:
         - mvn install -DskipTests
-    - <<: *testsbdd
-      name: "Run tests - bdd JDK8"
-      jdk: openjdk8
-    - <<: *testsbdd
-      name: "Run tests - bdd JDK10"
-      jdk: openjdk10
-    - <<: *testsbdd
-      name: "Run tests - bdd JDK11"
-      jdk: openjdk11
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK8"
-      jdk: openjdk8
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK10"
-      jdk: openjdk10
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK11"
-      jdk: openjdk11
-    - stage: test
-      name: Run tests - angular
-      jdk: openjdk8
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 # TODO: Lines below were commented to reduce build time and fine-tune the reporting process
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+#    - <<: *testsbdd
+#      name: "Run tests - bdd JDK8"
+#      jdk: openjdk8
+#    - <<: *testsbdd
+#      name: "Run tests - bdd JDK10"
+#      jdk: openjdk10
+#    - <<: *testsbdd
+#      name: "Run tests - bdd JDK11"
+#      jdk: openjdk11
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK8"
+#      jdk: openjdk8
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK10"
+#      jdk: openjdk10
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK11"
+#      jdk: openjdk11
+#    - stage: test
+#      name: Run tests - angular
+#      jdk: openjdk8
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
 #    - <<: *testshtml
 #      name: "Run tests - html JDK8"
 #      jdk: openjdk8
@@ -145,15 +145,15 @@ jobs:
     - <<: *testsperformance
       name: "Run tests - performance JDK11"
       jdk: openjdk11
-    - <<: *testsunit
-      name: "Run tests - jdi-light-unit-tests JDK8"
-      jdk: openjdk8
-    - <<: *testsunit
-      name: "Run tests - jdi-light-unit-tests JDK10"
-      jdk: openjdk10
-    - <<: *testsunit
-      name: "Run tests - jdi-light-unit-tests JDK11"
-      jdk: openjdk11
+#    - <<: *testsunit
+#      name: "Run tests - jdi-light-unit-tests JDK8"
+#      jdk: openjdk8
+#    - <<: *testsunit
+#      name: "Run tests - jdi-light-unit-tests JDK10"
+#      jdk: openjdk10
+#    - <<: *testsunit
+#      name: "Run tests - jdi-light-unit-tests JDK11"
+#      jdk: openjdk11
     - stage: reports
       name: Deploy allure reports to netlify
       script:
@@ -168,6 +168,8 @@ after_success:
   - echo "Build was successful"
 after_script:
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
+  - ls
+  - find jdi-*/target
   - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
   - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,11 @@ stages:
   - test
   - reports
 
+reportscript: &reportscript
+    - echo "REPORT SCRIPT line1 GOES HERE"
+    - echo "REPORT SCRIPT line2 GOES HERE"
+    - echo $JDK_VER
+
 testsbdd: &testsbdd
   stage: test
   name: "Run tests - bdd"
@@ -43,6 +48,8 @@ testsbdd: &testsbdd
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+    - echo "REPORT SCRIPT LINE 0"
+    - *reportscript
 
 testsbootstrap: &testsbootstrap
   stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,23 @@ jobs:
       name: Run tests - bdd
       jdk:
         - openjdk8
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+    - stage: test
+      name: Run tests - bdd
+      jdk:
         - openjdk10
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+    - stage: test
+      name: Run tests - bdd
+      jdk:
         - openjdk11
       script:
         - mvn -ntp install -DskipTests
@@ -63,10 +79,6 @@ jobs:
 
     - stage: test
       name: Run tests - bootstrap
-      jdk:
-        - openjdk8
-        - openjdk10
-        - openjdk11
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -74,10 +86,6 @@ jobs:
 
     - stage: test
       name: Run tests - angular
-      jdk:
-        - openjdk8
-        - openjdk10
-        - openjdk11
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -85,10 +93,6 @@ jobs:
 
     - stage: test
       name: Run tests - html
-      jdk:
-        - openjdk8
-        - openjdk10
-        - openjdk11
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -96,10 +100,6 @@ jobs:
 
     - stage: test
       name: Run tests - examples
-      jdk:
-        - openjdk8
-        - openjdk10
-        - openjdk11
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
@@ -107,10 +107,6 @@ jobs:
 
     - stage: test
       name: Run tests - performance
-      jdk:
-        - openjdk8
-        - openjdk10
-        - openjdk11
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
@@ -118,10 +114,6 @@ jobs:
 
     - stage: test
       name: Run tests - jdi-light-unit-tests
-      jdk:
-        - openjdk8
-        - openjdk10
-        - openjdk11
       script:
           - mvn -ntp install -DskipTests
           - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: java
+jdk:
+  - openjdk8
+  - openjdk10
+  - openjdk11
 before_install:
   - sudo apt-get -y install jq
   - java -Xmx32m -version
@@ -52,26 +56,7 @@ jobs:
 
     - stage: test
       name: Run tests - bdd
-      jdk:
-        - openjdk8
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-
-    - stage: test
-      name: Run tests - bdd
-      jdk:
-        - openjdk10
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-
-    - stage: test
-      name: Run tests - bdd
-      jdk:
-        - openjdk11
+      jdk: openjdk10
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,21 @@ stages:
   - test
   - reports
 
-tests-bdd: &tests-bdd
+testsbdd: &testsbdd
   stage: test
   name: "Run tests - bdd"
   script:
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+testsbootstrap: &testsbootstrap
+  stage: test
+  name: Run tests - bootstrap
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
 
 jobs:
   include:
@@ -57,30 +65,41 @@ jobs:
       script:
         - mvn install -DskipTests
 
-    - <<: *tests-bdd
+    - <<: *testsbdd
       name: "Run tests - bdd JDK8"
       jdk: openjdk8
       env:
         - JDK_VER="OpenJDK8"
 
-    - <<: *tests-bdd
+    - <<: *testsbdd
       name: "Run tests - bdd JDK10"
       jdk: openjdk10
       env:
         - JDK_VER="OpenJDK10"
 
-    - <<: *tests-bdd
+    - <<: *testsbdd
       name: "Run tests - bdd JDK11"
       jdk: openjdk11
       env:
         - JDK_VER="OpenJDK11"
 
-    - stage: test
-      name: Run tests - bootstrap
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK8"
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK10"
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *testsbootstrap
+      name: "Run tests - bootstrap JDK11"
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
 
     - stage: test
       name: Run tests - angular

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,13 @@ jobs:
         - mvn install -DskipTests
 
     - <<: *tests-bdd
+      jdk: openjdk8
+
+    - <<: *tests-bdd
+      jdk: openjdk10
+
+    - <<: *tests-bdd
+      jdk: openjdk11
 
     - stage: test
       name: Run tests - bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ stages:
 
 testsbdd: &tests-bdd
       stage: test
-      name: Run tests - bdd $JDK_VER
+      name: "Run tests - bdd ${JDK_VER}, *jdk" ${JDK_VER} *jdk
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"

--- a/.travis.yml
+++ b/.travis.yml
@@ -140,7 +140,15 @@ jobs:
       env:
         - JDK_VER="OpenJDK11"
 
-    - <<: *testsangular
+    - stage: test
+      name: Run tests - angular
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 
     - <<: *testshtml
       name: "Run tests - html JDK8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,60 @@ stages:
   - test
   - reports
 
-testsbdd: &tests-bdd
+tests-bdd: &tests-bdd
       stage: test
-      name: "Run tests - bdd" ${JDK_VER}
+      name: Run tests - BDD
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+tests-bootstrap: &tests-bootstrap
+      stage: test
+      name: Run tests - bootstrap
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+
+tests-angular: &tests-angular
+      stage: test
+      name: Run tests - angular
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+tests-html: &tests-html
+      stage: test
+      name: Run tests - html
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
+tests-examples: &tests-examples
+      stage: test
+      name: Run tests - examples
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+tests-performance: &tests-performance
+      stage: test
+      name: Run tests - performance
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+
+tests-unit: &tests-unit
+      stage: test
+      name: Run tests - jdi-light-unit-tests
+      script:
+        - mvn -ntp install -DskipTests
+        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
 
 jobs:
   include:
@@ -72,46 +119,95 @@ jobs:
       env:
         - JDK_VER="OpenJDK11"
 
-    - stage: test
-      name: Run tests - bootstrap
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+    - <<: *tests-bootstrap
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
 
-    - stage: test
-      name: Run tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+    - <<: *tests-bootstrap
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
 
-    - stage: test
-      name: Run tests - html
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+    - <<: *tests-bootstrap
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
 
-    - stage: test
-      name: Run tests - examples
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+    - <<: *tests-angular
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
 
-    - stage: test
-      name: Run tests - performance
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+    - <<: *tests-angular
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
 
-    - stage: test
-      name: Run tests - jdi-light-unit-tests
-      script:
-        - mvn -ntp install -DskipTests
-        - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+    - <<: *tests-angular
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+
+    - <<: *tests-html
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *tests-html
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *tests-html
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+
+    - <<: *tests-examples
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *tests-examples
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *tests-examples
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+
+    - <<: *tests-performance
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *tests-performance
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *tests-performance
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
+
+    - <<: *tests-unit
+      jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
+
+    - <<: *tests-unit
+      jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
+
+    - <<: *tests-unit
+      jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,73 +116,74 @@ jobs:
       name: "Run tests - bdd JDK11"
       jdk: openjdk11
 
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK8"
-      jdk: openjdk8
-
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK10"
-      jdk: openjdk10
-
-    - <<: *testsbootstrap
-      name: "Run tests - bootstrap JDK11"
-      jdk: openjdk11
-
-    - stage: test
-      name: Run tests - angular
-      jdk: openjdk8
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-
-    - <<: *testshtml
-      name: "Run tests - html JDK8"
-      jdk: openjdk8
-
-    - <<: *testshtml
-      name: "Run tests - html JDK10"
-      jdk: openjdk10
-
-    - <<: *testshtml
-      name: "Run tests - html JDK11"
-      jdk: openjdk11
-
-    - <<: *testsexamples
-      name: "Run tests - examples JDK8"
-      jdk: openjdk8
-
-    - <<: *testsexamples
-      name: "Run tests - examples JDK10"
-      jdk: openjdk10
-
-    - <<: *testsexamples
-      name: "Run tests - examples JDK11"
-      jdk: openjdk11
-
-    - <<: *testsperformance
-      name: "Run tests - performance JDK8"
-      jdk: openjdk8
-
-    - <<: *testsperformance
-      name: "Run tests - performance JDK10"
-      jdk: openjdk10
-
-    - <<: *testsperformance
-      name: "Run tests - performance JDK11"
-      jdk: openjdk11
-
-    - <<: *testsunit
-      name: "Run tests - jdi-light-unit-tests JDK8"
-      jdk: openjdk8
-
-    - <<: *testsunit
-      name: "Run tests - jdi-light-unit-tests JDK10"
-      jdk: openjdk10
-
-    - <<: *testsunit
-      name: "Run tests - jdi-light-unit-tests JDK11"
-      jdk: openjdk11
+# TODO: Lines below were commented to reduce build time and fine-tune the reporting process
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK8"
+#      jdk: openjdk8
+#
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK10"
+#      jdk: openjdk10
+#
+#    - <<: *testsbootstrap
+#      name: "Run tests - bootstrap JDK11"
+#      jdk: openjdk11
+#
+#    - stage: test
+#      name: Run tests - angular
+#      jdk: openjdk8
+#      script:
+#        - mvn -ntp install -DskipTests
+#        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+#
+#    - <<: *testshtml
+#      name: "Run tests - html JDK8"
+#      jdk: openjdk8
+#
+#    - <<: *testshtml
+#      name: "Run tests - html JDK10"
+#      jdk: openjdk10
+#
+#    - <<: *testshtml
+#      name: "Run tests - html JDK11"
+#      jdk: openjdk11
+#
+#    - <<: *testsexamples
+#      name: "Run tests - examples JDK8"
+#      jdk: openjdk8
+#
+#    - <<: *testsexamples
+#      name: "Run tests - examples JDK10"
+#      jdk: openjdk10
+#
+#    - <<: *testsexamples
+#      name: "Run tests - examples JDK11"
+#      jdk: openjdk11
+#
+#    - <<: *testsperformance
+#      name: "Run tests - performance JDK8"
+#      jdk: openjdk8
+#
+#    - <<: *testsperformance
+#      name: "Run tests - performance JDK10"
+#      jdk: openjdk10
+#
+#    - <<: *testsperformance
+#      name: "Run tests - performance JDK11"
+#      jdk: openjdk11
+#
+#    - <<: *testsunit
+#      name: "Run tests - jdi-light-unit-tests JDK8"
+#      jdk: openjdk8
+#
+#    - <<: *testsunit
+#      name: "Run tests - jdi-light-unit-tests JDK10"
+#      jdk: openjdk10
+#
+#    - <<: *testsunit
+#      name: "Run tests - jdi-light-unit-tests JDK11"
+#      jdk: openjdk11
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,17 +92,17 @@ jobs:
       name: Compile jdi code
       script:
         - mvn install -DskipTests
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+    - <<: *testsbdd
+      name: "Run tests - bdd JDK8"
+      jdk: openjdk8
+    - <<: *testsbdd
+      name: "Run tests - bdd JDK10"
+      jdk: openjdk10
+    - <<: *testsbdd
+      name: "Run tests - bdd JDK11"
+      jdk: openjdk11
 # TODO: Lines below were commented to reduce build time and fine-tune the reporting process
-#        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-#    - <<: *testsbdd
-#      name: "Run tests - bdd JDK8"
-#      jdk: openjdk8
-#    - <<: *testsbdd
-#      name: "Run tests - bdd JDK10"
-#      jdk: openjdk10
-#    - <<: *testsbdd
-#      name: "Run tests - bdd JDK11"
-#      jdk: openjdk11
 #    - <<: *testsbootstrap
 #      name: "Run tests - bootstrap JDK8"
 #      jdk: openjdk8
@@ -168,8 +168,8 @@ after_success:
   - echo "Build was successful"
 after_script:
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
-  - find -type d -regex ".*/jdi.*/target/allure-results"
-  - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
+  - echo 'allure-results dir $(find -type d -regex ".*/jdi.*/target/allure-results")'
+  - ALLURE_RESULTS=$(find -type d -regex ".*/jdi.*/target/allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
   - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK
   - echo "$ALLURE_RESULTS dir has been renamed to $ALLURE_RESULTS_JDK"

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,9 +235,11 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
-  - ls
+  - echo $TRAVIS_JDK_VERSION
+  - ALLURE_RESULTS_DIR=$(find jdi-*/target/ -type d - name "allure-results")
+  - echo $ALLURE_RESULTS_DIR
+  - mv $ALLURE_RESULTS_DIR $ALLURE_RESULTS_DIR-$TRAVIS_JDK_VERSION
   - ls jdi-*/target/
-  - ls jdi-*/target/allure-results-*
   - source reports.sh
   - grubAllureResults
   - du -d 1 -h ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,7 +235,7 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
-  - ls target/allure-results
+  - ls target/
   - source reports.sh
   - grubAllureResults
   - du -d 1 -h ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -236,6 +236,7 @@ after_success:
   - echo "Build was successful"
 after_script:
   - ls
+  - ls jdi-*/target/
   - ls jdi-*/target/allure-results-*
   - source reports.sh
   - grubAllureResults

--- a/.travis.yml
+++ b/.travis.yml
@@ -169,7 +169,9 @@ after_success:
 after_script:
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
   - ls
-  - find jdi-*/target
+  - find jdi-*/target | grep allure-results
+  - find jdi-*/target | grep examples
+  - find jdi-*/target | grep performance
   - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
   - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK

--- a/.travis.yml
+++ b/.travis.yml
@@ -235,7 +235,8 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
-  - ls target/
+  - ls
+  - ls jdi-*/target
   - source reports.sh
   - grubAllureResults
   - du -d 1 -h ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ stages:
 
 testsbdd: &tests-bdd
       stage: test
-      name: Run tests - bdd
+      name: Run tests - bdd $JDK_VER
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -59,12 +59,18 @@ jobs:
 
     - <<: *tests-bdd
       jdk: openjdk8
+      env:
+        - JDK_VER="OpenJDK8"
 
     - <<: *tests-bdd
       jdk: openjdk10
+      env:
+        - JDK_VER="OpenJDK10"
 
     - <<: *tests-bdd
       jdk: openjdk11
+      env:
+        - JDK_VER="OpenJDK11"
 
     - stage: test
       name: Run tests - bootstrap

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
         - mvn install -DskipTests
 
     - stage: test
-      name: Run tests - bdd jdk8
+      name: Run tests - bdd - jdk8
       jdk: openjdk8
       script:
         - java -version
@@ -59,7 +59,7 @@ jobs:
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
     - stage: test
-      name: Run tests - bdd jdk10
+      name: Run tests - bdd - jdk10
       jdk: openjdk10
       script:
         - java -version
@@ -68,7 +68,7 @@ jobs:
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
     - stage: test
-      name: Run tests - bdd jdk11
+      name: Run tests - bdd - jdk11
       jdk: openjdk11
       script:
         - java -version
@@ -77,42 +77,142 @@ jobs:
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
     - stage: test
-      name: Run tests - bootstrap
+      name: Run tests - bootstrap - jdk8
+      jdk: openjdk8
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
 
     - stage: test
-      name: Run tests - angular
+      name: Run tests - bootstrap - jdk10
+      jdk: openjdk10
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+
+    - stage: test
+      name: Run tests - bootstrap - jdk11
+      jdk: openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+
+    - stage: test
+      name: Run tests - angular - jdk8
+      jdk: openjdk8
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
 
     - stage: test
-      name: Run tests - html
+      name: Run tests - angular - jdk10
+      jdk: openjdk10
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+    - stage: test
+      name: Run tests - angular - jdk11
+      jdk: openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+    - stage: test
+      name: Run tests - html - jdk8
+      jdk: openjdk8
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
 
     - stage: test
-      name: Run tests - examples
+      name: Run tests - html - jdk10
+      jdk: openjdk10
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
+    - stage: test
+      name: Run tests - html - jdk11
+      jdk: openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
+    - stage: test
+      name: Run tests - examples - jdk8
+      jdk: openjdk8
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
 
     - stage: test
-      name: Run tests - performance
+      name: Run tests - examples - jdk10
+      jdk: openjdk10
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+    - stage: test
+      name: Run tests - examples - jdk11
+      jdk: openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+    - stage: test
+      name: Run tests - performance - jdk8
+      jdk: openjdk8
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
 
     - stage: test
-      name: Run tests - jdi-light-unit-tests
+      name: Run tests - performance - jdk10
+      jdk: openjdk10
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+
+    - stage: test
+      name: Run tests - performance - jdk11
+      jdk: openjdk11
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+
+    - stage: test
+      name: Run tests - jdi-light-unit-tests - jdk8
+      jdk: openjdk8
+      script:
+          - mvn -ntp install -DskipTests
+          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+
+    - stage: test
+      name: Run tests - jdi-light-unit-tests - jdk10
+      jdk: openjdk10
+      script:
+          - mvn -ntp install -DskipTests
+          - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+
+    - stage: test
+      name: Run tests - jdi-light-unit-tests - jdk11
+      jdk: openjdk11
       script:
           - mvn -ntp install -DskipTests
           - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS

--- a/jdi-bdd-tests/src/test/resources/allure.properties
+++ b/jdi-bdd-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results- ${env:JDK_VER}
+ allure.results.directory=target/allure-results
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-bdd-tests/src/test/resources/allure.properties
+++ b/jdi-bdd-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results-$JDK_VER
+allure.results.directory=target/allure-results- ${env:JDK_VER}
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-bdd-tests/src/test/resources/allure.properties
+++ b/jdi-bdd-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results
+allure.results.directory=target/allure-results-$JDK_VER
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-light-angular-tests/src/test/resources/allure.properties
+++ b/jdi-light-angular-tests/src/test/resources/allure.properties
@@ -1,1 +1,1 @@
-allure.results.directory=target/allure-results-$JDK_VER
+allure.results.directory=target/allure-results- ${env:JDK_VER}

--- a/jdi-light-angular-tests/src/test/resources/allure.properties
+++ b/jdi-light-angular-tests/src/test/resources/allure.properties
@@ -1,1 +1,1 @@
-allure.results.directory=target/allure-results
+allure.results.directory=target/allure-results-$JDK_VER

--- a/jdi-light-angular-tests/src/test/resources/allure.properties
+++ b/jdi-light-angular-tests/src/test/resources/allure.properties
@@ -1,1 +1,1 @@
-allure.results.directory=target/allure-results- ${env:JDK_VER}
+allure.results.directory=target/allure-results

--- a/jdi-light-bootstrap-tests/src/test/resources/allure.properties
+++ b/jdi-light-bootstrap-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results- ${env:JDK_VER}
+ allure.results.directory=target/allure-results
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-light-bootstrap-tests/src/test/resources/allure.properties
+++ b/jdi-light-bootstrap-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results-$JDK_VER
+allure.results.directory=target/allure-results- ${env:JDK_VER}
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-light-bootstrap-tests/src/test/resources/allure.properties
+++ b/jdi-light-bootstrap-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results
+allure.results.directory=target/allure-results-$JDK_VER
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-light-html-tests/src/test/resources/allure.properties
+++ b/jdi-light-html-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results- ${env:JDK_VER}
+ allure.results.directory=target/allure-results
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-light-html-tests/src/test/resources/allure.properties
+++ b/jdi-light-html-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results-$JDK_VER
+allure.results.directory=target/allure-results- ${env:JDK_VER}
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/jdi-light-html-tests/src/test/resources/allure.properties
+++ b/jdi-light-html-tests/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results
+allure.results.directory=target/allure-results-$JDK_VER
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/reports.sh
+++ b/reports.sh
@@ -88,7 +88,7 @@ function grubAllureResults() {
     checkBranchIsOk #there is an exit inside
 
     if [[ "x${TRAVIS_BUILD_STAGE_NAME}" == "xtest" ]] ; then #don't remove x, it's useful
-        for result in $(find -type d -regex ".*/jdi.*/target/allure-results")
+        for result in $(find -type d -regex ".*/jdi.*/target/allure-results-*")
         do
             echo RESULT: ${result}
             archiveFile="$(archive "${result}")"
@@ -128,7 +128,7 @@ function deployAllureResults() {
 function downloadAllureResults() {
     urlExistence=false
     echo "TRAVIS_BUILD_NUMBER: ${TRAVIS_BUILD_NUMBER}"
-    for urlKey in $(collectRelevantComments "${TRAVIS_BUILD_NUMBER}")
+    for urlKey in $(collectRelevantComments "${TRAVIS_BUILD_NUMBER}") ##TODO: We'll likely want to pass JDK version here.
     do
         urlExistence=true
         echo "Found: ${urlKey}"
@@ -164,7 +164,7 @@ function generateAllureReports() {
         allureDir="${report}allure-results"
         if [[ -d "$allureDir" ]] ; then
             echo "Results found for ${report}"
-            reportDirList="${reportDirList} ${allureDir}"
+            reportDirList="${reportDirList} ${allureDir}" ## TODO: Research if we can run separate report generation scripts for different versions of JDK?
         else
             echo "RESULTS NOT FOUND FOR ${report}"
         fi
@@ -174,7 +174,7 @@ function generateAllureReports() {
         exitWithError
     fi
     echo ${reportDirList}
-    allure generate --clean ${reportDirList}
+    allure generate --clean ${reportDirList} ##KEEP IN MIND THAT WE CLEAR THE REPORTDIR HERE
 }
 
 function deployToNetlify() {

--- a/reports.sh
+++ b/reports.sh
@@ -89,7 +89,7 @@ function grubAllureResults() {
     checkBranchIsOk #there is an exit inside
 
     if [[ "x${TRAVIS_BUILD_STAGE_NAME}" == "xtest" ]] ; then #don't remove x, it's useful
-        for result in $(find jdi*/target/allure-results-${TRAVIS_JDK_VERSION} -maxdepth 1 -type d)
+        for result in $(find -type d -regex ".*/jdi.*/target/allure-results-${TRAVIS_JDK_VERSION}")
         do
             echo RESULT: ${result}
             archiveFile="$(archive "${result}")"

--- a/reports.sh
+++ b/reports.sh
@@ -88,7 +88,7 @@ function grubAllureResults() {
     checkBranchIsOk #there is an exit inside
 
     if [[ "x${TRAVIS_BUILD_STAGE_NAME}" == "xtest" ]] ; then #don't remove x, it's useful
-        for result in $(find -type d -regex ".*/jdi.*/target/allure-results-*")
+        for result in $(find -type d -regex ".*/jdi.*/target/allure-results-${TRAVIS_JDK_VERSION}")
         do
             echo RESULT: ${result}
             archiveFile="$(archive "${result}")"

--- a/reports.sh
+++ b/reports.sh
@@ -123,18 +123,15 @@ function deployAllureResults() {
     JDK_VERSIONS="openjdk8 openjdk10 openjdk11"
     for JDK in $JDK_VERSIONS;
     do
-      echo "Extracting and deploying allure report for $JDK"
-      REPORTFILES=$(ls jdi*/target/allure-results-$JDK)
-      echo "generateAllureReports goes here and uses ls -d1 jdi*/target/ */jdi*/target/:"
-      ls -d1 jdi*/target/ */jdi*/target/
-      echo "End of ls -d1 jdi*/target/ */jdi*/target/"
+      echo "Start of generate and deploy for $JDK"
+      generateAllureReports ${JDK}
       echo "deployToNetlify 'allure-report' should go here"
+      echo "LOG1"
+      url="$(deployToNetlify "allure-report-${JDK}")"
+      echo "LOG2"
+      sendComment "$(aboutNetlify ${url})"
+      echo "End of $JDK"
     done
-    generateAllureReports
-    echo "LOG1"
-    url="$(deployToNetlify "allure-report")"
-    echo "LOG2"
-    sendComment "$(aboutNetlify ${url})"
 }
 
 function downloadAllureResults() {
@@ -174,7 +171,7 @@ function generateAllureReports() {
     for report in $(ls -d1 jdi*/target/ */jdi*/target/)
     do
         allureDirExistence=true
-        allureDir="${report}allure-results"
+        allureDir="${report}allure-results-$1"
         if [[ -d "$allureDir" ]] ; then
             echo "Results found for ${report}"
             reportDirList="${reportDirList} ${allureDir}" ## TODO: Research if we can run separate report generation scripts for different versions of JDK?
@@ -186,7 +183,7 @@ function generateAllureReports() {
         echo "Failed inside generateAllureReports()"
         exitWithError
     fi
-    echo ${reportDirList}
+    echo ReportDirList is: ${reportDirList}
     allure generate --clean ${reportDirList} ##KEEP IN MIND THAT WE CLEAR THE REPORTDIR HERE
 }
 

--- a/reports.sh
+++ b/reports.sh
@@ -188,17 +188,10 @@ function generateAllureReports() {
 }
 
 function deployToNetlify() {
-    echo "Start of deployToNetlify()"
     directory="$1"
-    echo "Evaluating result variable"
     result="$(netlify deploy --dir "${directory}" --json)"
-    echo "Evaluating deployUrl"
     deployUrl="$(echo "${result}"r |jq '.deploy_url' |sed 's/"//g')"
-    echo "RESULT"
-    echo ${result}
-    echo "END OF RESULT"
     echo "${deployUrl}"
-    echo "End of deployToNetlify()"
 }
 
 function exitWithError() {

--- a/reports.sh
+++ b/reports.sh
@@ -52,7 +52,7 @@ function sendComment() {
 
 function archive() {
     directory="$1"
-    archiveName="$(echo "${directory}"| awk -F"/" '{print $1}')".tar.gz
+    archiveName="$(echo "${directory}"| awk -F"/" '{print $1}')-${TRAVIS_JDK_VERSION}".tar.gz
     tar -czf "${archiveName}" "${directory}" > /dev/null
     echo "${archiveName}" #return
 }
@@ -88,7 +88,7 @@ function grubAllureResults() {
     checkBranchIsOk #there is an exit inside
 
     if [[ "x${TRAVIS_BUILD_STAGE_NAME}" == "xtest" ]] ; then #don't remove x, it's useful
-        for result in $(find -type d -regex ".*/jdi.*/target/allure-results-${TRAVIS_JDK_VERSION}")
+        for result in $(find jdi*/target/allure-results -maxdepth 1 -type d)
         do
             echo RESULT: ${result}
             archiveFile="$(archive "${result}")"

--- a/reports.sh
+++ b/reports.sh
@@ -190,7 +190,7 @@ function generateAllureReports() {
 function deployToNetlify() {
     directory="$1"
     result="$(netlify deploy --dir "${directory}" --json)"
-    deployUrl="$(echo "${result}"r |jq '.deploy_url' |sed 's/"//g')"
+    deployUrl="$(echo '"${result}"r' | jq '.deploy_url' | sed 's/"//g')"
     echo "${deployUrl}"
 }
 

--- a/reports.sh
+++ b/reports.sh
@@ -52,7 +52,7 @@ function sendComment() {
 
 function archive() {
     directory="$1"
-    archiveName="$(echo "${directory}"| awk -F"/" '{print $1}')-${TRAVIS_JDK_VERSION}".tar.gz
+    archiveName="$(echo "${directory}"| grep -o "jdi-[a-z-]*")-${TRAVIS_JDK_VERSION}".tar.gz
     tar -czf "${archiveName}" "${directory}" > /dev/null
     echo "${archiveName}" #return
 }

--- a/reports.sh
+++ b/reports.sh
@@ -69,7 +69,8 @@ function aboutTransfer() {
 
 function aboutNetlify() {
     url="$1"
-    echo "[${TRAVIS_BUILD_NUMBER}] - Allure report on Netlify: ${url}" #return
+    jdk="$2"
+    echo "[${TRAVIS_BUILD_NUMBER}] - ${jdk} - Allure report on Netlify: ${url}" #return
 }
 
 function checkBranchIsOk() {
@@ -123,21 +124,18 @@ function deployAllureResults() {
     JDK_VERSIONS="openjdk8 openjdk10 openjdk11"
     for JDK in $JDK_VERSIONS;
     do
-      echo "Start of generate and deploy for $JDK"
       generateAllureReports ${JDK}
-      echo "deployToNetlify 'allure-report' should go here"
       echo "LOG1"
       url="$(deployToNetlify "allure-report-${JDK}")"
       echo "LOG2"
-      sendComment "$(aboutNetlify ${url})"
-      echo "End of $JDK"
+      sendComment "$(aboutNetlify ${url} ${JDK})"
     done
 }
 
 function downloadAllureResults() {
     urlExistence=false
     echo "TRAVIS_BUILD_NUMBER: ${TRAVIS_BUILD_NUMBER}"
-    for urlKey in $(collectRelevantComments "${TRAVIS_BUILD_NUMBER}") ##TODO: We'll likely want to pass JDK version here.
+    for urlKey in $(collectRelevantComments "${TRAVIS_BUILD_NUMBER}")
     do
         urlExistence=true
         echo "Found: ${urlKey}"
@@ -165,7 +163,6 @@ function extractAllureResults() {
 }
 
 function generateAllureReports() {
-    echo "Start of generateAllureReports function"
     reportDirList="";
     allureDirExistence=false
     for report in $(ls -d1 jdi*/target/ */jdi*/target/)
@@ -174,7 +171,7 @@ function generateAllureReports() {
         allureDir="${report}allure-results-$1"
         if [[ -d "$allureDir" ]] ; then
             echo "Results found for ${report}"
-            reportDirList="${reportDirList} ${allureDir}" ## TODO: Research if we can run separate report generation scripts for different versions of JDK?
+            reportDirList="${reportDirList} ${allureDir}"
         else
             echo "RESULTS NOT FOUND FOR ${report}"
         fi
@@ -186,7 +183,6 @@ function generateAllureReports() {
     echo "Generating allure-report-$1 based on:\n ${reportDirList}"
     allure generate --clean ${reportDirList} ##KEEP IN MIND THAT WE CLEAR THE REPORTDIR HERE
     mv allure-report allure-report-$1
-    ls -alh | grep allure
     echo Report successfully renamed to allure-report-$1
 
 }

--- a/reports.sh
+++ b/reports.sh
@@ -181,7 +181,7 @@ function generateAllureReports() {
         exitWithError
     fi
     echo "Generating allure-report-$1 based on: ${reportDirList}"
-    allure generate --clean ${reportDirList} ##KEEP IN MIND THAT WE CLEAR THE REPORTDIR HERE
+    allure generate --clean ${reportDirList}
     mv allure-report allure-report-$1
     echo Report successfully renamed to allure-report-$1
 
@@ -190,7 +190,7 @@ function generateAllureReports() {
 function deployToNetlify() {
     directory="$1"
     result="$(netlify deploy --dir "${directory}" --json)"
-    deployUrl="$(echo '"${result}"r' | jq '.deploy_url' | sed 's/"//g')"
+    deployUrl="$(echo "${result}"r | jq '.deploy_url' | sed 's/"//g')"
     echo "${deployUrl}"
 }
 

--- a/reports.sh
+++ b/reports.sh
@@ -180,7 +180,7 @@ function generateAllureReports() {
         echo "Failed inside generateAllureReports()"
         exitWithError
     fi
-    echo "Generating allure-report-$1 based on:\n ${reportDirList}"
+    echo "Generating allure-report-$1 based on: ${reportDirList}"
     allure generate --clean ${reportDirList} ##KEEP IN MIND THAT WE CLEAR THE REPORTDIR HERE
     mv allure-report allure-report-$1
     echo Report successfully renamed to allure-report-$1
@@ -191,6 +191,9 @@ function deployToNetlify() {
     directory="$1"
     result="$(netlify deploy --dir "${directory}" --json)"
     deployUrl="$(echo "${result}"r |jq '.deploy_url' |sed 's/"//g')"
+    echo RESULT:
+    echo ${result}
+    echo END OF RESULT
     echo "${deployUrl}"
 }
 

--- a/reports.sh
+++ b/reports.sh
@@ -124,7 +124,11 @@ function deployAllureResults() {
     for JDK in $JDK_VERSIONS;
     do
       echo "Extracting and deploying allure report for $JDK"
-      ls jdi*/target/allure-results-$JDK
+      REPORTFILES=$(ls jdi*/target/allure-results-$JDK)
+      echo "generateAllureReports goes here and uses ls -d1 jdi*/target/ */jdi*/target/:"
+      ls -d1 jdi*/target/ */jdi*/target/
+      echo "End of ls -d1 jdi*/target/ */jdi*/target/"
+      echo "deployToNetlify 'allure-report' should go here"
     done
     generateAllureReports
     echo "LOG1"

--- a/reports.sh
+++ b/reports.sh
@@ -117,12 +117,15 @@ function uploadFile() {
 function deployAllureResults() {
     checkBranchIsOk #there is an exit inside
     downloadAllureResults
-    # great, now we have set of .tar.gz files for different versions of JDK
-    # Our goal now is to distribute them across multiple allure reports
-    echo "Downloaded allure results from file sharing:"
-    ls
-    echo "End of LS output"
     extractAllureResults
+    # Great, now we have huge amount of jsons for different JDKs distributed across directory tree
+    # Our goal now is to distribute them across multiple allure reports
+    JDK_VERSIONS="openjdk8 openjdk10 openjdk11"
+    for JDK in $JDK_VERSIONS;
+    do
+      echo "Extracting and deploying allure report for $JDK"
+      ls jdi*/target/allure-results-$JDK
+    done
     generateAllureReports
     echo "LOG1"
     url="$(deployToNetlify "allure-report")"

--- a/reports.sh
+++ b/reports.sh
@@ -117,6 +117,10 @@ function uploadFile() {
 function deployAllureResults() {
     checkBranchIsOk #there is an exit inside
     downloadAllureResults
+    # great, now we have set of .tar.gz files for different versions of JDK
+    # Our goal now is to distribute them across multiple allure reports
+    echo "Downloaded allure results from file sharing:"
+    ls
     extractAllureResults
     generateAllureReports
     echo "LOG1"

--- a/reports.sh
+++ b/reports.sh
@@ -185,6 +185,9 @@ function generateAllureReports() {
     fi
     echo ReportDirList is: ${reportDirList}
     allure generate --clean ${reportDirList} ##KEEP IN MIND THAT WE CLEAR THE REPORTDIR HERE
+    ls -alh | grep allure
+    echo End of allure generate
+
 }
 
 function deployToNetlify() {

--- a/reports.sh
+++ b/reports.sh
@@ -188,13 +188,17 @@ function generateAllureReports() {
 }
 
 function deployToNetlify() {
+    echo "Start of deployToNetlify()"
     directory="$1"
+    echo "Evaluating result variable"
     result="$(netlify deploy --dir "${directory}" --json)"
+    echo "Evaluating deployUrl"
     deployUrl="$(echo "${result}"r |jq '.deploy_url' |sed 's/"//g')"
-    echo RESULT:
+    echo "RESULT"
     echo ${result}
-    echo END OF RESULT
+    echo "END OF RESULT"
     echo "${deployUrl}"
+    echo "End of deployToNetlify()"
 }
 
 function exitWithError() {

--- a/reports.sh
+++ b/reports.sh
@@ -183,10 +183,11 @@ function generateAllureReports() {
         echo "Failed inside generateAllureReports()"
         exitWithError
     fi
-    echo ReportDirList is: ${reportDirList}
+    echo "Generating allure-report-$1 based on:\n ${reportDirList}"
     allure generate --clean ${reportDirList} ##KEEP IN MIND THAT WE CLEAR THE REPORTDIR HERE
+    mv allure-report allure-report-$1
     ls -alh | grep allure
-    echo End of allure generate
+    echo Report successfully renamed to allure-report-$1
 
 }
 

--- a/reports.sh
+++ b/reports.sh
@@ -88,7 +88,7 @@ function grubAllureResults() {
     checkBranchIsOk #there is an exit inside
 
     if [[ "x${TRAVIS_BUILD_STAGE_NAME}" == "xtest" ]] ; then #don't remove x, it's useful
-        for result in $(find jdi*/target/allure-results -maxdepth 1 -type d)
+        for result in $(find jdi*/target/allure-results-${TRAVIS_JDK_VERSION} -maxdepth 1 -type d)
         do
             echo RESULT: ${result}
             archiveFile="$(archive "${result}")"

--- a/reports.sh
+++ b/reports.sh
@@ -121,6 +121,7 @@ function deployAllureResults() {
     # Our goal now is to distribute them across multiple allure reports
     echo "Downloaded allure results from file sharing:"
     ls
+    echo "End of LS output"
     extractAllureResults
     generateAllureReports
     echo "LOG1"
@@ -160,6 +161,7 @@ function extractAllureResults() {
 }
 
 function generateAllureReports() {
+    echo "Start of generateAllureReports function"
     reportDirList="";
     allureDirExistence=false
     for report in $(ls -d1 jdi*/target/ */jdi*/target/)

--- a/test-examples/jdi-light-examples/src/test/resources/allure.properties
+++ b/test-examples/jdi-light-examples/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results- ${env:JDK_VER}
+ allure.results.directory=target/allure-results
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/test-examples/jdi-light-examples/src/test/resources/allure.properties
+++ b/test-examples/jdi-light-examples/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results-$JDK_VER
+allure.results.directory=target/allure-results- ${env:JDK_VER}
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/test-examples/jdi-light-examples/src/test/resources/allure.properties
+++ b/test-examples/jdi-light-examples/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results
+allure.results.directory=target/allure-results-$JDK_VER
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/test-examples/jdi-performance/src/test/resources/allure.properties
+++ b/test-examples/jdi-performance/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results- ${env:JDK_VER}
+ allure.results.directory=target/allure-results
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/test-examples/jdi-performance/src/test/resources/allure.properties
+++ b/test-examples/jdi-performance/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results-$JDK_VER
+allure.results.directory=target/allure-results- ${env:JDK_VER}
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}

--- a/test-examples/jdi-performance/src/test/resources/allure.properties
+++ b/test-examples/jdi-performance/src/test/resources/allure.properties
@@ -1,3 +1,3 @@
-allure.results.directory=target/allure-results
+allure.results.directory=target/allure-results-$JDK_VER
 #allure.link.issue.pattern=https://jira.com/browse/{}
 #allure.link.tms.pattern=https://jira.com/browse/{}


### PR DESCRIPTION
- according to https://docs.travis-ci.com/user/languages/java/
  this should run tests against multiple JDKs
- removed JAVA_HOME in line #31 - it should not be needed