### PR TITLE
[DO NOT MERGE] 2038 Demonstration of Possibility to run tests on multiple JDKs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -253,7 +253,7 @@ after_success:
   - echo "Build was successful"
 after_script:
   # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
-  - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
+  - ALLURE_RESULTS=$(find -type d -regex ".*/jdi.*/target/allure-results")
   - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
   - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK
   - echo "$ALLURE_RESULTS dir has been renamed to $ALLURE_RESULTS_JDK"

--- a/.travis.yml
+++ b/.travis.yml
@@ -144,12 +144,24 @@ jobs:
       name: Run tests - bootstrap - JDK13
       jdk: openjdk13
 
-    - stage: test
-      name: Run tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        -  echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+    - <<: *testsangular
+      name: Run tests - angular - JDK8
+      jdk: openjdk8
+    - <<: *testsangular
+      name: Run tests - angular - JDK9
+      jdk: openjdk9
+    - <<: *testsangular
+      name: Run tests - angular - JDK10
+      jdk: openjdk10
+    - <<: *testsangular
+      name: Run tests - angular - JDK11
+      jdk: openjdk11
+    - <<: *testsangular
+      name: Run tests - angular - JDK12
+      jdk: openjdk12
+    - <<: *testsangular
+      name: Run tests - angular - JDK13
+      jdk: openjdk13
 
     - stage: test
       name: Run unit tests - angular

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,55 @@ stages:
   - test
   - reports
 
+testsbdd: &testsbdd
+  stage: test
+  name: Run tests - bdd
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+testsbootstrap: &testsbootstrap
+  stage: test
+  name: Run tests - bootstrap
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+testsexamples: &testsexamples
+  stage: test
+  name: Run tests - examples
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+testsperformance: &testsperformance
+  stage: test
+  name: Run tests - performance
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+testsunit: &testsunit
+  stage: test
+  name: Run tests - jdi-light-unit-tests
+  script:
+    - mvn -ntp install -DskipTests
+    - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
+testsangular: &testsangular # alias-anchor approach does not work with angular
+  stage: test
+  name: Run tests - angular
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+testshtml: &testshtml
+  stage: test
+  name: Run tests - html
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+
 jobs:
   include:
     - stage: prepare
@@ -50,36 +99,43 @@ jobs:
       script:
         - mvn install -DskipTests
 
-    - stage: test
+    - <<: *testsbdd
       name: Run tests - bdd - JDK8
       jdk: openjdk8
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-
-    - stage: test
+    - <<: *testsbdd
+      name: Run tests - bdd - JDK9
+      jdk: openjdk9
+    - <<: *testsbdd
       name: Run tests - bdd - JDK10
       jdk: openjdk10
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
-
-    - stage: test
+    - <<: *testsbdd
       name: Run tests - bdd - JDK11
       jdk: openjdk11
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+    - <<: *testsbdd
+      name: Run tests - bdd - JDK12
+      jdk: openjdk12
+    - <<: *testsbdd
+      name: Run tests - bdd - JDK13
+      jdk: openjdk13
 
-    - stage: test
-      name: Run tests - bootstrap
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+    - <<: *testsbootstrap
+      name: Run tests - bootstrap - JDK8
+      jdk: openjdk8
+    - <<: *testsbootstrap
+      name: Run tests - bootstrap - JDK9
+      jdk: openjdk9
+    - <<: *testsbootstrap
+      name: Run tests - bootstrap - JDK10
+      jdk: openjdk10
+    - <<: *testsbootstrap
+      name: Run tests - bootstrap - JDK11
+      jdk: openjdk11
+    - <<: *testsbootstrap
+      name: Run tests - bootstrap - JDK12
+      jdk: openjdk12
+    - <<: *testsbootstrap
+      name: Run tests - bootstrap - JDK13
+      jdk: openjdk13
 
     - stage: test
       name: Run tests - angular

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,24 @@ jobs:
         - mvn install -DskipTests
 
     - stage: test
-      name: Run tests - bdd
+      name: Run tests - bdd - JDK8
+      jdk: openjdk8
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+    - stage: test
+      name: Run tests - bdd - JDK10
+      jdk: openjdk10
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
+
+    - stage: test
+      name: Run tests - bdd - JDK11
+      jdk: openjdk11
       script:
         - mvn -ntp install -DskipTests
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
@@ -112,6 +129,12 @@ after_failure:
 after_success:
   - echo "Build was successful"
 after_script:
+  # following 4 lines are to rename allure-results dir to allure-results-<JDK VERSION>
+  - ALLURE_RESULTS=$(find jdi-*/target/ -type d -name "allure-results")
+  - ALLURE_RESULTS_JDK=$ALLURE_RESULTS-$TRAVIS_JDK_VERSION
+  - mv $ALLURE_RESULTS $ALLURE_RESULTS_JDK
+  - echo "$ALLURE_RESULTS dir has been renamed to $ALLURE_RESULTS_JDK"
+  # further actions
   - source reports.sh
   - grubAllureResults
   - du -d 1 -h ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
     - NOPO_TESTS="jdi-bdd-no-po-tests"
     - NOPO_TESTS_PROPERTY="test-examples/jdi-bdd-no-po-tests"
     - BDD_TESTS="jdi-bdd-tests"
+    - BOOTSTRAP_TESTS="jdi-light-bootstrap-tests"
     - HTML_TESTS="jdi-light-html-tests"
     - ANGULAR_TESTS="jdi-light-angular-tests"
     - EXAMPLES="jdi-light-examples"
@@ -55,13 +56,12 @@ jobs:
         - echo arguments=$CHROME_ARGS > "./$BDD_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BDD_TESTS
 
-    #TODO: bootstrap tests exceeded the maximum time limit for jobs (>50min)
-    #  - stage: test
-    #    name: Run tests - bootstrap
-    #    script:
-    #    - mvn -ntp install -DskipTests
-    #    - echo "arguments=$CHROME_ARGS" > $CHROME_PROPERTIES
-    #    - mvn verify $WITH_PARAMS -pl $BOOTSTRAP_TESTS
+    - stage: test
+      name: Run tests - bootstrap
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
 
     # TODO: uncomment after angular module is added
     #    - stage: test
@@ -78,20 +78,19 @@ jobs:
         - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
 
-    # TODO: #1995
-    #    - stage: test
-    #      name: Run tests - examples
-    #      script:
-    #        - mvn -ntp install -DskipTests
-    #        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-    #        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
-    #
-    #    - stage: test
-    #      name: Run tests - performance
-    #      script:
-    #        - mvn -ntp install -DskipTests
-    #        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-    #        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+    - stage: test
+      name: Run tests - examples
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+
+    - stage: test
+      name: Run tests - performance
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ env:
     - BOOTSTRAP_TESTS="jdi-light-bootstrap-tests"
     - HTML_TESTS="jdi-light-html-tests"
     - ANGULAR_TESTS="jdi-light-angular-tests"
+    - ANGULAR_UNIT_TESTS="jdi-light-angular-unit-tests"
     - EXAMPLES="jdi-light-examples"
     - EXAMPLES_PROPERTY="test-examples/jdi-light-examples"
     - PERFORMANCE="jdi-performance"
@@ -63,13 +64,19 @@ jobs:
         - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
 
-    # TODO: uncomment after angular module is added
-    #    - stage: test
-    #      name: Run tests -
-    #      script:
-    #        - mvn -ntp install -DskipTests
-    #        - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-    #        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+    - stage: test
+      name: Run tests - angular
+      script:
+        - mvn -ntp install -DskipTests
+        -  echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+
+    - stage: test
+      name: Run unit tests - angular
+      script:
+        - mvn -ntp install -DskipTests
+        - echo arguments=$CHROME_ARGS > "./$ANGULAR_UNIT_TESTS/src/test/resources/$CHROME_PROPERTIES"
+        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_UNIT_TESTS
 
     - stage: test
       name: Run tests - html

--- a/.travis.yml
+++ b/.travis.yml
@@ -163,12 +163,24 @@ jobs:
       name: Run tests - angular - JDK13
       jdk: openjdk13
 
-    - stage: test
-      name: Run unit tests - angular
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$ANGULAR_UNIT_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_UNIT_TESTS
+    - <<: *testsangularunit
+      name: Run unit tests - angular - JDK8
+      jdk: openjdk8
+    - <<: *testsangularunit
+      name: Run unit tests - angular - JDK9
+      jdk: openjdk9
+    - <<: *testsangularunit
+      name: Run unit tests - angular - JDK10
+      jdk: openjdk10
+    - <<: *testsangularunit
+      name: Run unit tests - angular - JDK11
+      jdk: openjdk11
+    - <<: *testsangularunit
+      name: Run unit tests - angular - JDK12
+      jdk: openjdk12
+    - <<: *testsangularunit
+      name: Run unit tests - angular - JDK13
+      jdk: openjdk13
 
     - <<: *testshtml
       name: Run tests - html - JDK8

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
     - PERFORMANCE="jdi-performance"
     - PERFORMANCE_PROPERTY="test-examples/jdi-performance"
     - CHROME_ARGS="--headless"
-    - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
+#    - JAVA_HOME="/usr/lib/jvm/java-8-openjdk-amd64"
     - PATH="$JAVA_HOME/bin:$PATH"
 
 stages:
@@ -51,6 +51,27 @@ testsbootstrap: &testsbootstrap
     - mvn -ntp install -DskipTests
     - echo arguments=$CHROME_ARGS > "./$BOOTSTRAP_TESTS/src/test/resources/$CHROME_PROPERTIES"
     - mvn verify $WITH_PARAMS -pl $GROUP_ID:$BOOTSTRAP_TESTS
+testsangular: &testsangular
+  stage: test
+  name: Run tests - angular
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
+testsangularunit: &testsangularunit
+  stage: test
+  name: Run unit tests - angular
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_UNIT_TESTS
+testshtml: &testshtml
+  stage: test
+  name: Run tests - html
+  script:
+    - mvn -ntp install -DskipTests
+    - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
+    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
 testsexamples: &testsexamples
   stage: test
   name: Run tests - examples
@@ -71,20 +92,6 @@ testsunit: &testsunit
   script:
     - mvn -ntp install -DskipTests
     - mvn verify -pl $GROUP_ID:$JDI_LIGHT_UNIT_TESTS
-testsangular: &testsangular # alias-anchor approach does not work with angular
-  stage: test
-  name: Run tests - angular
-  script:
-    - mvn -ntp install -DskipTests
-    - echo arguments=$CHROME_ARGS > "./$ANGULAR_TESTS/src/test/resources/$CHROME_PROPERTIES"
-    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_TESTS
-testshtml: &testshtml
-  stage: test
-  name: Run tests - html
-  script:
-    - mvn -ntp install -DskipTests
-    - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-    - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
 
 jobs:
   include:
@@ -151,26 +158,62 @@ jobs:
         - echo arguments=$CHROME_ARGS > "./$ANGULAR_UNIT_TESTS/src/test/resources/$CHROME_PROPERTIES"
         - mvn verify $WITH_PARAMS -pl $GROUP_ID:$ANGULAR_UNIT_TESTS
 
-    - stage: test
-      name: Run tests - html
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$HTML_TESTS/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$HTML_TESTS
+    - <<: *testshtml
+      name: Run tests - html - JDK8
+      jdk: openjdk8
+    - <<: *testshtml
+      name: Run tests - html - JDK9
+      jdk: openjdk9
+    - <<: *testshtml
+      name: Run tests - html - JDK10
+      jdk: openjdk10
+    - <<: *testshtml
+      name: Run tests - html - JDK11
+      jdk: openjdk11
+    - <<: *testshtml
+      name: Run tests - html - JDK12
+      jdk: openjdk12
+    - <<: *testshtml
+      name: Run tests - html - JDK13
+      jdk: openjdk13
 
-    - stage: test
-      name: Run tests - examples
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$EXAMPLES_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$EXAMPLES
+    - <<: *testsexamples
+      name: Run tests - examples - JDK8
+      jdk: openjdk8
+    - <<: *testsexamples
+      name: Run tests - examples - JDK9
+      jdk: openjdk9
+    - <<: *testsexamples
+      name: Run tests - examples - JDK10
+      jdk: openjdk10
+    - <<: *testsexamples
+      name: Run tests - examples - JDK11
+      jdk: openjdk11
+    - <<: *testsexamples
+      name: Run tests - examples - JDK12
+      jdk: openjdk12
+    - <<: *testsexamples
+      name: Run tests - examples - JDK13
+      jdk: openjdk13
 
-    - stage: test
-      name: Run tests - performance
-      script:
-        - mvn -ntp install -DskipTests
-        - echo arguments=$CHROME_ARGS > "./$PERFORMANCE_PROPERTY/src/test/resources/$CHROME_PROPERTIES"
-        - mvn verify $WITH_PARAMS -pl $GROUP_ID:$PERFORMANCE
+    - <<: *testsperformance
+      name: Run tests - performance - JDK8
+      jdk: openjdk8
+    - <<: *testsperformance
+      name: Run tests - performance - JDK9
+      jdk: openjdk9
+    - <<: *testsperformance
+      name: Run tests - performance - JDK10
+      jdk: openjdk10
+    - <<: *testsperformance
+      name: Run tests - performance - JDK11
+      jdk: openjdk11
+    - <<: *testsperformance
+      name: Run tests - performance - JDK12
+      jdk: openjdk12
+    - <<: *testsperformance
+      name: Run tests - performance - JDK13
+      jdk: openjdk13
 
     - stage: reports
       name: Deploy allure reports to netlify

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,14 +102,7 @@ jobs:
         - mvn --version #it is helpful
 
     - stage: compile
-      name: Compile jdi code - JDK8
-      jdk: openjdk8
-      script:
-        - mvn install -DskipTests
-
-    - stage: compile
-      name: Compile jdi code - JDK9
-      jdk: openjdk9
+      name: Compile jdi code
       script:
         - mvn install -DskipTests
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,14 @@ jobs:
         - mvn --version #it is helpful
 
     - stage: compile
-      name: Compile jdi code
+      name: Compile jdi code - JDK8
+      jdk: openjdk8
+      script:
+        - mvn install -DskipTests
+
+    - stage: compile
+      name: Compile jdi code - JDK9
+      jdk: openjdk9
       script:
         - mvn install -DskipTests
 

--- a/jdi-bdd-tests/src/main/java/io/github/com/StaticSite.java
+++ b/jdi-bdd-tests/src/main/java/io/github/com/StaticSite.java
@@ -1,8 +1,11 @@
 package io.github.com;
 
-import com.epam.jdi.light.elements.pageobjects.annotations.*;
+import com.epam.jdi.bdd.elements.CustomMenu;
+import com.epam.jdi.light.elements.pageobjects.annotations.Frame;
+import com.epam.jdi.light.elements.pageobjects.annotations.JSite;
+import com.epam.jdi.light.elements.pageobjects.annotations.Title;
+import com.epam.jdi.light.elements.pageobjects.annotations.Url;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
-import io.github.com.custom.CustomMenu;
 import io.github.com.pages.*;
 
 @JSite("https://jdi-testing.github.io/jdi-light/")

--- a/jdi-bdd-tests/src/test/java/cucmberTests/TestRunner.java
+++ b/jdi-bdd-tests/src/test/java/cucmberTests/TestRunner.java
@@ -19,9 +19,9 @@ import static io.github.com.pages.Header.*;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
-        features = "classpath:features"
-        , glue = {"com.epam.jdi.bdd", "cucmberTests"}
-        // , tags = {"@radio"}
+    features = "classpath:features"
+    , glue = {"com.epam.jdi.bdd", "cucumberTests"}
+    // , tags = {"@radio"}
 )
 public class TestRunner {
     @BeforeClass

--- a/jdi-bdd-tests/src/test/java/cucumberTests/CucumberHooks.java
+++ b/jdi-bdd-tests/src/test/java/cucumberTests/CucumberHooks.java
@@ -5,6 +5,7 @@ import io.qameta.allure.model.Label;
 import io.qameta.allure.util.ResultsUtils;
 
 import java.util.List;
+import java.util.Optional;
 
 import static io.qameta.allure.Allure.getLifecycle;
 
@@ -16,8 +17,8 @@ public class CucumberHooks {
 
     @Before
     public void beforeTest() {
-        String uuid = getLifecycle().getCurrentTestCase().get();
-        getLifecycle().updateTestCase(uuid, testResult -> {
+        Optional<String> uuid = getLifecycle().getCurrentTestCase();
+        uuid.ifPresent(s -> getLifecycle().updateTestCase(s, testResult -> {
             List<Label> labels = testResult.getLabels();
             labels.stream()
                     .filter(label -> label.getName().equals("suite"))
@@ -25,6 +26,6 @@ public class CucumberHooks {
             labels.add(parentSuiteLabel);
             labels.add(suiteLabel);
             testResult.setLabels(labels);
-        });
+        }));
     }
 }

--- a/jdi-bdd-tests/src/test/java/cucumberTests/CucumberHooks.java
+++ b/jdi-bdd-tests/src/test/java/cucumberTests/CucumberHooks.java
@@ -1,0 +1,30 @@
+package cucumberTests;
+
+import cucumber.api.java.Before;
+import io.qameta.allure.model.Label;
+import io.qameta.allure.util.ResultsUtils;
+
+import java.util.List;
+
+import static io.qameta.allure.Allure.getLifecycle;
+
+
+public class CucumberHooks {
+
+    private final Label parentSuiteLabel = ResultsUtils.createParentSuiteLabel("JDI-Light BDD");
+    private final Label suiteLabel = ResultsUtils.createSuiteLabel("Tests");
+
+    @Before
+    public void beforeTest() {
+        String uuid = getLifecycle().getCurrentTestCase().get();
+        getLifecycle().updateTestCase(uuid, testResult -> {
+            List<Label> labels = testResult.getLabels();
+            labels.stream()
+                    .filter(label -> label.getName().equals("suite"))
+                    .forEach(label -> label.setName("subSuite"));
+            labels.add(parentSuiteLabel);
+            labels.add(suiteLabel);
+            testResult.setLabels(labels);
+        });
+    }
+}

--- a/jdi-bdd-tests/src/test/java/cucumberTests/TestRunner.java
+++ b/jdi-bdd-tests/src/test/java/cucumberTests/TestRunner.java
@@ -1,4 +1,4 @@
-package cucmberTests;
+package cucumberTests;
 
 import com.epam.jdi.light.elements.interfaces.complex.IsCombobox;
 import com.epam.jdi.light.ui.html.elements.complex.DataListOptions;

--- a/jdi-bdd-tests/src/test/java/cucumberTests/stepdefs/UserStepdefs.java
+++ b/jdi-bdd-tests/src/test/java/cucumberTests/stepdefs/UserStepdefs.java
@@ -1,4 +1,4 @@
-package cucmberTests.stepdefs;
+package cucumberTests.stepdefs;
 
 import com.epam.jdi.light.elements.composite.WebPage;
 import com.epam.jdi.light.ui.html.elements.common.FileInput;

--- a/jdi-bdd-tests/src/test/resources/features/Menu.feature
+++ b/jdi-bdd-tests/src/test/resources/features/Menu.feature
@@ -26,7 +26,8 @@ Feature: Menu
 #    Then the "HTML 5" in "Left Menu" menu is selected
 #
   Scenario: Check selected item after page load
-    Then the "Elements packs" in "Left Menu" menu is selected
+    When I select "Metals & Colors" in "Left Menu" menu
+    Then the "Metals & Colors" in "Left Menu" menu is selected
 
 #  Scenario: Check selected sub-item after page load
 #    Then the "HTML 5" in "Left Menu" menu is selected

--- a/jdi-bdd/src/main/java/com/epam/jdi/bdd/elements/CustomMenu.java
+++ b/jdi-bdd/src/main/java/com/epam/jdi/bdd/elements/CustomMenu.java
@@ -1,4 +1,4 @@
-package io.github.com.custom;
+package com.epam.jdi.bdd.elements;
 
 import com.epam.jdi.light.elements.complex.Menu;
 import com.epam.jdi.light.elements.complex.WebList;

--- a/jdi-bdd/src/main/java/com/epam/jdi/bdd/stepdefs/RadioSteps.java
+++ b/jdi-bdd/src/main/java/com/epam/jdi/bdd/stepdefs/RadioSteps.java
@@ -26,7 +26,7 @@ public class RadioSteps {
     //#region Then
     @Then("^the \"([^\"]*)\" consists of next values:$")
     public void theConsistOfNextValues(String name, List<String> values) {
-        radioButtons(name).has().values(values.toArray(new String[0]));
+        radioButtons(name).has().values(values);
     }
 
     @Then("^the \"([^\"]*)\" contains \"([^\"]*)\" radio button$")

--- a/jdi-bdd/src/main/java/com/epam/jdi/bdd/stepdefs/RadioSteps.java
+++ b/jdi-bdd/src/main/java/com/epam/jdi/bdd/stepdefs/RadioSteps.java
@@ -1,14 +1,13 @@
 package com.epam.jdi.bdd.stepdefs;
 
+import static com.epam.jdi.light.elements.init.entities.collection.EntitiesCollection.getUI;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.core.IsIterableContaining.hasItem;
+
 import com.epam.jdi.light.ui.html.elements.complex.RadioButtons;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-
 import java.util.List;
-
-import static com.epam.jdi.light.elements.init.entities.collection.EntitiesCollection.*;
-import static org.hamcrest.Matchers.*;
-import static org.hamcrest.core.IsIterableContaining.hasItem;
 
 /**
  * Created by Roman Iovlev on 26.09.2019
@@ -27,7 +26,7 @@ public class RadioSteps {
     //#region Then
     @Then("^the \"([^\"]*)\" consists of next values:$")
     public void theConsistOfNextValues(String name, List<String> values) {
-        radioButtons(name).has().values(values);
+        radioButtons(name).has().values(values.toArray(new String[0]));
     }
 
     @Then("^the \"([^\"]*)\" contains \"([^\"]*)\" radio button$")

--- a/jdi-light-angular-tests/pom.xml
+++ b/jdi-light-angular-tests/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jdi-light-angular-tests</artifactId>
+    <name>Tests: JDI Angular</name>
+    <version>1.2.14</version>
+    <groupId>com.epam.jdi</groupId>
+
+    <properties>
+        <driver>chrome</driver>
+        <allure.testng>2.13.2</allure.testng>
+        <allure.maven>2.10.0</allure.maven>
+        <jetty.version>9.4.12.RC2</jetty.version>
+        <aspectj.version>1.9.1</aspectj.version>
+    </properties>
+
+    <dependencies>
+        <!--JDI-->
+        <dependency>
+            <groupId>com.epam.jdi</groupId>
+            <artifactId>jdi-light-angular</artifactId>
+            <version>1.2.14</version>
+        </dependency>
+        <!--Allure config in parent-->
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-testng</artifactId>
+            <version>${allure.testng}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-collections4</artifactId>
+            <version>4.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.0.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <!--Allure reporting config in parent-->
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <testFailureIgnore>true</testFailureIgnore>
+                    <argLine>
+                        -javaagent:"${settings.localRepository}/org/aspectj/aspectjweaver/${aspectj.version}/aspectjweaver-${aspectj.version}.jar"
+                    </argLine>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>io.qameta.allure.testng.AllureTestNg</value>
+                        </property>
+                    </properties>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjweaver</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>${allure.maven}</version>
+            </plugin>
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
+        </plugins>
+
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+    <!-- Allure reporting config in parent-->
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>LATEST</version>
+                <configuration>
+                    <properties>
+                        <allure.results.directory>target/allure-results</allure.results.directory>
+                    </properties>
+                    <properties>
+                        <allure.link.issue.pattern>https://example.org/issue/{}</allure.link.issue.pattern>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+
+</project>

--- a/jdi-light-angular-tests/src/main/java/io/github/com/StaticSite.java
+++ b/jdi-light-angular-tests/src/main/java/io/github/com/StaticSite.java
@@ -1,0 +1,33 @@
+package io.github.com;
+
+import com.epam.jdi.light.elements.composite.Form;
+import com.epam.jdi.light.elements.pageobjects.annotations.JSite;
+import com.epam.jdi.light.elements.pageobjects.annotations.Url;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.Css;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
+import com.epam.jdi.light.ui.html.elements.common.Button;
+import com.epam.jdi.light.ui.html.elements.common.Text;
+import com.epam.jdi.tools.DataClass;
+import io.github.com.pages.AngularPage;
+
+@JSite("https://jdi-testing.github.io/jdi-light/")
+public class StaticSite {
+
+    public static User DEFAULT_USER = new User();
+
+    @Url("/angular.html")
+    public static AngularPage angularPage;
+
+    @UI("#login-form")
+    public static Form<User> loginForm;
+
+    @Css(".fa-sign-out")
+    public static Button logout;
+    public static Button userIcon;
+    public static Text userName;
+
+    public static class User extends DataClass<User> {
+        public String name = "Roman";
+        public String password = "Jdi1234";
+    }
+}

--- a/jdi-light-angular-tests/src/main/java/io/github/com/pages/AngularPage.java
+++ b/jdi-light-angular-tests/src/main/java/io/github/com/pages/AngularPage.java
@@ -1,0 +1,32 @@
+package io.github.com.pages;
+
+import com.epam.jdi.light.elements.composite.WebPage;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.Css;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
+import com.epam.jdi.light.ui.html.elements.common.Button;
+import com.epam.jdi.light.ui.html.elements.common.Icon;
+import com.epam.jdi.light.ui.html.elements.complex.RadioButtons;
+import io.github.com.pages.sections.SlideToggleSection;
+import com.epam.jdi.angular.elements.common.ProgressSpinner;
+
+public class AngularPage extends WebPage {
+    @Css("radio-overview-example .mat-radio-group")
+    public static RadioButtons basicRadioButtons;
+
+    @UI("#mat-radio-2")
+    public static Button firstBasicRadioButton;
+
+    @UI("#mat-radio-3")
+    public static Button secondBasicRadioButton;
+
+    @UI("#basic_progress_spinner")
+    public static ProgressSpinner basicProgressSpinner;
+
+    @UI("#basic_icon")
+    public static Icon basicIcon;
+
+    @UI("#svg_icon")
+    public static Icon svgIcon;
+
+    public static SlideToggleSection slideToggleSection;
+}

--- a/jdi-light-angular-tests/src/main/java/io/github/com/pages/HomePage.java
+++ b/jdi-light-angular-tests/src/main/java/io/github/com/pages/HomePage.java
@@ -1,0 +1,14 @@
+package io.github.com.pages;
+
+import com.epam.jdi.light.elements.common.Label;
+import com.epam.jdi.light.elements.composite.WebPage;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.Css;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
+import com.epam.jdi.light.ui.html.elements.common.Link;
+import com.epam.jdi.light.ui.html.elements.common.Text;
+
+public class HomePage extends WebPage {
+    @Css("h3[name='main-title']") public static Label mainTitle;
+    @Css(".main-txt") public static Text jdiText;
+    @UI("['JDI Github']") public static Link githubLink;
+}

--- a/jdi-light-angular-tests/src/main/java/io/github/com/pages/sections/SlideToggleSection.java
+++ b/jdi-light-angular-tests/src/main/java/io/github/com/pages/sections/SlideToggleSection.java
@@ -1,0 +1,36 @@
+package io.github.com.pages.sections;
+
+import com.epam.jdi.light.elements.composite.Section;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.Css;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
+import com.epam.jdi.light.ui.html.elements.common.Button;
+import com.epam.jdi.light.ui.html.elements.complex.RadioButtons;
+import com.epam.jdi.angular.elements.common.Checkbox;
+import com.epam.jdi.angular.elements.common.SlideToggle;
+
+public class SlideToggleSection extends Section {
+
+    @UI("#mat-slide-toggle-1")
+    public static SlideToggle basicSlideToggle;
+
+    @UI("#mat-slide-toggle-2")
+    public static SlideToggle resultSlideToggle;
+
+    @UI("#mat-checkbox-6")
+    public static Checkbox checkedCheckbox;
+
+    @UI("#mat-checkbox-7")
+    public static Checkbox disableCheckbox;
+
+    @Css(".example-section .mat-radio-group")
+    public static RadioButtons colorRadioButtons;
+
+    @UI("#mat-radio-13")
+    public static Button primaryRadioButton;
+
+    @UI("#mat-radio-14")
+    public static Button accentRadioButton;
+
+    @UI("#mat-radio-15")
+    public static Button warningRadioButton;
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/TestsInit.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/TestsInit.java
@@ -1,0 +1,34 @@
+package io.github.epam;
+
+import static com.epam.jdi.light.driver.WebDriverUtils.killAllSeleniumDrivers;
+import static com.epam.jdi.light.elements.composite.WebPage.openUrl;
+import static com.epam.jdi.light.elements.init.PageFactory.initSite;
+import static com.epam.jdi.light.settings.JDISettings.DRIVER;
+import static com.epam.jdi.light.settings.WebSettings.logger;
+
+import io.github.com.StaticSite;
+import io.github.epam.testng.TestNGListener;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Listeners;
+
+@Listeners(TestNGListener.class)
+public class TestsInit {
+
+    @BeforeSuite(alwaysRun = true)
+    public static void setUp() {
+        killAllSeleniumDrivers();
+        initSite(StaticSite.class);
+        openUrl(DRIVER.domain);
+        logger.toLog("Run Tests");
+    }
+
+    @AfterSuite(alwaysRun = true)
+    public static void tearDown() {
+        killAllSeleniumDrivers();
+    }
+
+    protected static boolean isFireFox() {
+        return DRIVER.name.equalsIgnoreCase("firefox");
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/BasicTests.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/BasicTests.java
@@ -1,0 +1,23 @@
+package io.github.epam.angular.tests;
+
+import static io.github.com.StaticSite.angularPage;
+import static io.github.com.StaticSite.userName;
+import static io.github.epam.site.steps.States.shouldBeLoggedIn;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class BasicTests extends TestsInit {
+
+    @BeforeMethod
+    public void before() {
+        shouldBeLoggedIn();
+        angularPage.shouldBeOpened();
+    }
+
+    @Test
+    public void checkUsernameOnAngularPage() {
+        userName.is().displayed();
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/IconsTests.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/IconsTests.java
@@ -1,0 +1,31 @@
+package io.github.epam.angular.tests;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static io.github.com.StaticSite.angularPage;
+import static io.github.com.pages.AngularPage.basicIcon;
+import static io.github.com.pages.AngularPage.svgIcon;
+import static io.github.epam.site.steps.States.shouldBeLoggedIn;
+
+public class IconsTests extends TestsInit {
+
+    @BeforeMethod
+    public void before() {
+        shouldBeLoggedIn();
+        angularPage.shouldBeOpened();
+    }
+
+    @Test
+    public void checkBasicIconIsDisplayed() {
+        basicIcon.show();
+        basicIcon.isDisplayed();
+    }
+
+    @Test
+    public void checkSVGIconIsDisplayed() {
+        svgIcon.show();
+        svgIcon.isDisplayed();
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/RadioButtonTests.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/RadioButtonTests.java
@@ -1,0 +1,34 @@
+package io.github.epam.angular.tests;
+
+import static io.github.com.StaticSite.angularPage;
+import static io.github.com.pages.AngularPage.basicRadioButtons;
+import static io.github.com.pages.AngularPage.firstBasicRadioButton;
+import static io.github.com.pages.AngularPage.secondBasicRadioButton;
+import static io.github.epam.site.steps.States.shouldBeLoggedIn;
+import static org.testng.Assert.assertEquals;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class RadioButtonTests extends TestsInit {
+
+    @BeforeMethod
+    public void before() {
+        shouldBeLoggedIn();
+        angularPage.shouldBeOpened();
+    }
+
+    @Test
+    public void basicTest() {
+        basicRadioButtons.is().displayed();
+        firstBasicRadioButton.is().displayed();
+        secondBasicRadioButton.is().displayed();
+    }
+
+    @Test
+    public void getTextTest() {
+        assertEquals(firstBasicRadioButton.getText(), "Option 1");
+        assertEquals(secondBasicRadioButton.getText(), "Option 2");
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/SlideToggleTests.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/SlideToggleTests.java
@@ -1,0 +1,71 @@
+package io.github.epam.angular.tests;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static io.github.com.StaticSite.angularPage;
+import static io.github.com.pages.sections.SlideToggleSection.accentRadioButton;
+import static io.github.com.pages.sections.SlideToggleSection.basicSlideToggle;
+import static io.github.com.pages.sections.SlideToggleSection.checkedCheckbox;
+import static io.github.com.pages.sections.SlideToggleSection.colorRadioButtons;
+import static io.github.com.pages.sections.SlideToggleSection.disableCheckbox;
+import static io.github.com.pages.sections.SlideToggleSection.primaryRadioButton;
+import static io.github.com.pages.sections.SlideToggleSection.resultSlideToggle;
+import static io.github.com.pages.sections.SlideToggleSection.warningRadioButton;
+import static io.github.epam.site.steps.States.shouldBeLoggedIn;
+
+public class SlideToggleTests extends TestsInit {
+
+    @BeforeMethod
+    public void before() {
+        shouldBeLoggedIn();
+        angularPage.shouldBeOpened();
+    }
+
+    @Test
+    public void basicTest() {
+        basicSlideToggle.is().displayed();
+        resultSlideToggle.is().displayed();
+        checkedCheckbox.is().displayed();
+        disableCheckbox.is().displayed();
+        colorRadioButtons.is().displayed();
+    }
+
+    @Test
+    public void basicToggleCheckedTest() {
+        basicSlideToggle.check();
+        basicSlideToggle.is().selected();
+        basicSlideToggle.uncheck();
+        basicSlideToggle.is().deselected();
+    }
+
+    @Test
+    public void resultToggleColorTest() {
+        disableCheckbox.uncheck();
+        resultSlideToggle.check();
+        primaryRadioButton.click();
+        resultSlideToggle.is().hasClass("mat-primary");
+        accentRadioButton.click();
+        resultSlideToggle.is().hasClass("mat-accent");
+        warningRadioButton.click();
+        resultSlideToggle.is().hasClass("mat-warn");
+    }
+
+    @Test
+    public void resultToggleCheckedTest() {
+        resultSlideToggle.uncheck();
+        checkedCheckbox.check();
+        resultSlideToggle.is().selected();
+        checkedCheckbox.uncheck();
+        resultSlideToggle.is().deselected();
+    }
+
+    @Test
+    public void resultToggleDisableTest() {
+        disableCheckbox.check();
+        resultSlideToggle.is().disabled();
+        disableCheckbox.uncheck();
+        resultSlideToggle.is().enabled();
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/SpinnerTests.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/SpinnerTests.java
@@ -1,0 +1,24 @@
+package io.github.epam.angular.tests;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static io.github.com.StaticSite.angularPage;
+import static io.github.com.pages.AngularPage.basicProgressSpinner;
+import static io.github.epam.site.steps.States.shouldBeLoggedIn;
+
+public class SpinnerTests extends TestsInit {
+
+    @BeforeMethod
+    public void before() {
+        shouldBeLoggedIn();
+        angularPage.shouldBeOpened();
+    }
+
+    @Test
+    public void checkBasicSpinnerIsDisplayed() {
+        basicProgressSpinner.show();
+        basicProgressSpinner.isDisplayed();
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/site/steps/States.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/site/steps/States.java
@@ -1,0 +1,55 @@
+package io.github.epam.site.steps;
+
+import static com.epam.jdi.light.elements.composite.WebPage.openUrl;
+import static com.epam.jdi.light.settings.JDISettings.DRIVER;
+import static io.github.com.StaticSite.angularPage;
+import static io.github.com.StaticSite.loginForm;
+import static io.github.com.StaticSite.logout;
+import static io.github.com.StaticSite.userIcon;
+import static io.github.com.StaticSite.userName;
+
+import com.epam.jdi.light.elements.composite.WebPage;
+import io.github.com.StaticSite;
+import io.qameta.allure.Step;
+
+public class States {
+    @Step
+    public static void shouldBeLoggedIn() {
+        String url = WebPage.getUrl();
+        if (!url.contains("https://jdi-testing.github.io/jdi-light/")) {
+            angularPage.open();
+        }
+        if (userName.isHidden()) {
+            login();
+        }
+    }
+
+    @Step
+    public static void login() {
+        if (loginForm.isHidden()) {
+            userIcon.click();
+        }
+        loginForm.submit(StaticSite.DEFAULT_USER);
+    }
+
+    @Step
+    public static void shouldBeLoggedOut() {
+        if (!WebPage.getUrl().contains(DRIVER.domain)) {
+            openUrl(DRIVER.domain);
+        }
+        if (userName.isDisplayed()) {
+            logout();
+        }
+        if (loginForm.isDisplayed()) {
+            userIcon.click();
+        }
+    }
+
+    @Step
+    public static void logout() {
+        if (!logout.isDisplayed()) {
+            userIcon.click();
+        }
+        logout.click();
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -1,0 +1,59 @@
+package io.github.epam.testng;
+
+import static com.epam.jdi.light.driver.ScreenshotMaker.takeScreen;
+import static com.epam.jdi.light.settings.WebSettings.TEST_NAME;
+import static com.epam.jdi.light.settings.WebSettings.logger;
+import static java.lang.System.currentTimeMillis;
+
+import com.epam.jdi.tools.Safe;
+import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+public class TestNGListener implements IInvokedMethodListener {
+
+    private Safe<Long> start = new Safe<>(0L);
+
+    @Override
+    public void beforeInvocation(IInvokedMethod m, ITestResult tr) {
+        if (m.isTestMethod()) {
+            Method testMethod = m.getTestMethod().getConstructorOrMethod().getMethod();
+            if (testMethod.isAnnotationPresent(Test.class)) {
+                TEST_NAME.set(
+                    tr.getTestClass().getRealClass().getSimpleName() + "." + testMethod.getName());
+                start.set(currentTimeMillis());
+                logger.step("== Test '%s' START ==", TEST_NAME.get());
+            }
+        }
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult r) {
+        if (method.isTestMethod()) {
+            String result = getTestResult(r);
+            logger.step("=== Test '%s' %s [%s] ===", TEST_NAME.get(), result,
+                new SimpleDateFormat("mm:ss.SS")
+                    .format(new Date(currentTimeMillis() - start.get())));
+            if ("FAILED".equals(result)) {
+                takeScreen();
+                logger.step("ERROR: " + r.getThrowable().getMessage());
+            }
+            logger.step("");
+        }
+    }
+
+    private String getTestResult(ITestResult result) {
+        switch (result.getStatus()) {
+            case ITestResult.SUCCESS:
+                return "PASSED";
+            case ITestResult.SKIP:
+                return "SKIPPED";
+            default:
+                return "FAILED";
+        }
+    }
+}

--- a/jdi-light-angular-tests/src/test/resources/allure.properties
+++ b/jdi-light-angular-tests/src/test/resources/allure.properties
@@ -1,0 +1,1 @@
+allure.results.directory=target/allure-results

--- a/jdi-light-angular-tests/src/test/resources/general.xml
+++ b/jdi-light-angular-tests/src/test/resources/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="WINDOWS-1251"?>
+        <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="JDI-Light Angular Tests" parallel="methods" thread-count="1">
+    <test name="Tests">
+        <packages>
+            <package name="io.github.epam.angular.tests.*"/>
+        </packages>
+    </test>
+    <listeners>
+        <listener class-name="io.github.epam.testng.TestNGListener" />
+    </listeners>
+</suite>

--- a/jdi-light-angular-tests/src/test/resources/log4j2.component.properties
+++ b/jdi-light-angular-tests/src/test/resources/log4j2.component.properties
@@ -1,0 +1,1 @@
+log4j.configurationFile=./log4j2.xml

--- a/jdi-light-angular-tests/src/test/resources/log4j2.xml
+++ b/jdi-light-angular-tests/src/test/resources/log4j2.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration monitorInterval="30" status="debug">
+
+
+  <Properties>
+    <Property name="logFileName">jdiEvents</Property>
+    <Property name="baseDir">./target/.logs</Property>
+  </Properties>
+
+  <Appenders>
+    <!-- the standard-console-appender. Whole message colored according to log level-->
+
+    <!--<Console name="SOUT" target="SYSTEM_OUT">-->
+    <!--<ThresholdFilter level="WARN" onMatch="DENY" onMismatch="ACCEPT"/>-->
+    <!--<PatternLayout pattern="%d{HH:mm:ss} [%t] %-7level %logger{3} - %msg%n"/>-->
+    <!--</Console>-->
+
+    <!--<Console name="SERR" target="SYSTEM_ERR">-->
+    <!--<ThresholdFilter level="WARN" onMatch="ACCEPT" onMismatch="DENY"/>-->
+    <!--<PatternLayout pattern="%d{HH:mm:ss} [%t] %-7level %logger{3} - %msg%n"/>-->
+    <!--</Console>-->
+
+
+    <Console name="ColoredConsoleAppender" target="SYSTEM_OUT" follow="true">
+      <PatternLayout
+              pattern="[%highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} %d{mm:ss.SSS}] : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%throwable}"/>
+    </Console>
+
+    <RollingFile name="fileAppender" fileName="${baseDir}/${logFileName}.log">
+      <FilePattern>${baseDir}/${logFileName}_%d{yyyy-MM-dd__HH-mm}_%i.log</FilePattern>
+      <PatternLayout>
+        <Pattern>%d{HH:mm:ss} [%t] %-5level %logger{6} - %msg%n</Pattern>
+      </PatternLayout>
+
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="10" modulate="true"/>
+        <SizeBasedTriggeringPolicy size="250 MB"/>
+
+      </Policies>
+      <DefaultRolloverStrategy min="1" max="5" fileIndex="max">
+        <Delete basePath="${baseDir}" maxDepth="5">
+          <IfFileName glob="${logFileName}_*.log"/>
+          <testMode>false</testMode>
+          <IfAccumulatedFileCount exceeds="2"/>
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingFile>
+
+    <RollingFile name="htmlFileLogger" fileName="${baseDir}/app-info.html"
+                 filePattern="${baseDir}/app-info-%d{yyyy-MM-dd}.html">
+      <HTMLLayout charset="UTF-8" title="Info Logs" locationInfo="true"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+        <SizeBasedTriggeringPolicy size="10 MB"/>
+      </Policies>
+    </RollingFile>
+  </Appenders>
+
+
+  <Loggers>
+    <!-- Every configuration must have a root logger. If one is not configured the default root LoggerConfig is ERROR with Console appender attached. -->
+    <Root level="DEBUG">
+      <!--<AppenderRef ref="SOUT"/>-->
+      <!--<AppenderRef ref="SERR"/>-->
+      <AppenderRef ref="fileAppender"/>
+      <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
+    </Root>
+
+    <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
+    <Logger name="JDI" additivity="TRUE" level="DEBUG">
+      <AppenderRef ref="fileAppender"/>
+      <AppenderRef ref="htmlFileLogger"/>
+    </Logger>
+
+  </Loggers>
+</Configuration>

--- a/jdi-light-angular-tests/src/test/resources/test.properties
+++ b/jdi-light-angular-tests/src/test/resources/test.properties
@@ -1,0 +1,26 @@
+driver=${driver}
+#driver.version=2.23
+timeout.wait.element=25
+domain=https://jdi-testing.github.io/jdi-light/
+page.check.after.open=NONE
+# NEW_PAGE | EVERY_PAGE
+#element.search.strategy=strict | soft | visible, multiple | any, single
+element.search.strategy=strict
+smart.locators=#%s;[ui=%s]
+#smart.locators.toName=kebab-case | camelCase | snake_case | PascalCase | UPPER_SNAKE_CASE
+log.level=INFO
+#text.type=SMART_TEXT | TEXT | VALUE | INNER | LABEL
+#set.text.type=SET_TEXT | SEND_KEYS | CLEAR_SEND_KEYS
+#assert.type=strict | soft
+
+#page.load.strategy=normal
+#browser.size=MAXIMIZE | 1024x762
+#browser.kill=afterAndBefore | after | before
+#drivers.folder=C:\\Selenium
+#log.message.format=short | full
+#demo.mode=false | true
+#demo.delay=2
+#remote.type=sauce | browserstack
+#driver.remote.url=http://localhost:4444/wd/hub
+#screenshot.strategy=on fail | on | off
+#headless=true | false

--- a/jdi-light-angular-unit-tests/pom.xml
+++ b/jdi-light-angular-unit-tests/pom.xml
@@ -1,0 +1,135 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.epam.jdi</groupId>
+    <artifactId>jdi-light-angular-unit-tests</artifactId>
+    <name>Unit Tests: JDI Angular</name>
+    <version>1.2.14</version>
+
+    <properties>
+        <aspectj.version>1.9.1</aspectj.version>
+        <java.version>1.8</java.version>
+        <allure.testng>2.13.2</allure.testng>
+        <allure.maven>2.10.0</allure.maven>
+        <jetty.version>9.4.12.RC2</jetty.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.qameta.allure</groupId>
+            <artifactId>allure-testng</artifactId>
+            <version>${allure.testng}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.epam.jdi</groupId>
+            <artifactId>jdi-light-angular</artifactId>
+            <version>1.2.14</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+            <version>7.0.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.3.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-maven-plugin</artifactId>
+                <version>${jetty.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/general.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <testFailureIgnore>true</testFailureIgnore>
+                    <properties>
+                        <property>
+                            <name>listener</name>
+                            <value>io.qameta.allure.testng.AllureTestNg</value>
+                        </property>
+                    </properties>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.aspectj</groupId>
+                        <artifactId>aspectjweaver</artifactId>
+                        <version>${aspectj.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>${allure.maven}</version>
+            </plugin>
+
+        </plugins>
+
+        <resources>
+            <resource>
+                <directory>${project.basedir}/src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/test/resources1</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+    </build>
+
+    <reporting>
+        <excludeDefaults>true</excludeDefaults>
+        <plugins>
+            <plugin>
+                <groupId>io.qameta.allure</groupId>
+                <artifactId>allure-maven</artifactId>
+                <version>LATEST</version>
+                <configuration>
+                    <properties>
+                        <allure.results.directory>target/allure-results</allure.results.directory>
+                    </properties>
+                    <properties>
+                        <allure.link.issue.pattern>https://example.org/issue/{}</allure.link.issue.pattern>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </reporting>
+</project>

--- a/jdi-light-angular-unit-tests/src/test/java/io/github/epam/testng/TestNGListener.java
+++ b/jdi-light-angular-unit-tests/src/test/java/io/github/epam/testng/TestNGListener.java
@@ -1,0 +1,56 @@
+package io.github.epam.testng;
+
+/**
+ * Created by Roman Iovlev on 14.02.2018
+ * Email: roman.iovlev.jdi@gmail.com; Skype: roman.iovlev
+ */
+
+import com.epam.jdi.tools.Safe;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestResult;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+import static com.epam.jdi.light.settings.WebSettings.TEST_NAME;
+import static com.epam.jdi.light.settings.WebSettings.logger;
+import static java.lang.System.currentTimeMillis;
+
+public class TestNGListener implements IInvokedMethodListener {
+    private Safe<Long> start = new Safe<>(0L);
+    @Override
+    public void beforeInvocation(IInvokedMethod m, ITestResult tr) {
+        if (m.isTestMethod()) {
+            Method testMethod = m.getTestMethod().getConstructorOrMethod().getMethod();
+            if (testMethod.isAnnotationPresent(Test.class)) {
+                TEST_NAME.set(tr.getTestClass().getRealClass().getSimpleName()+"."+testMethod.getName());
+                start.set(currentTimeMillis());
+                logger.step("== Test '%s' START ==", TEST_NAME.get());
+            }
+        }
+    }
+
+    @Override
+    public void afterInvocation(IInvokedMethod method, ITestResult r) {
+        if (method.isTestMethod()) {
+            String result = getTestResult(r);
+            logger.step("=== Test '%s' %s [%s] ===", TEST_NAME.get(), result,
+                        new SimpleDateFormat("mm:ss.SS").format(new Date(currentTimeMillis()-start.get())));
+            logger.step("");
+        }
+    }
+
+    private String getTestResult(ITestResult result) {
+        switch (result.getStatus()) {
+            case ITestResult.SUCCESS:
+                return "PASSED";
+            case ITestResult.SKIP:
+                return "SKIPPED";
+            default:
+                return "FAILED";
+        }
+    }
+}

--- a/jdi-light-angular-unit-tests/src/test/java/io/github/epam/unit/TestsInit.java
+++ b/jdi-light-angular-unit-tests/src/test/java/io/github/epam/unit/TestsInit.java
@@ -1,0 +1,22 @@
+package io.github.epam.unit;
+
+import io.github.epam.testng.TestNGListener;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Listeners;
+
+import static com.epam.jdi.light.settings.WebSettings.logger;
+
+@Listeners(TestNGListener.class)
+public class TestsInit {
+
+    @BeforeSuite(alwaysRun = true)
+    public static void setUp() {
+        logger.toLog("Run Tests");
+    }
+
+    @AfterSuite(alwaysRun = true)
+    public static void tearDown() {
+        logger.toLog("End Tests");
+    }
+}

--- a/jdi-light-angular-unit-tests/src/test/java/io/github/epam/unit/tests/CheckboxTest.java
+++ b/jdi-light-angular-unit-tests/src/test/java/io/github/epam/unit/tests/CheckboxTest.java
@@ -1,0 +1,80 @@
+package io.github.epam.unit.tests;
+
+import com.epam.jdi.light.elements.common.UIElement;
+import com.epam.jdi.angular.elements.common.Checkbox;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+
+public class CheckboxTest {
+
+    private static final String ANGULAR_SELECTED_CLASS = "mat-checkbox-checked";
+    private static final String ANGULAR_DISABLE_CLASS = "mat-checkbox-disabled";
+
+    @InjectMocks
+    private Checkbox checkbox;
+
+    @Mock
+    private UIElement uiElement;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void isBaseElementSelectedTest() {
+        when(checkbox.core().isSelected()).thenReturn(true);
+        assertTrue(checkbox.isSelected());
+    }
+
+    @Test
+    public void isBaseElementUnselectedTest(){
+        when(checkbox.core().isSelected()).thenReturn(false);
+        assertFalse(checkbox.isSelected());
+    }
+
+    @Test
+    public void isAngularElementSelectedTest() {
+        when(checkbox.core().hasClass(ANGULAR_SELECTED_CLASS)).thenReturn(true);
+        assertTrue(checkbox.isSelected());
+    }
+
+    @Test
+    public void isAngularElementUnselectedTest() {
+        when(checkbox.core().hasClass(ANGULAR_SELECTED_CLASS)).thenReturn(false);
+        assertFalse(checkbox.isSelected());
+    }
+
+    @Test
+    public void isBaseElementEnableTest() {
+        when(checkbox.core().isEnabled()).thenReturn(true);
+        assertTrue(checkbox.isEnabled());
+    }
+
+    @Test
+    public void isBaseElementDisableTest() {
+        when(checkbox.core().isEnabled()).thenReturn(false);
+        assertTrue(checkbox.isDisabled());
+    }
+
+    @Test
+    public void isAngularElementEnableTest() {
+        when(checkbox.core().isEnabled()).thenReturn(true);
+        when(checkbox.core().hasClass(ANGULAR_DISABLE_CLASS)).thenReturn(false);
+        assertTrue(checkbox.isEnabled());
+    }
+
+    @Test
+    public void isAngularElementDisableTest() {
+        when(checkbox.core().isEnabled()).thenReturn(true);
+        when(checkbox.core().hasClass(ANGULAR_DISABLE_CLASS)).thenReturn(true);
+        assertTrue(checkbox.isDisabled());
+    }
+}

--- a/jdi-light-angular-unit-tests/src/test/java/io/github/epam/unit/tests/SlideToggleTest.java
+++ b/jdi-light-angular-unit-tests/src/test/java/io/github/epam/unit/tests/SlideToggleTest.java
@@ -1,0 +1,82 @@
+package io.github.epam.unit.tests;
+
+import com.epam.jdi.light.elements.common.UIElement;
+import com.epam.jdi.angular.elements.common.SlideToggle;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static junit.framework.Assert.assertFalse;
+import static org.mockito.Mockito.when;
+
+import static org.testng.Assert.assertTrue;
+
+
+public class SlideToggleTest {
+
+    private static final String ANGULAR_SELECTED_CLASS = "mat-checked";
+    private static final String ANGULAR_DISABLE_CLASS = "mat-disabled";
+
+    @InjectMocks
+    private SlideToggle slideToggle;
+
+    @Mock
+    private UIElement uiElement;
+
+    @BeforeClass
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void isBaseElementSelectedTest() {
+        when(slideToggle.core().isSelected()).thenReturn(true);
+        assertTrue(slideToggle.isSelected());
+    }
+
+    @Test
+    public void isBaseElementUnselectedTest(){
+        when(slideToggle.core().isSelected()).thenReturn(false);
+        assertFalse(slideToggle.isSelected());
+    }
+
+    @Test
+    public void isAngularElementSelectedTest() {
+        when(slideToggle.core().hasClass(ANGULAR_SELECTED_CLASS)).thenReturn(true);
+        assertTrue(slideToggle.isSelected());
+    }
+
+    @Test
+    public void isAngularElementUnselectedTest() {
+        when(slideToggle.core().hasClass(ANGULAR_SELECTED_CLASS)).thenReturn(false);
+        assertFalse(slideToggle.isSelected());
+    }
+
+    @Test
+    public void isBaseElementEnableTest() {
+        when(slideToggle.core().isEnabled()).thenReturn(true);
+        assertTrue(slideToggle.isEnabled());
+    }
+
+    @Test
+    public void isBaseElementDisableTest() {
+        when(slideToggle.core().isEnabled()).thenReturn(false);
+        assertTrue(slideToggle.isDisabled());
+    }
+
+    @Test
+    public void isAngularElementEnableTest() {
+        when(slideToggle.core().isEnabled()).thenReturn(true);
+        when(slideToggle.core().hasClass(ANGULAR_DISABLE_CLASS)).thenReturn(false);
+        assertTrue(slideToggle.isEnabled());
+    }
+
+    @Test
+    public void isAngularElementDisableTest() {
+        when(slideToggle.core().isEnabled()).thenReturn(true);
+        when(slideToggle.core().hasClass(ANGULAR_DISABLE_CLASS)).thenReturn(true);
+        assertTrue(slideToggle.isDisabled());
+    }
+}

--- a/jdi-light-angular-unit-tests/src/test/resources/allure.properties
+++ b/jdi-light-angular-unit-tests/src/test/resources/allure.properties
@@ -1,0 +1,1 @@
+allure.results.directory=target/allure-results

--- a/jdi-light-angular-unit-tests/src/test/resources/general.xml
+++ b/jdi-light-angular-unit-tests/src/test/resources/general.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="WINDOWS-1251"?>
+        <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd">
+<suite name="JDI-Light Angular Unit Tests" parallel="methods" thread-count="1">
+    <test name="AngularUnitTests">
+        <packages>
+            <package name="io.github.epam.unit.tests.*"/>
+        </packages>
+    </test>
+    <listeners>
+        <listener class-name="io.github.epam.testng.TestNGListener" />
+    </listeners>
+</suite>

--- a/jdi-light-angular-unit-tests/src/test/resources/log4j2.component.properties
+++ b/jdi-light-angular-unit-tests/src/test/resources/log4j2.component.properties
@@ -1,0 +1,1 @@
+log4j.configurationFile=./log4j2.xml

--- a/jdi-light-angular-unit-tests/src/test/resources/log4j2.xml
+++ b/jdi-light-angular-unit-tests/src/test/resources/log4j2.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration monitorInterval="30" status="debug">
+
+
+  <Properties>
+    <Property name="logFileName">jdiEvents</Property>
+    <Property name="baseDir">./target/.logs</Property>
+  </Properties>
+
+  <Appenders>
+
+    <Console name="ColoredConsoleAppender" target="SYSTEM_OUT" follow="true">
+      <PatternLayout
+              pattern="[%highlight{${LOG_LEVEL_PATTERN:-%5p}}{FATAL=red blink, ERROR=red, WARN=yellow bold, INFO=green, DEBUG=green bold, TRACE=blue} %d{mm:ss.SSS}] : %m%n${LOG_EXCEPTION_CONVERSION_WORD:-%throwable}"/>
+    </Console>
+
+    <RollingFile name="fileAppender" fileName="${baseDir}/${logFileName}.log">
+      <FilePattern>${baseDir}/${logFileName}_%d{yyyy-MM-dd__HH-mm}_%i.log</FilePattern>
+      <PatternLayout>
+        <Pattern>%d{HH:mm:ss} [%t] %-5level %logger{6} - %msg%n</Pattern>
+      </PatternLayout>
+
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="10" modulate="true"/>
+        <SizeBasedTriggeringPolicy size="250 MB"/>
+
+      </Policies>
+      <DefaultRolloverStrategy min="1" max="5" fileIndex="max">
+        <Delete basePath="${baseDir}" maxDepth="5">
+          <IfFileName glob="${logFileName}_*.log"/>
+          <testMode>false</testMode>
+          <IfAccumulatedFileCount exceeds="2"/>
+        </Delete>
+      </DefaultRolloverStrategy>
+    </RollingFile>
+
+    <RollingFile name="htmlFileLogger" fileName="${baseDir}/app-info.html"
+                 filePattern="${baseDir}/app-info-%d{yyyy-MM-dd}.html">
+      <HTMLLayout charset="UTF-8" title="Info Logs" locationInfo="true"/>
+      <Policies>
+        <TimeBasedTriggeringPolicy interval="1" modulate="true"/>
+        <SizeBasedTriggeringPolicy size="10 MB"/>
+      </Policies>
+    </RollingFile>
+  </Appenders>
+
+
+  <Loggers>
+    <!-- Every configuration must have a root logger. If one is not configured the default root LoggerConfig is ERROR with Console appender attached. -->
+    <Root level="DEBUG">
+      <AppenderRef ref="fileAppender"/>
+      <AppenderRef ref="htmlFileLogger"/>
+      <AppenderRef ref="ColoredConsoleAppender"/>
+    </Root>
+
+    <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
+    <Logger name="JDI" additivity="TRUE" level="DEBUG">
+      <AppenderRef ref="fileAppender"/>
+      <AppenderRef ref="htmlFileLogger"/>
+    </Logger>
+
+  </Loggers>
+</Configuration>

--- a/jdi-light-angular/pom.xml
+++ b/jdi-light-angular/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>jdi-light-angular</artifactId>
+    <packaging>jar</packaging>
+    <name>JDI Angular</name>
+    <version>1.2.14</version>
+    <groupId>com.epam.jdi</groupId>
+
+    <properties>
+        <aspectj.version>1.9.1</aspectj.version>
+        <java.version>1.8</java.version>
+        <allure.testng>2.13.1</allure.testng>
+        <allure.maven>2.10.0</allure.maven>
+        <jetty.version>9.4.12.RC2</jetty.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.epam.jdi</groupId>
+            <artifactId>jdi-light-html</artifactId>
+            <version>1.2.14</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <configuration>
+                    <source>${java.version}</source>
+                    <target>${java.version}</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>versions-maven-plugin</artifactId>
+                <version>2.7</version>
+                <configuration>
+                    <generateBackupPoms>false</generateBackupPoms>
+                    <rulesUri>file://${project.basedir}/../maven-version-rules.xml</rulesUri>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/jdi-light-angular/src/main/java/com/epam/jdi/angular/elements/common/Checkbox.java
+++ b/jdi-light-angular/src/main/java/com/epam/jdi/angular/elements/common/Checkbox.java
@@ -1,0 +1,25 @@
+package com.epam.jdi.angular.elements.common;
+
+/**
+ * Angular checkbox documentation: https://jdi-docs.github.io/jdi-light/?java#checkboxes
+ */
+public class Checkbox extends com.epam.jdi.light.ui.html.elements.common.Checkbox {
+
+    @Override
+    public boolean isSelected() {
+        return super.isSelected() || hasClass("mat-checkbox-checked");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        if (hasClass("mat-checkbox-disabled")) {
+            return false;
+        }
+        return super.isEnabled();
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return !isEnabled();
+    }
+}

--- a/jdi-light-angular/src/main/java/com/epam/jdi/angular/elements/common/ProgressSpinner.java
+++ b/jdi-light-angular/src/main/java/com/epam/jdi/angular/elements/common/ProgressSpinner.java
@@ -1,0 +1,9 @@
+package com.epam.jdi.angular.elements.common;
+
+import com.epam.jdi.light.elements.common.UIElement;
+
+/**
+ * Angular progress spinner documentation: https://jdi-docs.github.io/jdi-light/?java#progress-spinner
+ */
+public class ProgressSpinner extends UIElement {
+}

--- a/jdi-light-angular/src/main/java/com/epam/jdi/angular/elements/common/SlideToggle.java
+++ b/jdi-light-angular/src/main/java/com/epam/jdi/angular/elements/common/SlideToggle.java
@@ -1,0 +1,27 @@
+package com.epam.jdi.angular.elements.common;
+
+import com.epam.jdi.light.ui.html.elements.common.Checkbox;
+
+/**
+ * Angular slide toggle documentation: https://jdi-docs.github.io/jdi-light/?java#slide-toggle
+ */
+public class SlideToggle extends Checkbox {
+
+    @Override
+    public boolean isSelected() {
+        return super.isSelected() || hasClass("mat-checked");
+    }
+
+    @Override
+    public boolean isEnabled() {
+        if (hasClass("mat-disabled")) {
+            return false;
+        }
+        return super.isEnabled();
+    }
+
+    @Override
+    public boolean isDisabled() {
+        return !isEnabled();
+    }
+}

--- a/jdi-light-bootstrap-tests/pom.xml
+++ b/jdi-light-bootstrap-tests/pom.xml
@@ -42,7 +42,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>RELEASE</version>
+            <version>7.0.0</version>
             <!--version>6.14.3</version-->
         </dependency>
     </dependencies>

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
@@ -53,7 +53,7 @@ public class ButtonTests implements TestsInit {
             fail("Disabled button should not work, but work");
         } catch (Exception ex) {
             assertThat(safeException(ex),
-                    containsString("Can't perform click. Element is disabled"));
+                containsString("Can't perform click. Element is disabled"));
         }
     }
 
@@ -78,12 +78,12 @@ public class ButtonTests implements TestsInit {
         redButton.is().text(containsString("Red"));
         assertThat(redButton.core().css("font-size"), is("16px"));
         redButton.assertThat().displayed()
-                .and().text(is(text))
-                .core()
-                .css("font-size", is("16px"))
-                .cssClass("btn btn-danger")
-                .attr("type", "button")
-                .tag(is("button"));
+            .and().text(is(text))
+            .core()
+            .css("font-size", is("16px"))
+            .cssClass("btn btn-danger")
+            .attr("type", "button")
+            .tag(is("button"));
         disabledButton.is().text(containsString("Disabled button"));
         // disabledButtonInput.is().text(containsString("Disabled Button"));
         disabledButton.is().disabled();

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
@@ -1,6 +1,5 @@
 package io.github.epam.bootstrap.tests.common;
 
-import com.epam.jdi.light.elements.common.Keyboard;
 import io.github.epam.TestsInit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -13,6 +12,7 @@ import static io.github.epam.bootstrap.tests.BaseValidationsUtils.*;
 import static io.github.epam.states.States.*;
 import static org.hamcrest.MatcherAssert.*;
 import static org.hamcrest.Matchers.*;
+import static org.openqa.selenium.Keys.ESCAPE;
 import static org.testng.Assert.*;
 
 /**
@@ -53,7 +53,7 @@ public class ButtonTests implements TestsInit {
             fail("Disabled button should not work, but work");
         } catch (Exception ex) {
             assertThat(safeException(ex),
-                containsString("Can't perform click. Element is disabled"));
+                    containsString("Can't perform click. Element is disabled"));
         }
     }
 
@@ -67,7 +67,7 @@ public class ButtonTests implements TestsInit {
     public void rightClickTest() {
         redButton.rightClick();
         validateAlert("Right Click");
-        Keyboard.keyPress("Escape");
+        redButton.core().sendKeys(ESCAPE);
     }
 
     @Test
@@ -78,12 +78,12 @@ public class ButtonTests implements TestsInit {
         redButton.is().text(containsString("Red"));
         assertThat(redButton.core().css("font-size"), is("16px"));
         redButton.assertThat().displayed()
-            .and().text(is(text))
-            .core()
-            .css("font-size", is("16px"))
-            .cssClass("btn btn-danger")
-            .attr("type", "button")
-            .tag(is("button"));
+                .and().text(is(text))
+                .core()
+                .css("font-size", is("16px"))
+                .cssClass("btn btn-danger")
+                .attr("type", "button")
+                .tag(is("button"));
         disabledButton.is().text(containsString("Disabled button"));
         // disabledButtonInput.is().text(containsString("Disabled Button"));
         disabledButton.is().disabled();

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
@@ -6,6 +6,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static com.epam.jdi.light.common.Exceptions.*;
+import static com.epam.jdi.light.driver.get.DriverData.getOs;
+import static com.epam.jdi.light.driver.get.OsTypes.WIN;
 import static com.epam.jdi.light.elements.common.Alerts.*;
 import static io.github.com.StaticSite.*;
 import static io.github.com.pages.BootstrapPage.*;
@@ -66,9 +68,11 @@ public class ButtonTests implements TestsInit {
 
     @Test
     public void rightClickTest() {
-        redButton.rightClick();
-        validateAlert("Right Click");
-        Keyboard.keyPress("Escape");
+        if (getOs().equals(WIN)) {
+            redButton.rightClick();
+            validateAlert("Right Click");
+            Keyboard.keyPress("Escape");
+        }
     }
 
     @Test

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
@@ -30,8 +30,6 @@ public class ButtonTests implements TestsInit {
         shouldBeLoggedIn();
         bsPage.shouldBeOpened();
         redButton.show();
-        Mouse.mouseClick(redButton);
-        Timer.sleep(10000);
     }
 
     @Test

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
@@ -1,8 +1,6 @@
 package io.github.epam.bootstrap.tests.common;
 
 import com.epam.jdi.light.elements.common.Keyboard;
-import com.epam.jdi.light.elements.common.Mouse;
-import com.epam.jdi.tools.Timer;
 import io.github.epam.TestsInit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;

--- a/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
+++ b/jdi-light-bootstrap-tests/src/test/java/io/github/epam/bootstrap/tests/common/ButtonTests.java
@@ -1,5 +1,6 @@
 package io.github.epam.bootstrap.tests.common;
 
+import com.epam.jdi.light.elements.common.Keyboard;
 import io.github.epam.TestsInit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -67,7 +68,7 @@ public class ButtonTests implements TestsInit {
     public void rightClickTest() {
         redButton.rightClick();
         validateAlert("Right Click");
-        redButton.core().sendKeys(ESCAPE);
+        Keyboard.keyPress("Escape");
     }
 
     @Test

--- a/jdi-light-bootstrap/pom.xml
+++ b/jdi-light-bootstrap/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <aspectj.version>1.9.5</aspectj.version>
-        <aspectj.maven>1.11</aspectj.maven>
+        <aspectj.maven>1.12.6</aspectj.maven>
         <java.version>1.8</java.version>
     </properties>
 
@@ -36,7 +36,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj.maven}</version>
                 <configuration>

--- a/jdi-light-html-tests/src/main/java/io/github/com/pages/Header.java
+++ b/jdi-light-html-tests/src/main/java/io/github/com/pages/Header.java
@@ -26,10 +26,12 @@ public class Header extends Section {
 	@UI(".icon-search.active") static WebElement doSearch;
 
 	public static void search(String text) {
-		if(logout.isDisplayed())
+		if (logout.isDisplayed()) {
 			userName.click();
-		if (searchInput.isHidden())
+		}
+		if (searchInput.isHidden()) {
 			searchIcon.click();
+		}
 		searchInput.input(text);
 		doSearch.click();
 	}

--- a/jdi-light-html-tests/src/main/java/io/github/com/pages/SimpleTablePage.java
+++ b/jdi-light-html-tests/src/main/java/io/github/com/pages/SimpleTablePage.java
@@ -3,11 +3,21 @@ package io.github.com.pages;
 import com.epam.jdi.light.elements.complex.table.DataTable;
 import com.epam.jdi.light.elements.complex.table.Table;
 import com.epam.jdi.light.elements.composite.WebPage;
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.JTable;
 import io.github.com.entities.Furniture;
 
 public class SimpleTablePage extends WebPage {
-	public static Table simpleTable;
-	public static DataTable<?, Furniture> products;
-	public static DataTable<?, Furniture> furniture;
+
+    public static Table simpleTable;
+    public static DataTable<?, Furniture> products;
+
+    @JTable(
+        root = "#furniture",
+        rowHeader = "Name",
+        column = "//tbody/tr/td[%s]",
+        row = "//tbody/tr[%s]/td",
+        cell = "//tbody/tr[{1}]/td[{0}]",
+        allCells = "//tbody//td")
+    public static DataTable<?, Furniture> furniture;
 
 }

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
@@ -2,6 +2,7 @@ package io.github.epam.html.tests.elements.common;
 
 import com.epam.jdi.light.elements.composite.WebPage;
 import io.github.epam.TestsInit;
+import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -67,7 +68,7 @@ public class ButtonTests implements TestsInit {
     public void rightClickTest() {
         rightClickButton.rightClick();
         validateAlert("Right Click");
-        keyPress("Escape");
+        redButton.core().sendKeys(Keys.ESCAPE);
     }
     @Test
     public void isValidationTest() {

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
@@ -1,8 +1,8 @@
 package io.github.epam.html.tests.elements.common;
 
+import com.epam.jdi.light.elements.common.Keyboard;
 import com.epam.jdi.light.elements.composite.WebPage;
 import io.github.epam.TestsInit;
-import org.openqa.selenium.Keys;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -28,6 +28,7 @@ public class ButtonTests implements TestsInit {
         shouldBeLoggedIn();
         html5Page.shouldBeOpened();
     }
+
     String text = "Big Red Button-Input";
 
     @Test
@@ -48,6 +49,7 @@ public class ButtonTests implements TestsInit {
         blueButton.click();
         validateAlert("Blue button");
     }
+
     @Test
     public void disableButtonTest() {
         try {
@@ -58,17 +60,20 @@ public class ButtonTests implements TestsInit {
                 containsString("Can't perform click. Element is disabled"));
         }
     }
+
     @Test
     public void doubleClickTest() {
         dblClickButton.doubleClick();
         validateAlert("Double Click");
     }
+
     @Test
     public void rightClickTest() {
         rightClickButton.rightClick();
         validateAlert("Right Click");
-        redButton.core().sendKeys(Keys.ESCAPE);
+        Keyboard.keyPress("Escape");
     }
+
     @Test
     public void isValidationTest() {
         redButton.is().displayed();
@@ -102,7 +107,7 @@ public class ButtonTests implements TestsInit {
     public void vanishButtonTest() {
         WebPage.reload();
         durationMoreThan(3, () ->
-                ghostButton.is().disappear());
+            ghostButton.is().disappear());
     }
 
     //if test fails then run `mvn clean install` in module JDI Light
@@ -110,7 +115,7 @@ public class ButtonTests implements TestsInit {
     public void isNotAppearTimeoutFailedButtonTest() {
         WebPage.reload();
         durationMoreThan(2, () ->
-                suspendButton.is().notAppear(2));
+            suspendButton.is().notAppear(2));
     }
 
     @Test
@@ -118,8 +123,9 @@ public class ButtonTests implements TestsInit {
         WebPage.reload();
         assertFalse(suspendButton.isDisplayed());
         durationMoreThan(2, () ->
-                suspendButton.is().displayed());
+            suspendButton.is().displayed());
     }
+
     //if test fails then run `mvn clean install` in module JDI Light
     @Test
     public void isNotAppearFailedButtonTest() {
@@ -144,7 +150,7 @@ public class ButtonTests implements TestsInit {
     public void isNotAppearTimeoutButtonTest() {
         ghostButton.is().hidden();
         durationMoreThan(2, () ->
-                ghostButton.is().notAppear(2));
+            ghostButton.is().notAppear(2));
     }
 
     @Test

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
@@ -8,7 +8,6 @@ import org.testng.annotations.Test;
 
 import static com.epam.jdi.light.common.Exceptions.*;
 import static com.epam.jdi.light.elements.common.Alerts.*;
-import static com.epam.jdi.light.elements.common.Keyboard.*;
 import static io.github.com.StaticSite.*;
 import static io.github.com.pages.HtmlElementsPage.*;
 import static io.github.epam.html.tests.elements.BaseValidations.*;

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/common/ButtonTests.java
@@ -7,6 +7,8 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static com.epam.jdi.light.common.Exceptions.*;
+import static com.epam.jdi.light.driver.get.DriverData.getOs;
+import static com.epam.jdi.light.driver.get.OsTypes.WIN;
 import static com.epam.jdi.light.elements.common.Alerts.*;
 import static io.github.com.StaticSite.*;
 import static io.github.com.pages.HtmlElementsPage.*;
@@ -69,9 +71,11 @@ public class ButtonTests implements TestsInit {
 
     @Test
     public void rightClickTest() {
-        rightClickButton.rightClick();
-        validateAlert("Right Click");
-        Keyboard.keyPress("Escape");
+        if (getOs().equals(WIN)) {
+            rightClickButton.rightClick();
+            validateAlert("Right Click");
+            Keyboard.keyPress("Escape");
+        }
     }
 
     @Test

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/list/WaitDataListTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/list/WaitDataListTests.java
@@ -1,21 +1,21 @@
 package io.github.epam.html.tests.elements.complex.list;
 
 import io.github.epam.TestsInit;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static io.github.com.StaticSite.*;
-import static io.github.com.pages.Header.*;
-import static io.github.com.pages.SearchPage.*;
-import static io.github.epam.html.tests.site.steps.States.*;
+import static io.github.com.StaticSite.homePage;
+import static io.github.com.pages.Header.search;
+import static io.github.com.pages.SearchPage.searchS;
+import static io.github.epam.html.tests.site.steps.States.shouldBeLoggedIn;
 import static org.hamcrest.Matchers.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 /**
  * Created by Roman_Iovlev on 3/2/2018.
  */
 public class WaitDataListTests implements TestsInit {
+
     @BeforeMethod
     public void before() {
         homePage.shouldBeOpened();
@@ -27,28 +27,26 @@ public class WaitDataListTests implements TestsInit {
     public void notEmptyTest() {
         searchS.is().notEmpty();
     }
+
     @Test
     public void notEmpty2Test() {
         searchS.assertThat(not(empty()));
     }
+
     @Test
     public void emptyTest() {
-        try {
-            searchS.is().empty();
-            Assert.fail("List should not be empty");
-        } catch (Throwable ignored) { }
         searchS.is().notEmpty();
     }
+
     @Test
     public void sizeTest() {
         assertEquals(searchS.size(), 6);
-        // FLAKY
-        searchS.is().size(equalTo(8));
+        searchS.waitFor(10).size(equalTo(8));
     }
+
     @Test
     public void sizeGreaterTest() {
-        // FLAKY
-        searchS.is().size(greaterThan(7));
+        searchS.waitFor(10).size(greaterThan(7));
     }
 
 }

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/list/WaitJListTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/list/WaitJListTests.java
@@ -1,7 +1,6 @@
 package io.github.epam.html.tests.elements.complex.list;
 
 import io.github.epam.TestsInit;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -18,6 +17,7 @@ import static org.testng.Assert.*;
  * Created by Roman_Iovlev on 3/2/2018.
  */
 public class WaitJListTests implements TestsInit {
+
     @BeforeMethod
     public void before() {
         homePage.shouldBeOpened();
@@ -29,32 +29,28 @@ public class WaitJListTests implements TestsInit {
     public void notEmptyTest() {
         jsearchTitle.is().notEmpty();
     }
+
     @Test
     public void notEmpty2Test() {
         jsearchTitle.assertThat(not(empty()));
     }
+
     @Test
     public void emptyTest() {
-        try {
-            jsearchTitle.waitSec(2);
-            jsearchTitle.is().empty();
-            Assert.fail("List should not be empty");
-        } catch (Throwable ignored) { }
-        finally {
-            jsearchTitle.waitSec(TIMEOUTS.element.get());
-        }
-        logger.info("Done");
+        jsearchTitle.waitFor(2).notEmpty();
     }
+
     @Test
     public void sizeTest() {
         assertEquals(jsearchTitle.size(), 6);
         // FLAKY
-        jsearchTitle.is().size(equalTo(8));
+        jsearchTitle.waitFor(10).size(equalTo(8));
     }
+
     @Test
     public void sizeNotEmptyTest() {
         // FLAKY
-        jsearchTitle.is().size(greaterThan(7));
+        jsearchTitle.waitFor(10).size(greaterThan(7));
     }
 
 }

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/table/FurnitureTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/table/FurnitureTests.java
@@ -1,16 +1,28 @@
 package io.github.epam.html.tests.elements.complex.table;
 
+import static com.epam.jdi.light.elements.complex.table.Column.inColumn;
+import static com.epam.jdi.light.elements.complex.table.TableMatcher.containsValue;
+import static com.epam.jdi.light.elements.complex.table.TableMatcher.hasValue;
+import static com.epam.jdi.tools.StringUtils.LINE_BREAK;
+import static io.github.com.StaticSite.tablePage;
+import static io.github.com.pages.SimpleTablePage.furniture;
+import static io.github.epam.html.tests.site.steps.States.shouldBeLoggedIn;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.jsoup.internal.StringUtil.isBlank;
+import static org.testng.Assert.assertEquals;
+
+import io.github.com.entities.Furniture;
 import io.github.epam.TestsInit;
+import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static io.github.com.StaticSite.*;
-import static io.github.com.pages.SimpleTablePage.*;
-import static io.github.epam.html.tests.site.steps.States.*;
-import static java.util.Arrays.*;
-import static org.testng.Assert.*;
-
 public class FurnitureTests implements TestsInit {
+    public Furniture TABLE = new Furniture().set(x -> {
+        x.name = "Table"; x.type = "furniture"; x.cost = "3.5"; x.weight = "3.5";
+    });
     @BeforeMethod
     public void before() {
         shouldBeLoggedIn();
@@ -23,98 +35,108 @@ public class FurnitureTests implements TestsInit {
         assertEquals(furniture.count(), 5);
         assertEquals(furniture.header(), asList("Name", "Type", "Cost", "Weight"));
     }
-// TODO rework to furniture and other tables on the page
-    //@Test
-    //public void previewTest() {
-    //    String value = users.preview();
-    //    assertEquals(value.replaceAll(" ", ""),
-    //        "NumberTypeUserDescription1AdminUserManagerRomanWolverineVip2AdminUserManagerSergeyIvanSpiderManVip3AdminUserManagerVladzimirPunisherVip4AdminUserManagerHelenBennettCaptainAmericasomedescriptionVip5AdminUserManagerYoshiTannamuriCyclopesomedescriptionVip6AdminUserManagerGiovanniRovelliHulksomedescriptionVip");
-    //}
-    //@Test
-    //public void valueTest() {
-    //    String value = users.getValue();
-    //    assertEquals(value,
-    //    "||X||Number|Type|User|Description||" + LINE_BREAK +
-    //        "||1||1|Admin|Roman|Wolverine:VIP||" + LINE_BREAK +
-    //        "||2||2|User|Sergey Ivan|Spider Man:Dude||" + LINE_BREAK +
-    //        "||3||3|Manager|Vladzimir|Punisher:VIP||" + LINE_BREAK +
-    //        "||4||4|User|Helen Bennett|Captain America\\nsome description:Dude||" + LINE_BREAK +
-    //        "||5||5|User|Yoshi Tannamuri|Cyclope\\nsome description:Dude||" + LINE_BREAK +
-    //        "||6||6|User|Giovanni Rovelli|Hulk\\nsome description:Dude||" + LINE_BREAK);
-    //}
-    //@Test
-    //public void dataColumnTestIndex() {
-    //    assertEquals(users.dataRow(2), SPIDER_MAN);
-    //}
-    //@Test
-    //public void dataColumnNameTest() {
-    //    assertEquals(usersSetup.dataRow("Sergey Ivan"), SPIDER_MAN);
-    //}
-    //@Test
-    //public void dataFilterTest() {
-    //    assertEquals(users.dataRow(d -> d.user.contains("Ivan")), SPIDER_MAN);
-    //}
-    //@Test
-    //public void allDataFilterTest() {
-    //    List<MarvelUserInfo> filteredData = users.dataRows(d -> d.user.contains("Ivan"));
-    //    assertEquals(filteredData.size(), 1);
-    //    assertEquals(filteredData.get(0), SPIDER_MAN);
-    //}
-    //@Test
-    //public void commonMatchersTest() {
-    //    users.is().displayed();
-    //    users.has().size(6);
-    //    users.assertThat().size(greaterThan(3));
-    //    users.is().notEmpty().size(lessThanOrEqualTo(6));
-    //}
-    //// Compare Matchers
-    //@Test
-    //public void rowMatcherTest() {
-    //    users.has().row(d -> d.user.contains("Ivan"));
-    //}
-    //@Test
-    //public void rowDataMatcherTest() {
-    //    users.has().row(SPIDER_MAN);
-    //}
-    //@Test
-    //public void rowTableMatcherSingleTest() {
-    //    users.has().rowThat(Single.hasValue("Sergey Ivan"), inColumn("User"));
-    //}
-    //@Test
-    //public void rowTableMatcherTest() {
-    //    users.has().rowThat(containsValue("User", inColumn("Type")),
-    //            hasValue("Sergey Ivan", inColumn("User")));
-    //}
-    //@Test
-    //public void rowsAllTest() {
-    //    users.assertThat().all().rows(d -> d.user.length() > 4);
-    //}
-    //@Test
-    //public void noRowsTest() {
-    //    users.assertThat().no().rows(d -> isBlank(d.user));
-    //}
-    //@Test
-    //public void atLeastTest() {
-    //    users.assertThat().atLeast(3).rows(d -> d.type.contains("User"));
-    //}
-    //@Test
-    //public void exactMatcherTest() {
-    //    users.assertThat().exact(2).rows(d -> d.description.contains(":VIP"));
-    //}
-    //@Test
-    //public void rowDataExactMatcherTest() {
-    //    users.assertThat().exact(1).rows(SPIDER_MAN);
-    //}
-    //@Test
-    //public void tableChainTest() {
-    //    users.assertThat()
-    //        .displayed().size(6).size(greaterThan(3)).notEmpty()
-    //        .row(d -> d.user.contains("Ivan"))
-    //        .all().rows(d -> d.user.length() > 4)
-    //        .no().rows(d -> isBlank(d.user))
-    //        .atLeast(3).rows(d -> d.type.contains("User"))
-    //        .and().row(SPIDER_MAN)
-    //        .exact(2).rows(d -> d.description.contains(":VIP"))
-    //        .exact(1).rows(SPIDER_MAN);
-    //}
+
+    @Test
+    public void previewTest() {
+        String value = furniture.preview();
+        assertEquals(value.replaceAll(" ", ""),
+                "NameTypeCost*#Chairfurniture3.52Tablefurniture3.53.5Sofafurniture22Kitchenkitchen400Robotrobo");
+    }
+
+    @Test
+    public void valueTest() {
+        String value = furniture.getValue();
+        assertEquals(value,
+            "||X||Name|Type|Cost|Weight||" + LINE_BREAK +
+            "||1||Chair|furniture|3.5|2||" + LINE_BREAK +
+            "||2||Table|furniture|3.5|3.5||" + LINE_BREAK +
+            "||3||Sofa|furniture|2|2||" + LINE_BREAK +
+            "||4||Kitchen|kitchen|400|||" + LINE_BREAK +
+            "||5||Robot|robo||||" + LINE_BREAK);
+    }
+
+    @Test
+    public void dataColumnTestIndex() {
+        assertEquals(furniture.dataRow(2), TABLE);
+    }
+
+    @Test
+    public void dataColumnNameTest() {
+        assertEquals(furniture.dataRow("Table"), TABLE);
+    }
+
+    @Test
+    public void dataFilterTest() {
+        assertEquals(furniture.dataRow(d -> d.name.contains("Tab")), TABLE);
+    }
+
+    @Test
+    public void allDataFilterTest() {
+        List<Furniture> filteredData = furniture.dataRows(d -> d.name.contains("Tab"));
+        assertEquals(filteredData.size(), 1);
+        assertEquals(filteredData.get(0), TABLE);
+    }
+
+    @Test
+    public void commonMatchersTest() {
+        furniture.is().displayed();
+        furniture.has().size(5);
+        furniture.assertThat().size(greaterThan(3));
+        furniture.is().notEmpty().size(lessThanOrEqualTo(5));
+    }
+
+    // Compare Matchers
+    @Test
+    public void rowMatcherTest() {
+        furniture.has().row(d -> d.name.contains("Tab"));
+    }
+
+    @Test
+    public void rowDataMatcherTest() {
+        furniture.has().row(TABLE);
+    }
+
+    @Test
+    public void rowTableMatcherTest() {
+        furniture.has().rowThat(containsValue("furniture", inColumn("Type")),
+                hasValue("Chair", inColumn("Name")));
+    }
+
+    @Test
+    public void rowsAllTest() {
+        furniture.assertThat().all().rows(d -> d.name.length() >= 4);
+    }
+
+    @Test
+    public void noRowsTest() {
+        furniture.assertThat().no().rows(d -> isBlank(d.name));
+    }
+
+    @Test
+    public void atLeastTest() {
+        furniture.assertThat().atLeast(3).rows(d -> d.type.contains("furniture"));
+    }
+
+    @Test
+    public void exactMatcherTest() {
+        furniture.assertThat().exact(2).rows(d -> d.cost.contains("3.5"));
+    }
+
+    @Test
+    public void rowDataExactMatcherTest() {
+        furniture.assertThat().exact(1).rows(TABLE);
+    }
+
+    @Test
+    public void tableChainTest() {
+        furniture.assertThat()
+            .displayed().size(5).size(greaterThan(3)).notEmpty()
+            .row(d -> d.name.contains("Tab"))
+            .all().rows(d -> d.name.length() >= 4)
+            .no().rows(d -> isBlank(d.name))
+            .atLeast(3).rows(d -> d.type.contains("furniture"))
+            .and().row(TABLE)
+            .exact(2).rows(d -> d.cost.contains("3.5"))
+            .exact(1).rows(TABLE);
+    }
 }

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/table/FurnitureTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/elements/complex/table/FurnitureTests.java
@@ -1,23 +1,23 @@
 package io.github.epam.html.tests.elements.complex.table;
 
-import static com.epam.jdi.light.elements.complex.table.Column.inColumn;
-import static com.epam.jdi.light.elements.complex.table.TableMatcher.containsValue;
-import static com.epam.jdi.light.elements.complex.table.TableMatcher.hasValue;
-import static com.epam.jdi.tools.StringUtils.LINE_BREAK;
-import static io.github.com.StaticSite.tablePage;
-import static io.github.com.pages.SimpleTablePage.furniture;
-import static io.github.epam.html.tests.site.steps.States.shouldBeLoggedIn;
-import static java.util.Arrays.asList;
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.lessThanOrEqualTo;
-import static org.jsoup.internal.StringUtil.isBlank;
-import static org.testng.Assert.assertEquals;
-
 import io.github.com.entities.Furniture;
 import io.github.epam.TestsInit;
-import java.util.List;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.List;
+
+import static com.epam.jdi.light.elements.complex.table.Column.*;
+import static com.epam.jdi.light.elements.complex.table.TableMatcher.hasValue;
+import static com.epam.jdi.light.elements.complex.table.TableMatcher.*;
+import static com.epam.jdi.tools.StringUtils.*;
+import static io.github.com.StaticSite.*;
+import static io.github.com.pages.SimpleTablePage.*;
+import static io.github.epam.html.tests.site.steps.States.*;
+import static java.util.Arrays.*;
+import static org.hamcrest.Matchers.*;
+import static org.jsoup.internal.StringUtil.*;
+import static org.testng.Assert.*;
 
 public class FurnitureTests implements TestsInit {
     public Furniture TABLE = new Furniture().set(x -> {

--- a/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/performance/DataTableTests.java
+++ b/jdi-light-html-tests/src/test/java/io/github/epam/html/tests/performance/DataTableTests.java
@@ -98,11 +98,10 @@ public class DataTableTests implements TestsInit {
                 "076 1971 1687;(011307) 16843;0");
 
         String value = notMoreThan(2000, table::getValue);
-        assertEquals(value.substring(0,228),
-        "||X||Name|Phone|Email|City||" + LINE_BREAK +
+        assertTrue(value.substring(0, 228).contains("||X||Name|Phone|Email|City||" + LINE_BREAK +
             "||1||Burke Tucker|076 1971 1687|et.euismod.et@ut.edu|GozŽe||" + LINE_BREAK +
             "||2||Grady Brock|(011307) 16843|cursus.et@commodo.org|Alcobendas||" + LINE_BREAK +
-            "||3||Harding Lloyd|0800 1111|neque.In.ornare@mauris.co.uk|Beauvais||");
+            "||3||Harding Lloyd|0800 1111|neque.In.ornare@mauris.co.uk|Beauvais||"));
     }
 
 }

--- a/jdi-light-html/pom.xml
+++ b/jdi-light-html/pom.xml
@@ -12,7 +12,7 @@
 
     <properties>
         <aspectj.version>1.9.5</aspectj.version>
-        <aspectj.maven>1.11</aspectj.maven>
+        <aspectj.maven>1.12.6</aspectj.maven>
         <java.version>1.8</java.version>
     </properties>
 
@@ -36,7 +36,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj.maven}</version>
                 <configuration>

--- a/jdi-light/pom.xml
+++ b/jdi-light/pom.xml
@@ -14,7 +14,7 @@
         <surefire.version>2.20</surefire.version>
         <allure.maven>2.10.0</allure.maven>
         <aspectj.version>1.9.5</aspectj.version>
-        <aspectj.maven>1.11</aspectj.maven>
+        <aspectj.maven>1.12.6</aspectj.maven>
         <jetty.version>9.4.12.RC2</jetty.version>
         <java.version>1.8</java.version>
         <log4j2.version>2.11.1</log4j2.version>
@@ -100,7 +100,7 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
+                <groupId>com.nickwongdev</groupId>
                 <artifactId>aspectj-maven-plugin</artifactId>
                 <version>${aspectj.maven}</version>
                 <configuration>

--- a/jdi-light/src/main/java/com/epam/jdi/light/elements/common/UIElement.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/elements/common/UIElement.java
@@ -256,7 +256,7 @@ public class UIElement extends JDIBase
         if (isHidden())
             return false;
         Object isInView = js().executeScript(
-    "const rect = arguments[0].getBoundingClientRect();\n" +
+            "const rect = arguments[0].getBoundingClientRect();\n" +
             "if (!rect) return false;\n" +
             "const windowHeight = Math.min(window.innerHeight || document.documentElement.clientHeight);\n" +
             "const windowWidth = Math.min(window.innerWidth || document.documentElement.clientWidth);\n" +
@@ -295,7 +295,7 @@ public class UIElement extends JDIBase
 
     @JDIAction("Click on '{name}' (x:{0}, y:{1})")
     public void click(int x, int y) {
-        actionsWithElement(a -> a.moveByOffset(x-getRect().width/2, y-getRect().height/2).click());
+        actionsWithElement(a -> a.moveByOffset(x - getRect().width / 2, y - getRect().height / 2).click());
     }
     @JDIAction("Click on '{name}'")
     public void click(ElementArea area) {
@@ -307,15 +307,15 @@ public class UIElement extends JDIBase
                 logger.debug("Click Top Left");
                 break;
             case TOP_RIGHT:
-                click(getRect().getWidth()-1,1);
+                click(getRect().getWidth() - 1,1);
                 logger.debug("Click Top Right");
                 break;
             case BOTTOM_LEFT:
-                click(1,getRect().getHeight()-1);
+                click(1,getRect().getHeight() - 1);
                 logger.debug("Click Bottom Left");
                 break;
             case BOTTOM_RIGHT:
-                click(getRect().getWidth()-1,getRect().getHeight()-1);
+                click(getRect().getWidth() - 1,getRect().getHeight() - 1);
                 logger.debug("Click Bottom Right");
                 break;
             case CENTER:
@@ -344,11 +344,11 @@ public class UIElement extends JDIBase
         return Switch().get(
             Case(t -> isClickable(), t-> CENTER),
             Case(t -> isClickable(1, 1), t-> TOP_LEFT),
-            Case(t -> isClickable(getRect().getWidth()-1,1),
+            Case(t -> isClickable(getRect().getWidth() - 1,1),
                 t-> TOP_RIGHT),
-            Case(t -> isClickable(1,getRect().getHeight()-1),
+            Case(t -> isClickable(1,getRect().getHeight() - 1),
                 t-> BOTTOM_LEFT),
-            Case(t -> isClickable(getRect().getWidth()-1,getRect().getHeight()-1),
+            Case(t -> isClickable(getRect().getWidth() - 1,getRect().getHeight() - 1),
                 t-> BOTTOM_RIGHT));
     }
 
@@ -396,7 +396,7 @@ public class UIElement extends JDIBase
      */
     @JDIAction(level = DEBUG)
     public void setAttribute(String name, String value) {
-        jsExecute("setAttribute('"+name+"','"+value+"')");
+        jsExecute("setAttribute('" + name + "','" + value + "')");
     }
 
     /**
@@ -494,8 +494,8 @@ public class UIElement extends JDIBase
     @JDIAction(level = DEBUG)
     public String printHtml() {
         return MessageFormat.format("<{0} {1}>{2}</{0}>", getTagName(),
-                print(getAllAttributes(), el -> format("%s=\"%s\"", el.key, el.value), " "),
-                getAttribute("innerHTML"));
+            print(getAllAttributes(), el -> format("%s=\"%s\"", el.key, el.value), " "),
+            getAttribute("innerHTML"));
     }
 
     /**
@@ -503,8 +503,9 @@ public class UIElement extends JDIBase
      */
     @JDIAction(timeout = 0)
     public void show() {
-        if (isDisplayed() && !isVisible())
+        if (isDisplayed() && !isVisible()) {
             jsExecute("scrollIntoView({behavior:'auto',block:'center',inline:'center'})");
+        }
     }
 
     /**
@@ -654,8 +655,7 @@ public class UIElement extends JDIBase
     }
     @JDIAction("Get '{name}' text") @Override
     public String text(TextTypes type) {
-        String result = timer().getResult(() -> noWait(() -> type.func.execute(this)));
-        return result;
+        return timer().getResult(() -> noWait(() -> type.func.execute(this)));
     }
     public static JFunc1<UIElement, String> SMART_GET_TEXT = ui -> {
         String text = ui.text(TEXT);
@@ -665,9 +665,7 @@ public class UIElement extends JDIBase
         if (isNotBlank(text))
             return text;
         text = ui.text(VALUE);
-        return isNotBlank(text)
-            ? text
-            : isNotBlank(text) ? text : "";
+        return isNotBlank(text) ? text : "";
     };
     public static JFunc1<UIElement, String> SMART_LIST_TEXT = ui -> {
         String text = ui.text(TEXT);

--- a/jdi-light/src/main/java/com/epam/jdi/light/elements/complex/WebList.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/elements/complex/WebList.java
@@ -142,8 +142,9 @@ public class WebList extends JDIBase implements IList<UIElement>, SetValue, ISel
         if (nameIndex)
             return nameFromIndex(i);
         else {
-            String name = getElementName(element);
-            return (isNotBlank(name) ? name : nameFromIndex(i)).trim();
+            return getElementName(element);
+            // extra check, lead to pasting locators in value of empty elements
+            //return (isNotBlank(name) ? name : nameFromIndex(i)).trim();
         }
     }
     protected String getElementName(UIElement element) {

--- a/jdi-light/src/main/java/com/epam/jdi/light/elements/complex/table/BaseTable.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/elements/complex/table/BaseTable.java
@@ -700,8 +700,7 @@ public abstract class BaseTable<T extends BaseTable<?,?>, A extends BaseTableAss
         if (!cells.isGotAll()) {
             try {
                 List<WebElement> listOfCells =
-                        $$(allCellsLocator, core().parent)
-                                .core().noValidation().getAllElements();
+                    $$(allCellsLocator, this).core().noValidation().getAllElements();
                 cells.set(new MapArray<>());
                 int k = 0;
                 int j = 1;

--- a/jdi-light/src/main/java/com/epam/jdi/light/elements/complex/table/BaseTable.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/elements/complex/table/BaseTable.java
@@ -5,7 +5,9 @@ import com.epam.jdi.light.asserts.generic.table.BaseTableAssert;
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.base.UIBaseElement;
 import com.epam.jdi.light.elements.common.UIElement;
-import com.epam.jdi.light.elements.complex.*;
+import com.epam.jdi.light.elements.complex.IHasSize;
+import com.epam.jdi.light.elements.complex.ISetup;
+import com.epam.jdi.light.elements.complex.WebList;
 import com.epam.jdi.light.elements.interfaces.base.HasRefresh;
 import com.epam.jdi.light.elements.interfaces.base.HasValue;
 import com.epam.jdi.light.elements.interfaces.common.IsText;
@@ -23,22 +25,25 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.epam.jdi.light.common.Exceptions.*;
-import static com.epam.jdi.light.driver.WebDriverByUtils.*;
-import static com.epam.jdi.light.elements.base.JDIBase.*;
-import static com.epam.jdi.light.elements.complex.table.Line.*;
-import static com.epam.jdi.light.elements.complex.table.TableMatcher.*;
-import static com.epam.jdi.light.elements.init.UIFactory.*;
-import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFromAnnotationRules.*;
-import static com.epam.jdi.tools.EnumUtils.*;
-import static com.epam.jdi.tools.LinqUtils.any;
+import static com.epam.jdi.light.common.Exceptions.exception;
+import static com.epam.jdi.light.driver.WebDriverByUtils.defineLocator;
+import static com.epam.jdi.light.driver.WebDriverByUtils.fillByMsgTemplate;
+import static com.epam.jdi.light.driver.WebDriverByUtils.fillByTemplate;
+import static com.epam.jdi.light.driver.WebDriverByUtils.getByLocator;
+import static com.epam.jdi.light.elements.base.JDIBase.STRING_SIMPLIFY;
+import static com.epam.jdi.light.elements.complex.table.Line.initLine;
+import static com.epam.jdi.light.elements.complex.table.TableMatcher.TABLE_MATCHER;
+import static com.epam.jdi.light.elements.init.UIFactory.$;
+import static com.epam.jdi.light.elements.init.UIFactory.$$;
+import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFromAnnotationRules.fieldHasAnnotation;
+import static com.epam.jdi.tools.EnumUtils.getEnumValue;
 import static com.epam.jdi.tools.LinqUtils.*;
-import static com.epam.jdi.tools.PrintUtils.*;
-import static com.epam.jdi.tools.StringUtils.*;
+import static com.epam.jdi.tools.PrintUtils.print;
+import static com.epam.jdi.tools.StringUtils.LINE_BREAK;
 import static java.lang.String.format;
-import static java.util.Arrays.*;
-import static org.apache.commons.lang3.StringUtils.*;
-import static org.hamcrest.Matchers.*;
+import static java.util.Arrays.asList;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 
 /**
  * Created by Roman Iovlev on 26.09.2019
@@ -700,7 +705,8 @@ public abstract class BaseTable<T extends BaseTable<?,?>, A extends BaseTableAss
         if (!cells.isGotAll()) {
             try {
                 List<WebElement> listOfCells =
-                    $$(allCellsLocator, this).core().noValidation().getAllElements();
+                    $$(allCellsLocator, this)
+                                .core().noValidation().getAllElements();
                 cells.set(new MapArray<>());
                 int k = 0;
                 int j = 1;

--- a/jdi-light/src/main/java/com/epam/jdi/light/settings/WebSettings.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/settings/WebSettings.java
@@ -7,7 +7,7 @@ import com.epam.jdi.light.driver.get.DriverTypes;
 import com.epam.jdi.light.elements.common.UIElement;
 import com.epam.jdi.light.elements.interfaces.base.IBaseElement;
 import com.epam.jdi.light.elements.interfaces.composite.PageObject;
-import com.epam.jdi.light.logger.*;
+import com.epam.jdi.light.logger.ILogger;
 import com.epam.jdi.tools.*;
 import com.epam.jdi.tools.func.*;
 import com.epam.jdi.tools.pairs.Pair;

--- a/pom.xml
+++ b/pom.xml
@@ -57,11 +57,14 @@
         <module>jdi-light-eyes</module>
         <module>jdi-bdd</module>
         <module>jdi-light-bootstrap</module>
+        <module>jdi-light-angular</module>
         <module>jdi-light-html-tests</module>
         <module>jdi-eyes-demo</module>
         <module>jdi-bdd-tests</module>
         <module>jdi-light-applitools-tests</module>
         <module>jdi-light-bootstrap-tests</module>
+        <module>jdi-light-angular-tests</module>
+        <module>jdi-light-angular-unit-tests</module>
         <module>test-examples/jdi-performance</module>
         <module>test-examples/jdi-light-examples</module>
         <module>test-examples/jdi-bdd-no-po-tests</module>

--- a/reports.sh
+++ b/reports.sh
@@ -124,7 +124,7 @@ function deployAllureResults() {
     JDK_VERSIONS="openjdk8 openjdk9 openjdk10 openjdk11 openjdk12 openjdk13"
     for JDK in $JDK_VERSIONS;
     do
-      generateAllureReports "${JDK}"
+      generateAllureReports ${JDK}
       echo "LOG1"
       url="$(deployToNetlify "allure-report-${JDK}")"
       echo "LOG2"
@@ -183,7 +183,7 @@ function generateAllureReports() {
     echo "Generating allure-report-$1 based on: ${reportDirList}"
     allure generate --clean ${reportDirList}
     mv allure-report allure-report-$1
-    echo "Report was renamed to allure-report-$1"
+    echo Report successfully renamed to allure-report-$1
 
 }
 

--- a/reports.sh
+++ b/reports.sh
@@ -128,7 +128,7 @@ function deployAllureResults() {
       echo "LOG1"
       url="$(deployToNetlify "allure-report-${JDK}")"
       echo "LOG2"
-      sendComment "$(aboutNetlify "${url}" "${JDK}")"
+      sendComment "$(aboutNetlify ${url} ${JDK})"
     done
 }
 
@@ -182,7 +182,7 @@ function generateAllureReports() {
     fi
     echo "Generating allure-report-$1 based on: ${reportDirList}"
     allure generate --clean ${reportDirList}
-    mv "allure-report" "allure-report-$1"
+    mv allure-report allure-report-$1
     echo "Report was renamed to allure-report-$1"
 
 }

--- a/reports.sh
+++ b/reports.sh
@@ -121,7 +121,7 @@ function deployAllureResults() {
     extractAllureResults
     # Great, now we have huge amount of jsons for different JDKs distributed across directory tree
     # Our goal now is to distribute them across multiple allure reports
-    JDK_VERSIONS="openjdk8 openjdk10 openjdk11"
+    JDK_VERSIONS="openjdk8 openjdk9 openjdk10 openjdk11 openjdk12 openjdk13"
     for JDK in $JDK_VERSIONS;
     do
       generateAllureReports ${JDK}

--- a/reports.sh
+++ b/reports.sh
@@ -52,7 +52,7 @@ function sendComment() {
 
 function archive() {
     directory="$1"
-    archiveName="$(echo "${directory}"| awk -F"/" '{print $1}')-${TRAVIS_JDK_VERSION}".tar.gz
+    archiveName="$(echo "${directory}"| grep -o "jdi-[a-z-]*")-${TRAVIS_JDK_VERSION}".tar.gz
     tar -czf "${archiveName}" "${directory}" > /dev/null
     echo "${archiveName}" #return
 }
@@ -89,7 +89,7 @@ function grubAllureResults() {
     checkBranchIsOk #there is an exit inside
 
     if [[ "x${TRAVIS_BUILD_STAGE_NAME}" == "xtest" ]] ; then #don't remove x, it's useful
-        for result in $(find jdi*/target/allure-results-${TRAVIS_JDK_VERSION} -maxdepth 1 -type d)
+        for result in $(find -type d -regex ".*/jdi.*/target/allure-results-${TRAVIS_JDK_VERSION}")
         do
             echo RESULT: ${result}
             archiveFile="$(archive "${result}")"

--- a/reports.sh
+++ b/reports.sh
@@ -158,7 +158,7 @@ function extractAllureResults() {
 function generateAllureReports() {
     reportDirList="";
     allureDirExistence=false
-    for report in $(ls -d1 jdi*/target/ */jdi*/target/)
+    for report in $(ls -d1 jdi*/target/ ./*/jdi*/target/)
     do
         allureDirExistence=true
         allureDir="${report}allure-results"

--- a/reports.sh
+++ b/reports.sh
@@ -124,11 +124,11 @@ function deployAllureResults() {
     JDK_VERSIONS="openjdk8 openjdk9 openjdk10 openjdk11 openjdk12 openjdk13"
     for JDK in $JDK_VERSIONS;
     do
-      generateAllureReports ${JDK}
+      generateAllureReports "${JDK}"
       echo "LOG1"
       url="$(deployToNetlify "allure-report-${JDK}")"
       echo "LOG2"
-      sendComment "$(aboutNetlify ${url} ${JDK})"
+      sendComment "$(aboutNetlify "${url}" "${JDK}")"
     done
 }
 
@@ -182,8 +182,8 @@ function generateAllureReports() {
     fi
     echo "Generating allure-report-$1 based on: ${reportDirList}"
     allure generate --clean ${reportDirList}
-    mv allure-report allure-report-$1
-    echo Report successfully renamed to allure-report-$1
+    mv "allure-report" "allure-report-$1"
+    echo "Report was renamed to allure-report-$1"
 
 }
 

--- a/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/TestRunner.java
+++ b/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/TestRunner.java
@@ -1,7 +1,7 @@
-package cucmberTests;
+package cucumberTests;
 
 import com.epam.jdi.light.elements.composite.WebPage;
-import cucmberTests.test.data.User;
+import cucumberTests.test.data.User;
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 import org.junit.AfterClass;
@@ -10,12 +10,12 @@ import org.junit.runner.RunWith;
 
 import static com.epam.jdi.light.driver.WebDriverUtils.*;
 import static com.epam.jdi.light.elements.init.UIFactory.*;
-import static cucmberTests.test.data.TestData.*;
+import static cucumberTests.test.data.TestData.*;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(
     features = "classpath:features"
-    , glue = {"com.epam.jdi.bdd", "cucmberTests"}
+    , glue = {"com.epam.jdi.bdd", "cucumberTests"}
     , tags = {"@form"}
 )
 public class TestRunner {

--- a/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/steps/UserStepdefs.java
+++ b/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/steps/UserStepdefs.java
@@ -1,4 +1,4 @@
-package cucmberTests.steps;
+package cucumberTests.steps;
 
 import cucumber.api.java.en.Given;
 

--- a/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/test/data/TestData.java
+++ b/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/test/data/TestData.java
@@ -1,4 +1,4 @@
-package cucmberTests.test.data;
+package cucumberTests.test.data;
 
 public class TestData {
     public static User ROMAN = new User().set(u -> { u.name = "Roman"; u.password = "Jdi1234"; });

--- a/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/test/data/User.java
+++ b/test-examples/jdi-bdd-no-po-tests/src/test/java/cucumberTests/test/data/User.java
@@ -1,4 +1,4 @@
-package cucmberTests.test.data;
+package cucumberTests.test.data;
 
 import com.epam.jdi.tools.DataClass;
 

--- a/test-examples/jdi-light-examples/src/main/java/io/github/com/pages/Header.java
+++ b/test-examples/jdi-light-examples/src/main/java/io/github/com/pages/Header.java
@@ -19,10 +19,12 @@ public class Header extends Section {
 	@Css(".icon-search.active") static WebElement doSearch;
 
 	public static void search(String text) {
-		if(logout.isDisplayed())
+		if (logout.isDisplayed()) {
 			userName.click();
-		if (searchInput.isHidden())
+		}
+		if (searchInput.isHidden()) {
 			searchIcon.click();
+		}
 		searchInput.input(text);
 		doSearch.click();
 	}

--- a/test-examples/jdi-light-examples/src/main/java/io/github/com/pages/SearchPage.java
+++ b/test-examples/jdi-light-examples/src/main/java/io/github/com/pages/SearchPage.java
@@ -15,7 +15,7 @@ public class SearchPage extends BaseSelPage {
 	@Css(".box") public DataList<SearchResult, Result> search;
 	@Css(".box") public DataList<SearchResult, ?> search2;
 	@Css(".box") public static List<SearchResult> search3;
-	@Css(".box") @WaitTimeout(2)
+	@Css(".box") @WaitTimeout(3)
 	public static DataList<SearchResult, ?> searchS;
 	@XPath("//*[@class='box']/h3[text()=\"%s\"]")
 	public DataList<SearchResult, ?> searchT2;

--- a/test-examples/jdi-light-examples/src/main/java/selenium/entities/TestData.java
+++ b/test-examples/jdi-light-examples/src/main/java/selenium/entities/TestData.java
@@ -6,7 +6,7 @@ public class TestData {
             " Grady Brock (011307) 16843 cursus.et@commodo.org Alcobendas" +
             " Harding Lloyd 0800 1111 neque.In.ornare@mauris.co.uk Beauvais" +
             " Zachary Hendrix 07624 035724 ipsum.non.arcu@auctorullamcorper.ca Redcliffe" +
-            " Logan Simmons (01367) 073346 ac.mattis.velit@import static org.hamcrest.MatcherAssert.*;etmagnisdis.com Gierle" +
+            " Logan Simmons (01367) 073346 ac.mattis.velit@etmagnisdis.com Gierle" +
             " Colby Young 0963 451 3377 In.scelerisque.scelerisque@elitelitfermentum.net Driffield" +
             " Peter Mitchell (01256) 43239 ipsum.porta@arcu.edu Duncan" +
             " Hamilton Curry (0181) 775 6791 et@dignissimmagnaa.org Chemnitz" +

--- a/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/RootTests.java
+++ b/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/RootTests.java
@@ -1,13 +1,15 @@
 package io.github.epam.tests;
 
+import static io.github.com.StaticSite.homePage;
+import static io.github.com.StaticSite.searchPage;
+import static io.github.com.pages.Header.loginForm;
+import static io.github.com.pages.Header.userIcon;
+import static io.github.epam.entities.Users.DEFAULT_USER;
+import static io.github.epam.tests.recommended.steps.Preconditions.shouldBeLoggedOut;
+
 import io.github.epam.StaticTestsInit;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static io.github.com.StaticSite.*;
-import static io.github.com.pages.Header.*;
-import static io.github.epam.entities.Users.*;
-import static io.github.epam.tests.recommended.steps.Preconditions.*;
 
 public class RootTests extends StaticTestsInit {
 
@@ -18,6 +20,7 @@ public class RootTests extends StaticTestsInit {
         loginForm.submit(DEFAULT_USER, "enter");
         homePage.checkOpened();
     }
+
     @Test
     public void initDeepTest() {
         Assert.assertNotNull(homePage.testField);

--- a/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitDataListTests.java
+++ b/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitDataListTests.java
@@ -1,21 +1,21 @@
 package io.github.epam.tests.google;
 
 import io.github.epam.StaticTestsInit;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static io.github.com.StaticSite.*;
-import static io.github.com.pages.Header.*;
-import static io.github.com.pages.SearchPage.*;
-import static io.github.epam.tests.recommended.steps.Preconditions.*;
+import static io.github.com.StaticSite.homePage;
+import static io.github.com.pages.Header.search;
+import static io.github.com.pages.SearchPage.searchS;
+import static io.github.epam.tests.recommended.steps.Preconditions.shouldBeLoggedIn;
 import static org.hamcrest.Matchers.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 /**
  * Created by Roman_Iovlev on 3/2/2018.
  */
 public class WaitDataListTests extends StaticTestsInit {
+
     @BeforeMethod
     public void before() {
         homePage.shouldBeOpened();
@@ -27,27 +27,26 @@ public class WaitDataListTests extends StaticTestsInit {
     public void notEmptyTest() {
         searchS.is().notEmpty();
     }
+
     @Test
     public void notEmpty2Test() {
         searchS.assertThat(not(empty()));
     }
+
     @Test
     public void emptyTest() {
-
-        try {
-            searchS.is().empty();
-            Assert.fail("List should not be empty");
-        } catch (Throwable ignored) { }
-        searchS.is().notEmpty();
+        searchS.waitFor(2).notEmpty();
     }
+
     @Test
     public void sizeTest() {
         assertEquals(searchS.size(), 6);
-        searchS.is().size(equalTo(8));
+        searchS.waitFor(10).size(equalTo(8));
     }
+
     @Test
     public void sizeGreaterTest() {
-        searchS.is().size(greaterThan(7));
+        searchS.waitFor(10).size(greaterThan(7));
     }
 
 }

--- a/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitDataListTests.java
+++ b/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitDataListTests.java
@@ -29,24 +29,19 @@ public class WaitDataListTests extends StaticTestsInit {
     }
 
     @Test
-    public void notEmpty2Test() {
+    public void notEmptyAssertThatTest() {
         searchS.assertThat(not(empty()));
-    }
-
-    @Test
-    public void emptyTest() {
-        searchS.waitFor(2).notEmpty();
     }
 
     @Test
     public void sizeTest() {
         assertEquals(searchS.size(), 6);
-        searchS.waitFor(10).size(equalTo(8));
+        searchS.has().size(equalTo(8));
     }
 
     @Test
     public void sizeGreaterTest() {
-        searchS.waitFor(10).size(greaterThan(7));
+        searchS.has().size(greaterThan(7));
     }
 
 }

--- a/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitJListTests.java
+++ b/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitJListTests.java
@@ -1,23 +1,21 @@
 package io.github.epam.tests.google;
 
 import io.github.epam.StaticTestsInit;
-import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static com.epam.jdi.light.settings.JDISettings.*;
-import static com.epam.jdi.light.settings.WebSettings.*;
-import static io.github.com.StaticSite.*;
-import static io.github.com.pages.Header.*;
-import static io.github.com.pages.SearchPage.*;
-import static io.github.epam.tests.recommended.steps.Preconditions.*;
+import static io.github.com.StaticSite.homePage;
+import static io.github.com.pages.Header.search;
+import static io.github.com.pages.SearchPage.jsearchTitle;
+import static io.github.epam.tests.recommended.steps.Preconditions.shouldBeLoggedIn;
 import static org.hamcrest.Matchers.*;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
 
 /**
  * Created by Roman_Iovlev on 3/2/2018.
  */
 public class WaitJListTests extends StaticTestsInit {
+
     @BeforeMethod
     public void before() {
         homePage.shouldBeOpened();
@@ -29,30 +27,26 @@ public class WaitJListTests extends StaticTestsInit {
     public void notEmptyTest() {
         jsearchTitle.is().notEmpty();
     }
+
     @Test
     public void notEmpty2Test() {
         jsearchTitle.assertThat(not(empty()));
     }
+
     @Test
     public void emptyTest() {
-        TIMEOUTS.element.setUp(2);
-        try {
-            jsearchTitle.is().empty();
-            Assert.fail("List should not be empty");
-        } catch (Throwable ignored) { }
-        finally {
-            TIMEOUTS.element.drop();
-        }
-        logger.info("Done");
+        jsearchTitle.waitFor(2).notEmpty();
     }
+
     @Test
     public void sizeTest() {
         assertEquals(jsearchTitle.size(), 6);
-        jsearchTitle.is().size(equalTo(8));
+        jsearchTitle.waitFor(10).size(equalTo(8));
     }
+
     @Test
     public void sizeNotEmptyTest() {
-        jsearchTitle.is().size(greaterThan(7));
+        jsearchTitle.waitFor(10).size(greaterThan(7));
     }
 
 }

--- a/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitJListTests.java
+++ b/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/google/WaitJListTests.java
@@ -24,29 +24,29 @@ public class WaitJListTests extends StaticTestsInit {
     }
 
     @Test
-    public void notEmptyTest() {
+    public void isNotEmptyTest() {
         jsearchTitle.is().notEmpty();
     }
 
     @Test
-    public void notEmpty2Test() {
+    public void notEmptyAssertThatTest() {
         jsearchTitle.assertThat(not(empty()));
     }
 
     @Test
-    public void emptyTest() {
+    public void notEmptyTest() {
         jsearchTitle.waitFor(2).notEmpty();
     }
 
     @Test
     public void sizeTest() {
         assertEquals(jsearchTitle.size(), 6);
-        jsearchTitle.waitFor(10).size(equalTo(8));
+        jsearchTitle.is().size(equalTo(8));
     }
 
     @Test
     public void sizeNotEmptyTest() {
-        jsearchTitle.waitFor(10).size(greaterThan(7));
+        jsearchTitle.waitFor(5).size(greaterThan(7));
     }
 
 }

--- a/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/recommended/TableTests.java
+++ b/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/recommended/TableTests.java
@@ -25,6 +25,7 @@ public class TableTests extends StaticTestsInit {
         tablePage.shouldBeOpened();
     }
 
+    // too long for regular run
     @Test(enabled = false)
     public void tablePerformanceTest() {
         tablePerformance(users);

--- a/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/recommended/TableTests.java
+++ b/test-examples/jdi-light-examples/src/test/java/io/github/epam/tests/recommended/TableTests.java
@@ -1,22 +1,26 @@
 package io.github.epam.tests.recommended;
 
+import static com.epam.jdi.light.elements.common.Alerts.validateAlert;
+import static com.epam.jdi.tools.StringUtils.LINE_BREAK;
+import static io.github.com.StaticSite.tablePage;
+import static io.github.com.pages.PerformancePage.users;
+import static io.github.com.pages.PerformancePage.usersSetup;
+import static io.github.epam.test.data.TableData.GRADY_BROCK;
+import static io.github.epam.tests.recommended.steps.Preconditions.shouldBeLoggedIn;
+import static java.lang.System.currentTimeMillis;
+import static java.lang.System.out;
+import static java.util.Arrays.asList;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
 import com.epam.jdi.light.elements.complex.table.Table;
 import io.github.epam.StaticTestsInit;
 import io.github.epam.custom.UserRow;
 import io.github.epam.entities.UserInfo;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static com.epam.jdi.light.elements.common.Alerts.*;
-import static com.epam.jdi.tools.StringUtils.*;
-import static io.github.com.StaticSite.*;
-import static io.github.com.pages.PerformancePage.*;
-import static io.github.epam.test.data.TableData.*;
-import static io.github.epam.tests.recommended.steps.Preconditions.*;
-import static java.lang.System.*;
-import static java.util.Arrays.*;
-import static org.hamcrest.Matchers.*;
-import static org.testng.Assert.*;
 
 public class TableTests extends StaticTestsInit {
     @BeforeMethod
@@ -26,7 +30,7 @@ public class TableTests extends StaticTestsInit {
     }
 
     // too long for regular run
-    @Test(enabled = false)
+    @Test
     public void tablePerformanceTest() {
         tablePerformance(users);
     }
@@ -73,11 +77,11 @@ public class TableTests extends StaticTestsInit {
             "Harding Lloyd 0800 1111 neque.In.ornare@mauris.co.uk Beauv");
         logTime("Preview");
         value = table.getValue();
-        assertEquals(value.substring(0,228),
+        assertTrue(value.substring(0, 228).contains(
             "||X||Name|Phone|Email|City||" + LINE_BREAK +
-            "||1||Burke Tucker|076 1971 1687|et.euismod.et@ut.edu|GozŽe||" + LINE_BREAK +
-            "||2||Grady Brock|(011307) 16843|cursus.et@commodo.org|Alcobendas||" + LINE_BREAK +
-            "||3||Harding Lloyd|0800 1111|neque.In.ornare@mauris.co.uk|Beauvais||");
+                "||1||Burke Tucker|076 1971 1687|et.euismod.et@ut.edu|GozŽe||" + LINE_BREAK +
+                "||2||Grady Brock|(011307) 16843|cursus.et@commodo.org|Alcobendas||" + LINE_BREAK +
+                "||3||Harding Lloyd|0800 1111|neque.In.ornare@mauris.co.uk|Beauvais||"));
         logTime("Get value");
     }
 

--- a/test-examples/jdi-performance/pom.xml
+++ b/test-examples/jdi-performance/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>RELEASE</version>
+            <version>7.0.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test-examples/jdi-performance/src/main/java/org/mytests/uiobjects/example/TestData.java
+++ b/test-examples/jdi-performance/src/main/java/org/mytests/uiobjects/example/TestData.java
@@ -2,404 +2,404 @@ package org.mytests.uiobjects.example;
 
 public class TestData {
     public static String TABLE_SNAPSHOOT = "Name Phone Email City" +
-            "Burke Tucker 076 1971 1687 et.euismod.et@ut.edu GozŽe" +
-            "Grady Brock (011307) 16843 cursus.et@commodo.org Alcobendas" +
-            "Harding Lloyd 0800 1111 neque.In.ornare@mauris.co.uk Beauvais" +
-            "Zachary Hendrix 07624 035724 ipsum.non.arcu@auctorullamcorper.ca Redcliffe" +
-            "Logan Simmons (01367) 073346 ac.mattis.velit@etmagnisdis.com Gierle" +
-            "Colby Young 0963 451 3377 In.scelerisque.scelerisque@elitelitfermentum.net Driffield" +
-            "Peter Mitchell (01256) 43239 ipsum.porta@arcu.edu Duncan" +
-            "Hamilton Curry (0181) 775 6791 et@dignissimmagnaa.org Chemnitz" +
-            "Nero Stephens 0845 46 42 pellentesque.Sed@Craseutellus.edu Sachs Harbour" +
-            "Tanner Bruce 0800 1111 elementum.sem@maurisIntegersem.org Kungälv" +
-            "Akeem Harrington (0111) 759 1390 ac.arcu.Nunc@enimnislelementum.com Gävle" +
-            "Benjamin Glenn (016977) 3597 est.mollis@eu.co.uk Chippenham" +
-            "Zachary Sampson 0800 1111 tempor.erat.neque@consectetueradipiscing.org Kota" +
-            "Sean Brown 0317 398 0597 nibh.Donec.est@nonquamPellentesque.co.uk Castel San Niccolò" +
-            "Ferris Mckinney 0800 1111 leo.elementum@sedconsequat.net Langford" +
-            "Chancellor Cabrera 0383 300 9486 Etiam.vestibulum@Nam.edu Bauchi" +
-            "Keith Long 0800 364 7432 Integer.mollis.Integer@aliquetlobortisnisi.co.uk The Hague" +
-            "Dalton Richardson 0395 522 3568 lacus.Quisque.purus@Integeraliquamadipiscing.com Calvera" +
-            "Clarke Langley 0398 596 6834 porttitor.eros@velitPellentesque.ca Fino Mornasco" +
-            "Eaton Dyer 055 1441 9535 egestas.lacinia.Sed@Sedeueros.ca Lac-Serent" +
-            "Tyrone Pena (01329) 37079 nec.ligula@lobortisClassaptent.com Tuscaloosa" +
-            "Curran Becker 056 1678 9780 nulla@Nunccommodo.org Bruck an der Mur" +
-            "Damon Bryant 0801 483 9983 est.arcu@est.ca Baton Rouge" +
-            "Ryan Cline 0845 46 46 euismod.est.arcu@augue.co.uk Cockburn" +
-            "Judah Wheeler 056 4229 0035 risus.Donec@Quisquefringilla.net Kleinmachnow" +
-            "Ciaran Dotson (016977) 4778 id@sitamet.edu Rotem" +
-            "Nash Sharp (016977) 6083 amet@fringillaDonec.org Carovilli" +
-            "Benedict Bryant 0873 083 9083 non.sapien.molestie@blanditNamnulla.com Gravelbourg" +
-            "Tarik Hansen (023) 7618 2932 dui.lectus.rutrum@Sedauctor.net Afsnee" +
-            "Ulric Justice (0115) 392 1246 lacus@Loremipsum.net Matagami" +
-            "Ray Davis 0800 848169 semper@Phasellusdapibusquam.ca Tongerlo" +
-            "Beck Smith 07624 185893 nascetur.ridiculus.mus@semvitaealiquam.ca Rancagua" +
-            "Jelani Stafford 0800 049344 faucibus@nibh.co.uk Leersum" +
-            "Philip Lopez 0845 46 49 ac@orciadipiscingnon.co.uk Grand Island" +
-            "Jameson Arnold 0988 427 2322 nisl@blanditviverra.ca Tuscaloosa" +
-            "Burton Bishop (01025) 570147 semper.dui.lectus@commodoat.org Los Sauces" +
-            "Preston Monroe 0325 630 0384 neque@sed.com Burnie" +
-            "Joseph Eaton 0887 569 9679 malesuada@urnaNunc.co.uk La Cruz" +
-            "Carl Clements 07624 940647 et@mauris.edu Avise" +
-            "Hoyt Terry (0111) 334 8178 lorem@Phasellusnulla.net Fort St. John" +
-            "Octavius Espinoza (01629) 05356 Nullam.velit.dui@cursusluctus.edu Logan City" +
-            "Alexander Villarreal 07624 426932 ornare@neceleifendnon.com Bhuj" +
-            "Hayden Holmes 0360 901 1201 accumsan.laoreet@utipsumac.ca Weißenfels" +
-            "Sean Mueller 07638 352622 et.ultrices.posuere@Curabitur.ca Kerkhove" +
-            "Malcolm Richardson 076 9535 9828 urna.Ut.tincidunt@elitfermentumrisus.co.uk Cleveland" +
-            "Stewart Spence (023) 6496 7274 et.ultrices.posuere@dolorelit.org Calestano" +
-            "Quinlan Conrad (016977) 5533 tellus.Aenean@massaIntegervitae.edu Raipur" +
-            "Conan Blanchard (015246) 18321 dignissim.Maecenas.ornare@tincidunttempus.org Neuruppin" +
-            "Tate Trujillo 0387 316 9960 mauris.erat@vitaesodales.net Wood Buffalo" +
-            "Chadwick Bradford (0191) 538 2293 non.quam.Pellentesque@Maurisquis.com Edmundston" +
-            "Neville Alvarado (010779) 48043 vel.arcu@nuncQuisqueornare.co.uk Bear" +
-            "Baker Maldonado 0800 380112 sit.amet.luctus@arcuVestibulum.org Pointe-au-Pic" +
-            "Judah Hardy (011296) 66434 ultrices.posuere.cubilia@rhoncusid.com Orsogna" +
-            "Keegan Henson 0309 312 4037 eget@tempus.ca Habra" +
-            "Simon Beard (01306) 069594 In.lorem.Donec@diam.ca Swindon" +
-            "Hop Santiago 0855 726 9053 tortor.nibh.sit@sodaleselit.net Saint-Mard" +
-            "Carson Hoover 0320 958 4039 magna.tellus.faucibus@risus.com Patarrá" +
-            "Jelani Jefferson 07624 127835 metus@Donecsollicitudinadipiscing.co.uk Termes" +
-            "Dane Clark 076 3329 9156 sit@Integeraliquamadipiscing.ca San Diego" +
-            "Abraham Bryan 0311 770 4531 velit.in@tellusSuspendisse.ca Chartres" +
-            "Otto Miller (01009) 642663 orci@ipsumPhasellusvitae.ca Turnhout" +
-            "Talon Davidson 070 7593 9470 odio.Aliquam@Curabiturdictum.ca Minto" +
-            "Reed Patel 055 3390 4318 pharetra@Aliquamfringillacursus.co.uk San Cristóbal de la Laguna" +
-            "Herman Yang 0996 157 4214 elit.pretium@Nulla.edu Berlin" +
-            "Justin Horton 0800 249 3179 sagittis@lobortisnisinibh.ca Cape Breton Island" +
-            "Flynn Robertson 056 9705 7346 Lorem@cursus.co.uk Moulins" +
-            "Baker Lane 055 0842 5343 tincidunt@mi.ca Grosseto" +
-            "Elliott Neal (0119) 359 1626 non.arcu.Vivamus@cursusdiamat.edu Nueva Imperial" +
-            "Ray Yang 07624 181309 Nullam.enim@justosit.ca Lacombe County" +
-            "Ethan Albert (014674) 49440 cursus.luctus.ipsum@Quisquefringillaeuismod.ca Duffel" +
-            "Daquan Cash 070 0820 0781 Donec@convallisdolor.net Kohima" +
-            "Marshall Good (0121) 467 5361 Ut.nec.urna@felisadipiscing.ca Morena" +
-            "Edward Dean 0817 789 5834 eu.metus@Sed.ca West Valley City" +
-            "Rooney Brooks (0112) 337 7340 ornare.lectus.ante@malesuadamalesuada.com Evansville" +
-            "Judah Becker (01256) 779536 diam@ut.net Mörfelden-Walldorf" +
-            "Keaton Hahn 07624 524330 sit.amet@insodaleselit.edu Bollnäs" +
-            "Craig Mejia 07841 125712 consequat.enim@Vestibulumante.net Paupisi" +
-            "Kermit Wright 0800 1111 ut.aliquam@Loremipsum.ca Fresno" +
-            "Vernon Erickson 056 7788 3683 vulputate@quis.edu Cuglieri" +
-            "Kennedy Wade 0800 1111 auctor.nunc@utdolordapibus.net Radebeul" +
-            "Sebastian Gibson (0161) 575 6673 odio.auctor.vitae@quis.net Nieuwkerken-Waas" +
-            "Brennan Klein 056 1403 9853 faucibus@maurisa.edu Exeter" +
-            "Ryder Morse 0500 343447 nibh@incursuset.edu New Westminster" +
-            "Ignatius Mullen 0845 46 44 elit.fermentum.risus@utquam.com Tavigny" +
-            "Malachi Stanton (016969) 67601 interdum.Nunc@Donecporttitortellus.net Koersel" +
-            "Tanek Sloan 07624 351205 cubilia@laoreetposuere.ca Tiverton" +
-            "John Meyer 07475 360711 Nunc@duiaugue.net New Westminster" +
-            "Tarik Hunt (01084) 044437 feugiat@pellentesque.ca Sedgewick" +
-            "Tate Spears 055 5012 9185 euismod@parturient.com Croydon" +
-            "Stuart Hopkins 056 1376 7135 pede@semperdui.org Allahabad" +
-            "Aidan Ray 07624 271603 sem.mollis@anequeNullam.co.uk Valleyview" +
-            "Griffith Nieves (0121) 592 3029 Vivamus@arcuSed.net Spiere" +
-            "Jared Kramer 0845 46 45 Proin@mattisvelit.net Haldia" +
-            "Felix Stevenson (0191) 546 2187 pellentesque.tellus@utpharetrased.co.uk Paisley" +
-            "Wade Cross 0800 183220 dolor.quam@vehiculaet.com Hugli-Chinsurah" +
-            "Lee Crane 056 6498 9876 nascetur@risusDonec.org Igboho" +
-            "Zahir Buchanan (0191) 909 2062 nunc.sed.pede@nec.edu Lac-Serent" +
-            "Brian Meyer (016977) 0358 mollis.nec@seddictumeleifend.co.uk Houston" +
-            "Tarik Leach 055 8679 2768 risus@Pellentesqueultricies.net Llaillay" +
-            "Logan Gamble 0800 1111 ac.arcu.Nunc@fermentum.edu Viggiano" +
-            "Isabelle Mcdowell (01304) 321760 Nam.nulla.magna@mollisDuissit.ca Kiel" +
-            "Leila Logan 070 1742 9174 pharetra.sed.hendrerit@lorem.net Fort Laird" +
-            "Cameran Robertson 0845 46 40 vulputate@estMauriseu.org Laja" +
-            "Ciara Mcclure 07476 375018 aliquam@eliteratvitae.edu Schagen" +
-            "Sydnee Williamson (015122) 34852 egestas.a@aliquet.ca Hagen" +
-            "Fay Cobb (0141) 701 4563 felis.eget@sollicitudincommodo.com Marcedusa" +
-            "Anika Graham 07624 978050 lacus@augueeutellus.edu Valley East" +
-            "Callie Mullen 076 6778 6017 egestas@atauctor.co.uk Gallicchio" +
-            "Illana Fitzgerald 0800 394996 dignissim.Maecenas.ornare@erat.ca Quillón" +
-            "Kathleen Hughes (0101) 491 2925 odio.Nam.interdum@etnetus.ca Matamata" +
-            "September Andrews 0827 620 1389 Duis.gravida@orcitinciduntadipiscing.com Sint-Pieters-Leeuw" +
-            "Martina Davidson (012275) 85154 Donec.vitae.erat@Inmi.co.uk Liverpool" +
-            "Hedy Phillips 0800 120 9706 risus@netuset.edu Wolfenbüttel" +
-            "Hilda Hubbard 076 5780 0993 non@lacusNulla.co.uk Henstedt-Ulzburg" +
-            "Beverly Cameron 07380 723139 ultrices.a.auctor@dignissim.edu Lumaco" +
-            "Kirsten Drake 07915 777813 tincidunt.tempus@Craspellentesque.org Freiberg" +
-            "Karleigh Hubbard 0800 593726 Integer.mollis.Integer@Maecenasmalesuadafringilla.net Albiano" +
-            "Aretha Craft (0131) 721 5375 natoque@id.net Hamme" +
-            "Kerry Andrews 056 4028 5526 pharetra@eleifendCrassed.net Columbia" +
-            "Alma Espinoza 0500 215138 montes@Aeneaneuismod.com Giugliano in Campania" +
-            "Yael Jimenez 070 1654 2995 faucibus@DonecfringillaDonec.com Srinagar" +
-            "Miriam Holland 070 7849 6859 a@enimgravida.edu Kitscoty" +
-            "Scarlett Whitley (016552) 76917 cursus.vestibulum@Integeraliquam.net Colombo" +
-            "Aretha Norris 0845 46 48 Donec@ultriciesligulaNullam.edu Bathurst" +
-            "Faith Reyes 0349 153 9269 aliquet@consequatauctornunc.org Cunco" +
-            "Hanna Espinoza (01260) 449000 non.massa.non@cursus.org Ruddervoorde" +
-            "Yen Gibbs 0800 869684 mattis.Integer@acfeugiat.org Colwood" +
-            "Regina Obrien 0800 299789 In.lorem.Donec@ligulaAenean.com Osnabrück" +
-            "Illana Parrish 0800 291 0292 magnis.dis.parturient@elitsedconsequat.co.uk Tumbler Ridge" +
-            "Sigourney Stein (017821) 17943 rhoncus@purusMaecenas.org Geer" +
-            "Martha Daugherty 076 4262 4528 mollis.Integer.tincidunt@aliquetdiam.com Slijpe" +
-            "Piper Figueroa (025) 9423 5980 dis@quispedeSuspendisse.ca Sant'Angelo Limosano" +
-            "Kylan Schmidt 0886 691 4919 Sed.nunc@nequeNullamnisl.ca Tropea" +
-            "Zephr Fox 0800 638 9987 a@auguemalesuada.ca Luttre" +
-            "Clementine Mathews 056 5155 6096 magna.nec.quam@Aliquam.co.uk Sale" +
-            "Amela Sanders 056 5209 8664 pede@pharetrafeliseget.net Rycroft" +
-            "Dorothy Sullivan (018212) 78744 sapien.cursus.in@Donecnon.net Kharagpur" +
-            "Cleo Townsend 070 1931 2864 dolor.dapibus.gravida@Duisvolutpatnunc.net Longchamps" +
-            "Hope Berry 055 4389 2474 ante.bibendum@Morbiquis.ca La Estrella" +
-            "Britanney Ferrell 0800 768856 a@dignissimpharetra.co.uk Trollhättan" +
-            "Kiona Barber (01814) 745705 a@vitaeposuereat.edu Herk-de-Stad" +
-            "TaShya Sparks 0827 428 9203 dolor.Fusce.mi@aliquetmolestie.net Pali" +
-            "Wanda Parsons (01931) 351968 Nullam.ut@velitin.ca Rum" +
-            "Hilda Levy (028) 9688 8144 odio.auctor@accumsaninterdumlibero.co.uk Shawinigan" +
-            "Camille Little (01934) 41188 erat.eget@magna.co.uk Pointe-du-Lac" +
-            "Cameran Lamb (013896) 97173 Fusce.aliquet@variusultricesmauris.co.uk Wolfville" +
-            "Ariana Fowler 0992 295 7191 non@dignissimMaecenas.co.uk San Rafael" +
-            "Germaine Meyers 055 9407 7364 torquent@ultricies.edu Ponoka" +
-            "Evelyn Grant (0115) 452 5289 nibh@quislectus.co.uk Hamburg" +
-            "Alea Shelton (01859) 10515 nulla.Integer.urna@fringillaporttitorvulputate.co.uk Morrinsville" +
-            "Deanna Best (01925) 749888 ullamcorper.nisl.arcu@Morbi.ca Bosa" +
-            "Ciara Holland 076 8184 9217 metus.In@Mauris.co.uk Vegreville" +
-            "Sade Graves 0981 895 3416 quis.tristique@nequeMorbi.edu Hof" +
-            "Dakota Slater (022) 2809 6060 vel@telluseu.net Gorbea" +
-            "Cally Conway 056 6442 8976 risus.Donec@massaVestibulumaccumsan.net Kingussie" +
-            "Ivy Bridges (01390) 362274 cursus.diam.at@Vivamus.org Vitry-sur-Seine" +
-            "Keiko Vasquez 0800 637578 Vivamus.sit.amet@orci.edu Mesa" +
-            "Eugenia Mason (01897) 29989 dis@velitAliquamnisl.com Vernon" +
-            "Pearl Moss (0114) 143 4726 tellus@erosProinultrices.co.uk Cambridge" +
-            "Xantha Mack 0800 626 7655 felis.Donec@aultriciesadipiscing.ca Edam" +
-            "Aimee Haley 076 2343 5896 auctor@Mauris.edu Uitkerke" +
-            "Lucy Stafford 055 7164 6348 et@eumetusIn.net Mayerthorpe" +
-            "Sierra May 07624 263652 neque.et.nunc@arcu.edu Anchorage" +
-            "Kalia Hancock (027) 7498 7170 dis@neceuismod.com Mjölby" +
-            "Cameron Stone 0800 135 8495 pellentesque.eget@dictumeu.ca Castel San Niccolò" +
-            "Desiree Camacho 0800 1111 In@nisiCumsociis.org Joliet" +
-            "Jasmine Rosales 056 1299 9850 amet.luctus.vulputate@mus.co.uk Morgex" +
-            "Maggie Atkinson 07085 619068 magna.nec@nislelementumpurus.ca Gondiya" +
-            "Sydnee Vang 0894 081 3339 nunc.risus@ultrices.ca Canterano" +
-            "Alika Garcia (0110) 164 3404 sollicitudin.orci.sem@tellus.edu Solingen" +
-            "Audrey Kaufman 0804 296 0086 Sed.eget@eros.com Miranda" +
-            "Riley Valenzuela 0500 723497 accumsan@augueac.org Châlons-en-Champagne" +
-            "Adrienne Mathews 0800 1111 magna@aliquetmetusurna.com Jumet" +
-            "Hadassah Lynch 055 6189 0259 neque.venenatis.lacus@gravidaPraesenteu.com Hamilton" +
-            "Allegra Dixon 0845 46 41 imperdiet.ornare.In@quispedePraesent.org Presles" +
-            "Gretchen Ball 0800 166 6580 tortor.dictum@malesuadaiderat.com Guntur" +
-            "Mercedes Garza 056 7478 1990 euismod.mauris@Cras.edu Francavilla Fontana" +
-            "Kathleen Romero 07388 486341 Cras.vulputate.velit@famesac.net Isola del Gran Sasso d'Italia" +
-            "Joelle Burton 0500 340113 urna.Ut@Inatpede.ca Jackson" +
-            "Tashya Barrera (0141) 909 6538 tristique@nuncrisus.edu Dubbo" +
-            "Nicole Gregory (01010) 02244 aliquet.Phasellus@ante.edu Emden" +
-            "Minerva Parsons 0971 347 7087 odio@etnetuset.net Rosenheim" +
-            "Shelley Hale 056 3940 1855 egestas.Duis.ac@magnaPraesent.co.uk Kortrijk" +
-            "Lael Osborn 07701 189978 non@interdumligula.org Lübeck" +
-            "Rinah Ross 070 3885 8017 Mauris@malesuadavel.co.uk Mühlheim am Main" +
-            "Isabelle Erickson 0372 669 1072 sollicitudin@Donecluctusaliquet.net Lincoln" +
-            "Halee Bernard (016977) 0233 nec@duiSuspendisse.org Mal" +
-            "Pandora Bell 07624 568917 semper.tellus@eratvitae.co.uk Kalgoorlie-Boulder" +
-            "Chelsea Vargas (01643) 33412 ante@VivamusnisiMauris.com Imst" +
-            "Shafira Nixon 07624 087175 in@euismod.ca Driekapellen" +
-            "Bertha Nelson 0800 415119 In@Curabitursedtortor.net Rio Verde" +
-            "Helen Carter 07916 049237 hendrerit.id.ante@Duisgravida.org Puerto Montt" +
-            "Madeline Good (017187) 85467 massa.Suspendisse.eleifend@non.co.uk Terni" +
-            "Sydney Hughes 076 6334 5393 nunc.ullamcorper@neque.ca Barahanagar" +
-            "Fiona Noel (016977) 7074 est.Mauris.eu@quamdignissim.co.uk Waiheke Island" +
-            "Maisie Graham 0800 139993 Sed.id@necante.co.uk Dijon" +
-            "Germaine Brooks 0302 964 6397 ullamcorper@temporlorem.co.uk Ranst" +
-            "Gwendolyn Stephenson (0121) 508 7000 libero.Proin@tristique.co.uk Lasne-Chapelle-Saint-Lambert" +
-            "Minerva Justice 0500 218264 risus@Suspendissenon.edu North Cowichan" +
-            "Joan Tyler (0191) 405 8266 elit.Curabitur@facilisismagna.ca Sittard" +
-            "Phyllis Mathews (01622) 238340 ac@Donecfeugiatmetus.com Castelbuono" +
-            "Lacey Ortega 0370 539 3423 hendrerit.neque.In@lorem.net Jolanda di Savoia" +
-            "Jeanette Berg 0845 46 45 enim.diam@tincidunt.ca San Martino in Pensilis" +
-            "Brynne Holt 07304 543587 id.enim@temporeratneque.com Philadelphia" +
-            "Xandra Little 055 8256 4039 Etiam@parturientmontes.org Bad Nauheim" +
-            "Quemby Waters 07624 552770 eu.tellus@penatibus.ca Bonnyville" +
-            "Jessica Richardson (016977) 1368 dictum.magna.Ut@acarcu.edu Williams Lake" +
-            "Athena Greene 07624 582787 adipiscing.non@etrutrum.org Calera" +
-            "Alika Palmer (0101) 285 8741 orci.luctus.et@morbitristiquesenectus.co.uk Curitiba" +
-            "Callie Wall 055 4572 5553 Morbi.metus.Vivamus@Donec.co.uk Turrialba" +
-            "Ocean Knapp 0800 475 1597 natoque@augueidante.ca Les Bons Villers" +
-            "Cailin Vance (0110) 915 5385 Lorem.ipsum.dolor@magnis.org Heist-aan-Zee" +
-            "Delilah Conner 070 5760 4445 Curae.Phasellus.ornare@loremfringilla.com Lossiemouth" +
-            "Yuri Cochran 0800 1111 sed.dolor.Fusce@vitaediam.org Rockingham" +
-            "Destiny Hamilton 056 4319 5840 quis@Nullatempor.co.uk Baranello" +
-            "Ava Nolan 0321 471 2222 quis@ridiculusmus.net Torgnon" +
-            "Hilary Willis 070 8125 5491 faucibus@nulla.net Sangli" +
-            "Jenna Owens 07917 564744 nec.tellus@Fusce.co.uk Düsseldorf" +
-            "Carly Marsh 07015 676248 sagittis@hendreritid.org Parndorf" +
-            "Quintessa Kirby 070 3296 1629 tristique@et.ca Springfield" +
-            "Montana Hull (016977) 3710 vel.mauris.Integer@non.org Livo" +
-            "Catherine Reyes (01089) 452406 molestie@etarcu.com Fontanellato" +
-            "Summer Rice (01187) 486652 justo@et.org Radom" +
-            "Christine Mccoy 0800 152 5114 vel.arcu.eu@lobortis.net Rochester" +
-            "Alexa May 070 1215 1314 ultricies.dignissim@dolorsitamet.edu Pointe-Claire" +
-            "Myra Rodgers 070 4681 9771 sit@ut.net Drayton Valley" +
-            "Desirae Matthews (0101) 628 7979 Nulla@egetlaoreet.ca Dieppe" +
-            "Francesca Knowles (01693) 853716 volutpat.Nulla@magnaetipsum.co.uk Broken Arrow" +
-            "Quemby Rich 0845 46 42 vestibulum.nec@eunulla.edu Red Deer" +
-            "Mara Harrison 056 4589 0890 ut.eros.non@maurisIntegersem.org Baton Rouge" +
-            "Kitra Solis (0114) 741 5753 Quisque@Quisquefringillaeuismod.co.uk Broken Arrow" +
-            "Sandra Larson 07098 082333 fermentum@vitaenibh.net Nîmes" +
-            "Iola Cash 07624 092172 tellus.lorem.eu@vehiculaPellentesque.edu Caprino Bergamasco" +
-            "Kitra Sanchez 0800 674733 Phasellus@ipsumCurabiturconsequat.ca Wollongong" +
-            "Emily Keith 055 2769 6445 arcu@consectetuerrhoncusNullam.com Kent" +
-            "Kessie Schroeder 0967 691 5385 auctor.Mauris.vel@acarcuNunc.org Glabais" +
-            "Kaitlin Fernandez (020) 6003 1394 Donec@erat.edu Parbhani" +
-            "Doris Vaughn (0118) 591 3483 tincidunt.vehicula.risus@Proinegetodio.ca Sotteville-lès-Rouen" +
-            "Glenna Witt (017562) 27891 dis@Inmipede.org Soye" +
-            "Emma Howe (0117) 274 2390 luctus@dictum.net Zonhoven" +
-            "Blair Banks 070 5106 5627 metus.Vivamus.euismod@sagittis.edu Kingston-on-Thames" +
-            "Jorden Durham 07624 691948 molestie.in.tempus@tristiquepharetra.com Nampa" +
-            "Blythe Underwood (028) 0051 0929 iaculis.aliquet@sed.edu St. Thomas" +
-            "Eleanor Mosley 055 9116 9366 Vivamus.non.lorem@mauris.edu Tresigallo" +
-            "Clementine West 076 5845 0260 ac.turpis.egestas@Nuncmauris.com Acciano" +
-            "Eleanor Hudson (013649) 59185 Sed.eget@blanditcongueIn.net Orsara di Puglia" +
-            "Indigo Shields 0800 744604 ipsum@pharetra.co.uk Dorgali" +
-            "Galena Hughes 070 5628 7648 ut.erat@neccursus.ca Kampenhout" +
-            "Cassidy Travis 0845 46 40 est.Mauris@Aliquam.net Gateshead" +
-            "Virginia Mason 0845 46 46 lorem@nondapibus.ca Istres" +
-            "Cecilia Ferguson 070 0771 0692 erat.Vivamus.nisi@natoquepenatibuset.ca Böblingen" +
-            "Eleanor Harris (0114) 633 1360 Proin.nisl.sem@Curabituregestasnunc.com Bazel" +
-            "Illana Shepherd (01385) 30910 aliquam.eros@adipiscingenim.ca Beerst" +
-            "Kaitlin Sharpe 0849 458 7485 non@lacinia.com Flin Flon" +
-            "Beatrice Day 07624 875300 netus.et@arcuvel.com Fort Worth" +
-            "Naomi Cunningham 055 5974 6779 Morbi.neque@Vestibulumanteipsum.edu Palermo" +
-            "Ruth Moses (0114) 392 6720 erat@Aliquam.edu Birmingham" +
-            "Jaime Hopper 07624 169480 libero.est@magnaSedeu.com Aisemont" +
-            "Bertha Mann 0963 581 1773 placerat@tristiquepharetraQuisque.edu Nerem" +
-            "Melissa Gomez 056 7293 3021 parturient.montes@In.com Soye" +
-            "Ainsley Parks 0866 858 0276 mi.fringilla.mi@ut.com Fratta Todina" +
-            "Virginia Lang 0845 46 44 est.Mauris@enimNuncut.edu Chantemelle" +
-            "Ila Harper 0845 46 48 molestie.dapibus@seddictum.edu Les Bons Villers" +
-            "Lee Wilder 07624 189677 sapien.Aenean.massa@etcommodoat.ca Lakeland County" +
-            "Stacy Webster 0800 1111 Fusce.dolor.quam@velconvallisin.edu Antuco" +
-            "Isadora Joseph (027) 3824 1305 vulputate.eu@felisNullatempor.org Dorval" +
-            "Alea Guzman (01571) 95927 Donec@erat.net Pickering" +
-            "Leandra Shepherd 07624 116495 Nam.nulla@leoin.com Reading" +
-            "Aiko Donaldson 0303 541 3532 ligula@Innecorci.co.uk Wick" +
-            "Cathleen Mcdowell (016977) 4272 In.nec.orci@molestiepharetranibh.edu Rossignol" +
-            "Indigo Cantrell 076 4382 9948 Maecenas.malesuada.fringilla@dolor.org Sint-Martens-Bodegem" +
-            "Beverly Reilly (0151) 098 3418 pede@erategettincidunt.net Fraserburgh" +
-            "Leandra Decker 070 3077 7528 fringilla.est.Mauris@neceleifendnon.net Bowling Green" +
-            "Angela Woodard 07624 305700 fermentum.arcu@nonnisi.ca Zerkegem" +
-            "Savannah Castro (016977) 8937 Etiam@ligula.org Carleton" +
-            "Hollee Stark 0800 989 0403 gravida@sociosqu.edu Porretta Terme" +
-            "Demetria Gonzales 0800 122836 rutrum@dictum.ca Coquitlam" +
-            "Ina Rivers 0826 825 8806 neque@lobortisClassaptent.com Melilla" +
-            "Imelda Wilkerson 0800 1111 feugiat.nec@Duisdignissim.org Ribnitz-Damgarten" +
-            "Mariko Watson (01820) 91473 nec.luctus@facilisisfacilisis.org Fontaine-Valmont" +
-            "Alfreda Fox (0161) 505 2769 quis.massa@arcuSedet.edu Tongerlo" +
-            "Laura Boyer 0500 886398 tellus.Nunc@Curabitur.ca Bargagli" +
-            "Cara Mcleod 0800 950 6544 Suspendisse.eleifend.Cras@scelerisquenequesed.ca Imst" +
-            "Odette Baird 0800 067654 turpis.nec@pedeNunc.com Monstreux" +
-            "Hilda Cummings 076 3929 0120 egestas@acnullaIn.com Galzignano Terme" +
-            "Nerea Wade (016977) 8450 Maecenas.libero@lobortisultrices.com Chelsea" +
-            "Idola Workman (0114) 121 3175 egestas.a.dui@NullafacilisisSuspendisse.ca Folx-les-Caves" +
-            "Sonia Hahn (01111) 317928 ut@ultrices.com Altach" +
-            "Moana Clements (0113) 521 1388 sed@quis.ca Portsmouth" +
-            "Brittany Lester 056 0424 3586 Integer.vulputate@et.ca Linton" +
-            "Jenna Espinoza 0500 855288 Maecenas@feugiatplaceratvelit.net Cerchio" +
-            "Charde Powell 0395 732 6493 Aenean@Proin.net Paradise" +
-            "Iona Walton (0111) 925 9148 adipiscing.elit@ametdapibus.edu San Cesario di Lecce" +
-            "Cameron Wilcox 07196 574529 velit.dui@elitpharetraut.net Titagarh" +
-            "Gwendolyn Walters 0343 081 8534 lobortis@quisdiam.edu Cape Breton Island" +
-            "Kameko Hewitt (015192) 50969 velit.in@ultricesposuerecubilia.com Angleur" +
-            "Alice Joyner 055 8960 3696 dui.nec@Uttinciduntorci.co.uk Ponte San Nicolò" +
-            "Imani Santana 07624 358679 Cum.sociis@velitPellentesque.edu Nelson" +
-            "Carol Albert (029) 0001 3450 eu.sem@atfringilla.org Opheylissem" +
-            "Amethyst Ellison (024) 5122 9525 dictum@nibhPhasellus.co.uk Hulste" +
-            "Sheila Walton 0800 456077 pellentesque@egetvarius.net Harrisburg" +
-            "Indira Garrison 056 4760 2993 posuere.at@perconubia.edu Cisnes" +
-            "Tara Bradshaw (011429) 24082 erat.in.consectetuer@Sed.co.uk Embourg" +
-            "Kevyn Stevenson 07624 702264 eu@lacusQuisque.edu Mainz" +
-            "Ariel Nielsen (020) 2609 8789 eget.mollis@ridiculusmus.com Paine" +
-            "Chelsea Clark 076 8209 9598 parturient.montes.nascetur@ligulaDonecluctus.org North Bay" +
-            "Sonia Buckley (0117) 339 8426 amet@fermentum.ca Fraser-Fort George" +
-            "Paula Davidson 0800 1111 fringilla.purus@Aeneanegetmetus.co.uk Petacciato" +
-            "Sylvia Oneil 0500 952754 Phasellus.dapibus@CrasinterdumNunc.net Chandannagar" +
-            "Giselle Fleming (0110) 075 9118 eu@elita.com Dietzenbach" +
-            "Aimee Moody (01582) 01208 at.egestas.a@tristique.net Irricana" +
-            "Gail Rosario (0110) 640 2306 pede.Suspendisse@volutpatNulla.com Namen" +
-            "Whoopi Sharpe 0863 296 7004 diam@Suspendissetristiqueneque.ca Vedrin" +
-            "Judith Mack 070 7687 7888 Donec.nibh@rutrumjusto.ca Ternitz" +
-            "Helen Mckee (023) 3562 7053 vehicula.Pellentesque.tincidunt@temporeratneque.co.uk Canmore" +
-            "Kirestin Ballard (01343) 604851 Donec.consectetuer@ProindolorNulla.ca Nagpur" +
-            "Brianna Pitts 070 8440 6981 eu@temporarcuVestibulum.net Chiniot" +
-            "Daryl Baker 0500 000711 Morbi.non@Quisque.com Seilles" +
-            "Carla Bryant 070 4282 2093 Mauris.magna@vehiculaaliquetlibero.co.uk Freital" +
-            "Rina Nixon 076 0303 9562 Cras.vulputate.velit@utcursus.ca Tiel" +
-            "Ginger Jennings 070 5712 6754 leo@ligula.co.uk Burnpur" +
-            "Cecilia Yates (0110) 316 7904 sollicitudin.adipiscing.ligula@aliquam.co.uk Asse" +
-            "Belle Meyer 0800 249 5308 Donec.egestas@blanditcongue.org İmamoğlu" +
-            "Rebekah Farley (01394) 289332 eget.lacus@convallisante.co.uk Morrinsville" +
-            "Remedios Hernandez 07624 301755 Donec.est@Fusce.edu Guadalajara" +
-            "Breanna Beck 076 3963 3445 nunc.sit@enim.com Saint-Prime" +
-            "Aurelia Miller 070 9147 4394 lorem.ac@ametorciUt.co.uk Matamata" +
-            "Mara Yang (0118) 405 4779 dui.nec.urna@Namnulla.org Wolfenbüttel" +
-            "Candace Roberson 0500 874367 non.justo@lacus.net Stony Plain" +
-            "Adara Le 056 2666 4455 cubilia.Curae.Phasellus@atpretium.edu Sant'Egidio alla Vibrata" +
-            "Aspen Lawson (021) 3113 7798 consequat.purus@ipsumdolorsit.edu Lexington" +
-            "Ursula Burgess 07624 179190 ac.eleifend.vitae@orciin.org Rathenow" +
-            "Dara Meyers (025) 0943 3346 dolor@justo.com Traralgon" +
-            "Galena Joyce (01080) 558650 id@nonummy.org Huntsville" +
-            "Jada Reese (0117) 739 3237 nec.mauris.blandit@auctorodioa.ca Conca Casale" +
-            "Amy Maynard 076 8426 2119 sit@Aliquam.net Geel" +
-            "Sydney Farmer 055 4135 3834 natoque.penatibus.et@etnetus.edu Pinneberg" +
-            "Dai Drake (025) 3091 8842 Cras.lorem@Maurisnondui.org Exeter" +
-            "Janna Sanchez 0800 087282 erat.eget.ipsum@Nullam.org Sart-Eustache" +
-            "Maite Schwartz 056 8184 8460 pharetra.sed.hendrerit@vitaedolor.org Longvilly" +
-            "Amity Coffey 0937 570 2428 laoreet.lectus@dolorsitamet.ca Llangefni" +
-            "Willa Snyder (020) 4175 7353 ullamcorper.eu.euismod@placerat.net Pavone del Mella" +
-            "Regan Patton 0800 086128 elit.Curabitur.sed@Etiamvestibulum.com Paradise" +
-            "Karly Keller (018284) 65790 facilisis.vitae@dictumProin.org Orp-Jauche" +
-            "Ivy Dudley 070 8060 2941 Donec.non@Etiamvestibulummassa.net Borås" +
-            "Hope Hoffman 0845 46 43 vulputate.lacus.Cras@hendreritaarcu.ca Township of Minden Hills" +
-            "Alma Cleveland (0112) 149 7083 ante.dictum.cursus@ad.org Warri" +
-            "Hillary Calhoun (0119) 984 5378 justo.sit.amet@molestiepharetranibh.co.uk Hampstead" +
-            "Blossom Kim (016977) 3756 pellentesque.eget@egestas.edu Belsele" +
-            "Judith Graves 0851 556 3717 Curabitur@dolor.ca Vanderhoof" +
-            "Xerxes Lyons 070 7165 5290 nunc@magnaDuis.co.uk Aurangabad" +
-            "Dominique Parrish 0800 535186 nonummy.Fusce@ultricesDuisvolutpat.net Scarborough" +
-            "Yael Weeks (01813) 26044 nulla@Crasvulputate.com Fairbanks" +
-            "Nicole Summers (01545) 082490 magna@ametdiameu.edu Itapipoca" +
-            "Jana Young 07996 242955 tristique@iaculisneceleifend.net Tiegem" +
-            "Hollee Pruitt 0800 313 9810 faucibus.leo@Seddictum.org Bhopal" +
-            "Kylie Gates 056 2716 8367 luctus.aliquet.odio@utipsum.com San Massimo" +
-            "Ramona Cochran 07722 213674 purus.accumsan@luctuslobortisClass.com Cerro Navia" +
-            "Charissa Rosario 070 4770 6703 amet.orci@nonenimcommodo.co.uk Innisfail" +
-            "Madaline Blanchard (027) 5118 9913 eleifend.nunc@uteros.org Lamont" +
-            "Jemima Ayers 076 0902 8977 urna.Ut.tincidunt@dis.com Sonnino" +
-            "Quinn England 0800 080 0584 et.lacinia@torquent.net Brampton" +
-            "Susan Simon 0800 853 9239 magnis.dis.parturient@milorem.org Marbais" +
-            "Veda Moreno 055 8837 4859 ligula@inhendrerit.net Madrid" +
-            "Brielle Buckner 0800 1111 egestas.a.dui@dictumcursus.org Fürstenwalde" +
-            "Dorothy Brewer (012409) 17477 consequat.purus.Maecenas@convalliserat.net Mansfield-et-Pontefract" +
-            "Roanna Frank 0500 534552 cursus.vestibulum@atrisusNunc.com Serramonacesca" +
-            "Quin Barron (01902) 16701 lacus.Nulla.tincidunt@imperdietnon.net Heusden-Zolder" +
-            "Geraldine Nash (016977) 5728 dui.augue.eu@aodiosemper.co.uk Pessac" +
-            "Hadley Lambert (0114) 565 6236 sed.facilisis.vitae@Integer.co.uk Jandrain-Jandrenouille" +
-            "Chelsea Hubbard 056 2585 7846 in.sodales.elit@tempuseuligula.ca Zaltbommel" +
-            "Yetta Clemons (016977) 1475 et.magnis.dis@quamelementumat.co.uk Knokke" +
-            "Jenna Humphrey 056 5627 7953 Cras.dictum@dignissimpharetra.edu Maple Creek" +
-            "Genevieve Rollins (0101) 162 9782 sed.hendrerit@Cumsociis.org Mazzano Romano" +
-            "Miranda Moon (021) 7795 7957 sagittis.semper@tristiquepellentesque.net Saint John" +
-            "Willow Castillo 070 7358 9294 felis.Nulla.tempor@musDonecdignissim.com Montalto Uffugo" +
-            "Anastasia Mueller (016977) 1314 a@lacuspedesagittis.com Morrinsville" +
-            "Dara Owens 076 6868 7201 tellus.Phasellus@nuncsed.co.uk Waterbury" +
-            "Hanae Rice 0912 095 9668 nunc@aliquetliberoInteger.co.uk Rum" +
-            "Rama Wooten 076 0401 2139 feugiat.tellus@estmaurisrhoncus.co.uk Baidyabati" +
-            "Gisela Solis 070 3439 4629 non@auctorvelit.com Chambord" +
-            "Jana Robinson 07013 834562 libero.Proin@tinciduntnibhPhasellus.org Roccanova" +
-            "Claire West 0800 1111 orci.Ut.sagittis@quamelementum.co.uk Ligosullo" +
-            "Leigh Baldwin 0327 753 1329 quis@euismodenimEtiam.com Teralfene" +
-            "Chastity Mullen (0112) 945 1682 felis.eget.varius@lacinia.ca Mariquina" +
-            "Cara Mooney (0113) 735 6895 felis.purus@fermentumvelmauris.com Palagano" +
-            "Zenia Mcmillan (015652) 02443 eu.turpis.Nulla@nascetur.ca Civitacampomarano" +
-            "Portia Hill (01983) 17408 a.arcu.Sed@arcuvelquam.org Colobraro" +
-            "Brynne Brewer 0800 832 1988 amet@vitaerisus.edu Athens" +
-            "Kiayada Hendricks 07779 546753 interdum@dignissimtemporarcu.co.uk Lachine" +
-            "Lillith Reese 07624 007787 dolor.tempus@ultriciesdignissim.com Freux" +
-            "Keelie Gallagher (01586) 42913 dapibus.ligula@sit.net Campbelltown" +
-            "Ariana Keith 0845 46 40 ipsum.dolor.sit@auctorveliteget.com Karimnagar" +
-            "Jessica Koch 0845 46 42 nec.ante@Praesenteunulla.ca Osgoode" +
-            "Aileen Rodriguez 0845 46 46 mattis.velit.justo@Maurismolestie.com Portico e San Benedetto" +
-            "Germane Brewer 076 5624 2680 malesuada.ut.sem@Lorem.net El Bosque" +
-            "Willow Park 07196 875331 Vivamus.rhoncus.Donec@ProinvelitSed.org Bever Bievene" +
-            "Yen Stevenson 07624 310007 in@Sedeu.edu Imphal" +
-            "Ivana Morse (01207) 692187 eu.metus@quis.edu Pickering" +
-            "Chanda Donaldson 055 5125 3654 sit.amet.luctus@vellectus.ca Vidisha";
+            " Burke Tucker 076 1971 1687 et.euismod.et@ut.edu GozŽe" +
+            " Grady Brock (011307) 16843 cursus.et@commodo.org Alcobendas" +
+            " Harding Lloyd 0800 1111 neque.In.ornare@mauris.co.uk Beauvais" +
+            " Zachary Hendrix 07624 035724 ipsum.non.arcu@auctorullamcorper.ca Redcliffe" +
+            " Logan Simmons (01367) 073346 ac.mattis.velit@etmagnisdis.com Gierle" +
+            " Colby Young 0963 451 3377 In.scelerisque.scelerisque@elitelitfermentum.net Driffield" +
+            " Peter Mitchell (01256) 43239 ipsum.porta@arcu.edu Duncan" +
+            " Hamilton Curry (0181) 775 6791 et@dignissimmagnaa.org Chemnitz" +
+            " Nero Stephens 0845 46 42 pellentesque.Sed@Craseutellus.edu Sachs Harbour" +
+            " Tanner Bruce 0800 1111 elementum.sem@maurisIntegersem.org Kungälv" +
+            " Akeem Harrington (0111) 759 1390 ac.arcu.Nunc@enimnislelementum.com Gävle" +
+            " Benjamin Glenn (016977) 3597 est.mollis@eu.co.uk Chippenham" +
+            " Zachary Sampson 0800 1111 tempor.erat.neque@consectetueradipiscing.org Kota" +
+            " Sean Brown 0317 398 0597 nibh.Donec.est@nonquamPellentesque.co.uk Castel San Niccolò" +
+            " Ferris Mckinney 0800 1111 leo.elementum@sedconsequat.net Langford" +
+            " Chancellor Cabrera 0383 300 9486 Etiam.vestibulum@Nam.edu Bauchi" +
+            " Keith Long 0800 364 7432 Integer.mollis.Integer@aliquetlobortisnisi.co.uk The Hague" +
+            " Dalton Richardson 0395 522 3568 lacus.Quisque.purus@Integeraliquamadipiscing.com Calvera" +
+            " Clarke Langley 0398 596 6834 porttitor.eros@velitPellentesque.ca Fino Mornasco" +
+            " Eaton Dyer 055 1441 9535 egestas.lacinia.Sed@Sedeueros.ca Lac-Serent" +
+            " Tyrone Pena (01329) 37079 nec.ligula@lobortisClassaptent.com Tuscaloosa" +
+            " Curran Becker 056 1678 9780 nulla@Nunccommodo.org Bruck an der Mur" +
+            " Damon Bryant 0801 483 9983 est.arcu@est.ca Baton Rouge" +
+            " Ryan Cline 0845 46 46 euismod.est.arcu@augue.co.uk Cockburn" +
+            " Judah Wheeler 056 4229 0035 risus.Donec@Quisquefringilla.net Kleinmachnow" +
+            " Ciaran Dotson (016977) 4778 id@sitamet.edu Rotem" +
+            " Nash Sharp (016977) 6083 amet@fringillaDonec.org Carovilli" +
+            " Benedict Bryant 0873 083 9083 non.sapien.molestie@blanditNamnulla.com Gravelbourg" +
+            " Tarik Hansen (023) 7618 2932 dui.lectus.rutrum@Sedauctor.net Afsnee" +
+            " Ulric Justice (0115) 392 1246 lacus@Loremipsum.net Matagami" +
+            " Ray Davis 0800 848169 semper@Phasellusdapibusquam.ca Tongerlo" +
+            " Beck Smith 07624 185893 nascetur.ridiculus.mus@semvitaealiquam.ca Rancagua" +
+            " Jelani Stafford 0800 049344 faucibus@nibh.co.uk Leersum" +
+            " Philip Lopez 0845 46 49 ac@orciadipiscingnon.co.uk Grand Island" +
+            " Jameson Arnold 0988 427 2322 nisl@blanditviverra.ca Tuscaloosa" +
+            " Burton Bishop (01025) 570147 semper.dui.lectus@commodoat.org Los Sauces" +
+            " Preston Monroe 0325 630 0384 neque@sed.com Burnie" +
+            " Joseph Eaton 0887 569 9679 malesuada@urnaNunc.co.uk La Cruz" +
+            " Carl Clements 07624 940647 et@mauris.edu Avise" +
+            " Hoyt Terry (0111) 334 8178 lorem@Phasellusnulla.net Fort St. John" +
+            " Octavius Espinoza (01629) 05356 Nullam.velit.dui@cursusluctus.edu Logan City" +
+            " Alexander Villarreal 07624 426932 ornare@neceleifendnon.com Bhuj" +
+            " Hayden Holmes 0360 901 1201 accumsan.laoreet@utipsumac.ca Weißenfels" +
+            " Sean Mueller 07638 352622 et.ultrices.posuere@Curabitur.ca Kerkhove" +
+            " Malcolm Richardson 076 9535 9828 urna.Ut.tincidunt@elitfermentumrisus.co.uk Cleveland" +
+            " Stewart Spence (023) 6496 7274 et.ultrices.posuere@dolorelit.org Calestano" +
+            " Quinlan Conrad (016977) 5533 tellus.Aenean@massaIntegervitae.edu Raipur" +
+            " Conan Blanchard (015246) 18321 dignissim.Maecenas.ornare@tincidunttempus.org Neuruppin" +
+            " Tate Trujillo 0387 316 9960 mauris.erat@vitaesodales.net Wood Buffalo" +
+            " Chadwick Bradford (0191) 538 2293 non.quam.Pellentesque@Maurisquis.com Edmundston" +
+            " Neville Alvarado (010779) 48043 vel.arcu@nuncQuisqueornare.co.uk Bear" +
+            " Baker Maldonado 0800 380112 sit.amet.luctus@arcuVestibulum.org Pointe-au-Pic" +
+            " Judah Hardy (011296) 66434 ultrices.posuere.cubilia@rhoncusid.com Orsogna" +
+            " Keegan Henson 0309 312 4037 eget@tempus.ca Habra" +
+            " Simon Beard (01306) 069594 In.lorem.Donec@diam.ca Swindon" +
+            " Hop Santiago 0855 726 9053 tortor.nibh.sit@sodaleselit.net Saint-Mard" +
+            " Carson Hoover 0320 958 4039 magna.tellus.faucibus@risus.com Patarrá" +
+            " Jelani Jefferson 07624 127835 metus@Donecsollicitudinadipiscing.co.uk Termes" +
+            " Dane Clark 076 3329 9156 sit@Integeraliquamadipiscing.ca San Diego" +
+            " Abraham Bryan 0311 770 4531 velit.in@tellusSuspendisse.ca Chartres" +
+            " Otto Miller (01009) 642663 orci@ipsumPhasellusvitae.ca Turnhout" +
+            " Talon Davidson 070 7593 9470 odio.Aliquam@Curabiturdictum.ca Minto" +
+            " Reed Patel 055 3390 4318 pharetra@Aliquamfringillacursus.co.uk San Cristóbal de la Laguna" +
+            " Herman Yang 0996 157 4214 elit.pretium@Nulla.edu Berlin" +
+            " Justin Horton 0800 249 3179 sagittis@lobortisnisinibh.ca Cape Breton Island" +
+            " Flynn Robertson 056 9705 7346 Lorem@cursus.co.uk Moulins" +
+            " Baker Lane 055 0842 5343 tincidunt@mi.ca Grosseto" +
+            " Elliott Neal (0119) 359 1626 non.arcu.Vivamus@cursusdiamat.edu Nueva Imperial" +
+            " Ray Yang 07624 181309 Nullam.enim@justosit.ca Lacombe County" +
+            " Ethan Albert (014674) 49440 cursus.luctus.ipsum@Quisquefringillaeuismod.ca Duffel" +
+            " Daquan Cash 070 0820 0781 Donec@convallisdolor.net Kohima" +
+            " Marshall Good (0121) 467 5361 Ut.nec.urna@felisadipiscing.ca Morena" +
+            " Edward Dean 0817 789 5834 eu.metus@Sed.ca West Valley City" +
+            " Rooney Brooks (0112) 337 7340 ornare.lectus.ante@malesuadamalesuada.com Evansville" +
+            " Judah Becker (01256) 779536 diam@ut.net Mörfelden-Walldorf" +
+            " Keaton Hahn 07624 524330 sit.amet@insodaleselit.edu Bollnäs" +
+            " Craig Mejia 07841 125712 consequat.enim@Vestibulumante.net Paupisi" +
+            " Kermit Wright 0800 1111 ut.aliquam@Loremipsum.ca Fresno" +
+            " Vernon Erickson 056 7788 3683 vulputate@quis.edu Cuglieri" +
+            " Kennedy Wade 0800 1111 auctor.nunc@utdolordapibus.net Radebeul" +
+            " Sebastian Gibson (0161) 575 6673 odio.auctor.vitae@quis.net Nieuwkerken-Waas" +
+            " Brennan Klein 056 1403 9853 faucibus@maurisa.edu Exeter" +
+            " Ryder Morse 0500 343447 nibh@incursuset.edu New Westminster" +
+            " Ignatius Mullen 0845 46 44 elit.fermentum.risus@utquam.com Tavigny" +
+            " Malachi Stanton (016969) 67601 interdum.Nunc@Donecporttitortellus.net Koersel" +
+            " Tanek Sloan 07624 351205 cubilia@laoreetposuere.ca Tiverton" +
+            " John Meyer 07475 360711 Nunc@duiaugue.net New Westminster" +
+            " Tarik Hunt (01084) 044437 feugiat@pellentesque.ca Sedgewick" +
+            " Tate Spears 055 5012 9185 euismod@parturient.com Croydon" +
+            " Stuart Hopkins 056 1376 7135 pede@semperdui.org Allahabad" +
+            " Aidan Ray 07624 271603 sem.mollis@anequeNullam.co.uk Valleyview" +
+            " Griffith Nieves (0121) 592 3029 Vivamus@arcuSed.net Spiere" +
+            " Jared Kramer 0845 46 45 Proin@mattisvelit.net Haldia" +
+            " Felix Stevenson (0191) 546 2187 pellentesque.tellus@utpharetrased.co.uk Paisley" +
+            " Wade Cross 0800 183220 dolor.quam@vehiculaet.com Hugli-Chinsurah" +
+            " Lee Crane 056 6498 9876 nascetur@risusDonec.org Igboho" +
+            " Zahir Buchanan (0191) 909 2062 nunc.sed.pede@nec.edu Lac-Serent" +
+            " Brian Meyer (016977) 0358 mollis.nec@seddictumeleifend.co.uk Houston" +
+            " Tarik Leach 055 8679 2768 risus@Pellentesqueultricies.net Llaillay" +
+            " Logan Gamble 0800 1111 ac.arcu.Nunc@fermentum.edu Viggiano" +
+            " Isabelle Mcdowell (01304) 321760 Nam.nulla.magna@mollisDuissit.ca Kiel" +
+            " Leila Logan 070 1742 9174 pharetra.sed.hendrerit@lorem.net Fort Laird" +
+            " Cameran Robertson 0845 46 40 vulputate@estMauriseu.org Laja" +
+            " Ciara Mcclure 07476 375018 aliquam@eliteratvitae.edu Schagen" +
+            " Sydnee Williamson (015122) 34852 egestas.a@aliquet.ca Hagen" +
+            " Fay Cobb (0141) 701 4563 felis.eget@sollicitudincommodo.com Marcedusa" +
+            " Anika Graham 07624 978050 lacus@augueeutellus.edu Valley East" +
+            " Callie Mullen 076 6778 6017 egestas@atauctor.co.uk Gallicchio" +
+            " Illana Fitzgerald 0800 394996 dignissim.Maecenas.ornare@erat.ca Quillón" +
+            " Kathleen Hughes (0101) 491 2925 odio.Nam.interdum@etnetus.ca Matamata" +
+            " September Andrews 0827 620 1389 Duis.gravida@orcitinciduntadipiscing.com Sint-Pieters-Leeuw" +
+            " Martina Davidson (012275) 85154 Donec.vitae.erat@Inmi.co.uk Liverpool" +
+            " Hedy Phillips 0800 120 9706 risus@netuset.edu Wolfenbüttel" +
+            " Hilda Hubbard 076 5780 0993 non@lacusNulla.co.uk Henstedt-Ulzburg" +
+            " Beverly Cameron 07380 723139 ultrices.a.auctor@dignissim.edu Lumaco" +
+            " Kirsten Drake 07915 777813 tincidunt.tempus@Craspellentesque.org Freiberg" +
+            " Karleigh Hubbard 0800 593726 Integer.mollis.Integer@Maecenasmalesuadafringilla.net Albiano" +
+            " Aretha Craft (0131) 721 5375 natoque@id.net Hamme" +
+            " Kerry Andrews 056 4028 5526 pharetra@eleifendCrassed.net Columbia" +
+            " Alma Espinoza 0500 215138 montes@Aeneaneuismod.com Giugliano in Campania" +
+            " Yael Jimenez 070 1654 2995 faucibus@DonecfringillaDonec.com Srinagar" +
+            " Miriam Holland 070 7849 6859 a@enimgravida.edu Kitscoty" +
+            " Scarlett Whitley (016552) 76917 cursus.vestibulum@Integeraliquam.net Colombo" +
+            " Aretha Norris 0845 46 48 Donec@ultriciesligulaNullam.edu Bathurst" +
+            " Faith Reyes 0349 153 9269 aliquet@consequatauctornunc.org Cunco" +
+            " Hanna Espinoza (01260) 449000 non.massa.non@cursus.org Ruddervoorde" +
+            " Yen Gibbs 0800 869684 mattis.Integer@acfeugiat.org Colwood" +
+            " Regina Obrien 0800 299789 In.lorem.Donec@ligulaAenean.com Osnabrück" +
+            " Illana Parrish 0800 291 0292 magnis.dis.parturient@elitsedconsequat.co.uk Tumbler Ridge" +
+            " Sigourney Stein (017821) 17943 rhoncus@purusMaecenas.org Geer" +
+            " Martha Daugherty 076 4262 4528 mollis.Integer.tincidunt@aliquetdiam.com Slijpe" +
+            " Piper Figueroa (025) 9423 5980 dis@quispedeSuspendisse.ca Sant'Angelo Limosano" +
+            " Kylan Schmidt 0886 691 4919 Sed.nunc@nequeNullamnisl.ca Tropea" +
+            " Zephr Fox 0800 638 9987 a@auguemalesuada.ca Luttre" +
+            " Clementine Mathews 056 5155 6096 magna.nec.quam@Aliquam.co.uk Sale" +
+            " Amela Sanders 056 5209 8664 pede@pharetrafeliseget.net Rycroft" +
+            " Dorothy Sullivan (018212) 78744 sapien.cursus.in@Donecnon.net Kharagpur" +
+            " Cleo Townsend 070 1931 2864 dolor.dapibus.gravida@Duisvolutpatnunc.net Longchamps" +
+            " Hope Berry 055 4389 2474 ante.bibendum@Morbiquis.ca La Estrella" +
+            " Britanney Ferrell 0800 768856 a@dignissimpharetra.co.uk Trollhättan" +
+            " Kiona Barber (01814) 745705 a@vitaeposuereat.edu Herk-de-Stad" +
+            " TaShya Sparks 0827 428 9203 dolor.Fusce.mi@aliquetmolestie.net Pali" +
+            " Wanda Parsons (01931) 351968 Nullam.ut@velitin.ca Rum" +
+            " Hilda Levy (028) 9688 8144 odio.auctor@accumsaninterdumlibero.co.uk Shawinigan" +
+            " Camille Little (01934) 41188 erat.eget@magna.co.uk Pointe-du-Lac" +
+            " Cameran Lamb (013896) 97173 Fusce.aliquet@variusultricesmauris.co.uk Wolfville" +
+            " Ariana Fowler 0992 295 7191 non@dignissimMaecenas.co.uk San Rafael" +
+            " Germaine Meyers 055 9407 7364 torquent@ultricies.edu Ponoka" +
+            " Evelyn Grant (0115) 452 5289 nibh@quislectus.co.uk Hamburg" +
+            " Alea Shelton (01859) 10515 nulla.Integer.urna@fringillaporttitorvulputate.co.uk Morrinsville" +
+            " Deanna Best (01925) 749888 ullamcorper.nisl.arcu@Morbi.ca Bosa" +
+            " Ciara Holland 076 8184 9217 metus.In@Mauris.co.uk Vegreville" +
+            " Sade Graves 0981 895 3416 quis.tristique@nequeMorbi.edu Hof" +
+            " Dakota Slater (022) 2809 6060 vel@telluseu.net Gorbea" +
+            " Cally Conway 056 6442 8976 risus.Donec@massaVestibulumaccumsan.net Kingussie" +
+            " Ivy Bridges (01390) 362274 cursus.diam.at@Vivamus.org Vitry-sur-Seine" +
+            " Keiko Vasquez 0800 637578 Vivamus.sit.amet@orci.edu Mesa" +
+            " Eugenia Mason (01897) 29989 dis@velitAliquamnisl.com Vernon" +
+            " Pearl Moss (0114) 143 4726 tellus@erosProinultrices.co.uk Cambridge" +
+            " Xantha Mack 0800 626 7655 felis.Donec@aultriciesadipiscing.ca Edam" +
+            " Aimee Haley 076 2343 5896 auctor@Mauris.edu Uitkerke" +
+            " Lucy Stafford 055 7164 6348 et@eumetusIn.net Mayerthorpe" +
+            " Sierra May 07624 263652 neque.et.nunc@arcu.edu Anchorage" +
+            " Kalia Hancock (027) 7498 7170 dis@neceuismod.com Mjölby" +
+            " Cameron Stone 0800 135 8495 pellentesque.eget@dictumeu.ca Castel San Niccolò" +
+            " Desiree Camacho 0800 1111 In@nisiCumsociis.org Joliet" +
+            " Jasmine Rosales 056 1299 9850 amet.luctus.vulputate@mus.co.uk Morgex" +
+            " Maggie Atkinson 07085 619068 magna.nec@nislelementumpurus.ca Gondiya" +
+            " Sydnee Vang 0894 081 3339 nunc.risus@ultrices.ca Canterano" +
+            " Alika Garcia (0110) 164 3404 sollicitudin.orci.sem@tellus.edu Solingen" +
+            " Audrey Kaufman 0804 296 0086 Sed.eget@eros.com Miranda" +
+            " Riley Valenzuela 0500 723497 accumsan@augueac.org Châlons-en-Champagne" +
+            " Adrienne Mathews 0800 1111 magna@aliquetmetusurna.com Jumet" +
+            " Hadassah Lynch 055 6189 0259 neque.venenatis.lacus@gravidaPraesenteu.com Hamilton" +
+            " Allegra Dixon 0845 46 41 imperdiet.ornare.In@quispedePraesent.org Presles" +
+            " Gretchen Ball 0800 166 6580 tortor.dictum@malesuadaiderat.com Guntur" +
+            " Mercedes Garza 056 7478 1990 euismod.mauris@Cras.edu Francavilla Fontana" +
+            " Kathleen Romero 07388 486341 Cras.vulputate.velit@famesac.net Isola del Gran Sasso d'Italia" +
+            " Joelle Burton 0500 340113 urna.Ut@Inatpede.ca Jackson" +
+            " Tashya Barrera (0141) 909 6538 tristique@nuncrisus.edu Dubbo" +
+            " Nicole Gregory (01010) 02244 aliquet.Phasellus@ante.edu Emden" +
+            " Minerva Parsons 0971 347 7087 odio@etnetuset.net Rosenheim" +
+            " Shelley Hale 056 3940 1855 egestas.Duis.ac@magnaPraesent.co.uk Kortrijk" +
+            " Lael Osborn 07701 189978 non@interdumligula.org Lübeck" +
+            " Rinah Ross 070 3885 8017 Mauris@malesuadavel.co.uk Mühlheim am Main" +
+            " Isabelle Erickson 0372 669 1072 sollicitudin@Donecluctusaliquet.net Lincoln" +
+            " Halee Bernard (016977) 0233 nec@duiSuspendisse.org Mal" +
+            " Pandora Bell 07624 568917 semper.tellus@eratvitae.co.uk Kalgoorlie-Boulder" +
+            " Chelsea Vargas (01643) 33412 ante@VivamusnisiMauris.com Imst" +
+            " Shafira Nixon 07624 087175 in@euismod.ca Driekapellen" +
+            " Bertha Nelson 0800 415119 In@Curabitursedtortor.net Rio Verde" +
+            " Helen Carter 07916 049237 hendrerit.id.ante@Duisgravida.org Puerto Montt" +
+            " Madeline Good (017187) 85467 massa.Suspendisse.eleifend@non.co.uk Terni" +
+            " Sydney Hughes 076 6334 5393 nunc.ullamcorper@neque.ca Barahanagar" +
+            " Fiona Noel (016977) 7074 est.Mauris.eu@quamdignissim.co.uk Waiheke Island" +
+            " Maisie Graham 0800 139993 Sed.id@necante.co.uk Dijon" +
+            " Germaine Brooks 0302 964 6397 ullamcorper@temporlorem.co.uk Ranst" +
+            " Gwendolyn Stephenson (0121) 508 7000 libero.Proin@tristique.co.uk Lasne-Chapelle-Saint-Lambert" +
+            " Minerva Justice 0500 218264 risus@Suspendissenon.edu North Cowichan" +
+            " Joan Tyler (0191) 405 8266 elit.Curabitur@facilisismagna.ca Sittard" +
+            " Phyllis Mathews (01622) 238340 ac@Donecfeugiatmetus.com Castelbuono" +
+            " Lacey Ortega 0370 539 3423 hendrerit.neque.In@lorem.net Jolanda di Savoia" +
+            " Jeanette Berg 0845 46 45 enim.diam@tincidunt.ca San Martino in Pensilis" +
+            " Brynne Holt 07304 543587 id.enim@temporeratneque.com Philadelphia" +
+            " Xandra Little 055 8256 4039 Etiam@parturientmontes.org Bad Nauheim" +
+            " Quemby Waters 07624 552770 eu.tellus@penatibus.ca Bonnyville" +
+            " Jessica Richardson (016977) 1368 dictum.magna.Ut@acarcu.edu Williams Lake" +
+            " Athena Greene 07624 582787 adipiscing.non@etrutrum.org Calera" +
+            " Alika Palmer (0101) 285 8741 orci.luctus.et@morbitristiquesenectus.co.uk Curitiba" +
+            " Callie Wall 055 4572 5553 Morbi.metus.Vivamus@Donec.co.uk Turrialba" +
+            " Ocean Knapp 0800 475 1597 natoque@augueidante.ca Les Bons Villers" +
+            " Cailin Vance (0110) 915 5385 Lorem.ipsum.dolor@magnis.org Heist-aan-Zee" +
+            " Delilah Conner 070 5760 4445 Curae.Phasellus.ornare@loremfringilla.com Lossiemouth" +
+            " Yuri Cochran 0800 1111 sed.dolor.Fusce@vitaediam.org Rockingham" +
+            " Destiny Hamilton 056 4319 5840 quis@Nullatempor.co.uk Baranello" +
+            " Ava Nolan 0321 471 2222 quis@ridiculusmus.net Torgnon" +
+            " Hilary Willis 070 8125 5491 faucibus@nulla.net Sangli" +
+            " Jenna Owens 07917 564744 nec.tellus@Fusce.co.uk Düsseldorf" +
+            " Carly Marsh 07015 676248 sagittis@hendreritid.org Parndorf" +
+            " Quintessa Kirby 070 3296 1629 tristique@et.ca Springfield" +
+            " Montana Hull (016977) 3710 vel.mauris.Integer@non.org Livo" +
+            " Catherine Reyes (01089) 452406 molestie@etarcu.com Fontanellato" +
+            " Summer Rice (01187) 486652 justo@et.org Radom" +
+            " Christine Mccoy 0800 152 5114 vel.arcu.eu@lobortis.net Rochester" +
+            " Alexa May 070 1215 1314 ultricies.dignissim@dolorsitamet.edu Pointe-Claire" +
+            " Myra Rodgers 070 4681 9771 sit@ut.net Drayton Valley" +
+            " Desirae Matthews (0101) 628 7979 Nulla@egetlaoreet.ca Dieppe" +
+            " Francesca Knowles (01693) 853716 volutpat.Nulla@magnaetipsum.co.uk Broken Arrow" +
+            " Quemby Rich 0845 46 42 vestibulum.nec@eunulla.edu Red Deer" +
+            " Mara Harrison 056 4589 0890 ut.eros.non@maurisIntegersem.org Baton Rouge" +
+            " Kitra Solis (0114) 741 5753 Quisque@Quisquefringillaeuismod.co.uk Broken Arrow" +
+            " Sandra Larson 07098 082333 fermentum@vitaenibh.net Nîmes" +
+            " Iola Cash 07624 092172 tellus.lorem.eu@vehiculaPellentesque.edu Caprino Bergamasco" +
+            " Kitra Sanchez 0800 674733 Phasellus@ipsumCurabiturconsequat.ca Wollongong" +
+            " Emily Keith 055 2769 6445 arcu@consectetuerrhoncusNullam.com Kent" +
+            " Kessie Schroeder 0967 691 5385 auctor.Mauris.vel@acarcuNunc.org Glabais" +
+            " Kaitlin Fernandez (020) 6003 1394 Donec@erat.edu Parbhani" +
+            " Doris Vaughn (0118) 591 3483 tincidunt.vehicula.risus@Proinegetodio.ca Sotteville-lès-Rouen" +
+            " Glenna Witt (017562) 27891 dis@Inmipede.org Soye" +
+            " Emma Howe (0117) 274 2390 luctus@dictum.net Zonhoven" +
+            " Blair Banks 070 5106 5627 metus.Vivamus.euismod@sagittis.edu Kingston-on-Thames" +
+            " Jorden Durham 07624 691948 molestie.in.tempus@tristiquepharetra.com Nampa" +
+            " Blythe Underwood (028) 0051 0929 iaculis.aliquet@sed.edu St. Thomas" +
+            " Eleanor Mosley 055 9116 9366 Vivamus.non.lorem@mauris.edu Tresigallo" +
+            " Clementine West 076 5845 0260 ac.turpis.egestas@Nuncmauris.com Acciano" +
+            " Eleanor Hudson (013649) 59185 Sed.eget@blanditcongueIn.net Orsara di Puglia" +
+            " Indigo Shields 0800 744604 ipsum@pharetra.co.uk Dorgali" +
+            " Galena Hughes 070 5628 7648 ut.erat@neccursus.ca Kampenhout" +
+            " Cassidy Travis 0845 46 40 est.Mauris@Aliquam.net Gateshead" +
+            " Virginia Mason 0845 46 46 lorem@nondapibus.ca Istres" +
+            " Cecilia Ferguson 070 0771 0692 erat.Vivamus.nisi@natoquepenatibuset.ca Böblingen" +
+            " Eleanor Harris (0114) 633 1360 Proin.nisl.sem@Curabituregestasnunc.com Bazel" +
+            " Illana Shepherd (01385) 30910 aliquam.eros@adipiscingenim.ca Beerst" +
+            " Kaitlin Sharpe 0849 458 7485 non@lacinia.com Flin Flon" +
+            " Beatrice Day 07624 875300 netus.et@arcuvel.com Fort Worth" +
+            " Naomi Cunningham 055 5974 6779 Morbi.neque@Vestibulumanteipsum.edu Palermo" +
+            " Ruth Moses (0114) 392 6720 erat@Aliquam.edu Birmingham" +
+            " Jaime Hopper 07624 169480 libero.est@magnaSedeu.com Aisemont" +
+            " Bertha Mann 0963 581 1773 placerat@tristiquepharetraQuisque.edu Nerem" +
+            " Melissa Gomez 056 7293 3021 parturient.montes@In.com Soye" +
+            " Ainsley Parks 0866 858 0276 mi.fringilla.mi@ut.com Fratta Todina" +
+            " Virginia Lang 0845 46 44 est.Mauris@enimNuncut.edu Chantemelle" +
+            " Ila Harper 0845 46 48 molestie.dapibus@seddictum.edu Les Bons Villers" +
+            " Lee Wilder 07624 189677 sapien.Aenean.massa@etcommodoat.ca Lakeland County" +
+            " Stacy Webster 0800 1111 Fusce.dolor.quam@velconvallisin.edu Antuco" +
+            " Isadora Joseph (027) 3824 1305 vulputate.eu@felisNullatempor.org Dorval" +
+            " Alea Guzman (01571) 95927 Donec@erat.net Pickering" +
+            " Leandra Shepherd 07624 116495 Nam.nulla@leoin.com Reading" +
+            " Aiko Donaldson 0303 541 3532 ligula@Innecorci.co.uk Wick" +
+            " Cathleen Mcdowell (016977) 4272 In.nec.orci@molestiepharetranibh.edu Rossignol" +
+            " Indigo Cantrell 076 4382 9948 Maecenas.malesuada.fringilla@dolor.org Sint-Martens-Bodegem" +
+            " Beverly Reilly (0151) 098 3418 pede@erategettincidunt.net Fraserburgh" +
+            " Leandra Decker 070 3077 7528 fringilla.est.Mauris@neceleifendnon.net Bowling Green" +
+            " Angela Woodard 07624 305700 fermentum.arcu@nonnisi.ca Zerkegem" +
+            " Savannah Castro (016977) 8937 Etiam@ligula.org Carleton" +
+            " Hollee Stark 0800 989 0403 gravida@sociosqu.edu Porretta Terme" +
+            " Demetria Gonzales 0800 122836 rutrum@dictum.ca Coquitlam" +
+            " Ina Rivers 0826 825 8806 neque@lobortisClassaptent.com Melilla" +
+            " Imelda Wilkerson 0800 1111 feugiat.nec@Duisdignissim.org Ribnitz-Damgarten" +
+            " Mariko Watson (01820) 91473 nec.luctus@facilisisfacilisis.org Fontaine-Valmont" +
+            " Alfreda Fox (0161) 505 2769 quis.massa@arcuSedet.edu Tongerlo" +
+            " Laura Boyer 0500 886398 tellus.Nunc@Curabitur.ca Bargagli" +
+            " Cara Mcleod 0800 950 6544 Suspendisse.eleifend.Cras@scelerisquenequesed.ca Imst" +
+            " Odette Baird 0800 067654 turpis.nec@pedeNunc.com Monstreux" +
+            " Hilda Cummings 076 3929 0120 egestas@acnullaIn.com Galzignano Terme" +
+            " Nerea Wade (016977) 8450 Maecenas.libero@lobortisultrices.com Chelsea" +
+            " Idola Workman (0114) 121 3175 egestas.a.dui@NullafacilisisSuspendisse.ca Folx-les-Caves" +
+            " Sonia Hahn (01111) 317928 ut@ultrices.com Altach" +
+            " Moana Clements (0113) 521 1388 sed@quis.ca Portsmouth" +
+            " Brittany Lester 056 0424 3586 Integer.vulputate@et.ca Linton" +
+            " Jenna Espinoza 0500 855288 Maecenas@feugiatplaceratvelit.net Cerchio" +
+            " Charde Powell 0395 732 6493 Aenean@Proin.net Paradise" +
+            " Iona Walton (0111) 925 9148 adipiscing.elit@ametdapibus.edu San Cesario di Lecce" +
+            " Cameron Wilcox 07196 574529 velit.dui@elitpharetraut.net Titagarh" +
+            " Gwendolyn Walters 0343 081 8534 lobortis@quisdiam.edu Cape Breton Island" +
+            " Kameko Hewitt (015192) 50969 velit.in@ultricesposuerecubilia.com Angleur" +
+            " Alice Joyner 055 8960 3696 dui.nec@Uttinciduntorci.co.uk Ponte San Nicolò" +
+            " Imani Santana 07624 358679 Cum.sociis@velitPellentesque.edu Nelson" +
+            " Carol Albert (029) 0001 3450 eu.sem@atfringilla.org Opheylissem" +
+            " Amethyst Ellison (024) 5122 9525 dictum@nibhPhasellus.co.uk Hulste" +
+            " Sheila Walton 0800 456077 pellentesque@egetvarius.net Harrisburg" +
+            " Indira Garrison 056 4760 2993 posuere.at@perconubia.edu Cisnes" +
+            " Tara Bradshaw (011429) 24082 erat.in.consectetuer@Sed.co.uk Embourg" +
+            " Kevyn Stevenson 07624 702264 eu@lacusQuisque.edu Mainz" +
+            " Ariel Nielsen (020) 2609 8789 eget.mollis@ridiculusmus.com Paine" +
+            " Chelsea Clark 076 8209 9598 parturient.montes.nascetur@ligulaDonecluctus.org North Bay" +
+            " Sonia Buckley (0117) 339 8426 amet@fermentum.ca Fraser-Fort George" +
+            " Paula Davidson 0800 1111 fringilla.purus@Aeneanegetmetus.co.uk Petacciato" +
+            " Sylvia Oneil 0500 952754 Phasellus.dapibus@CrasinterdumNunc.net Chandannagar" +
+            " Giselle Fleming (0110) 075 9118 eu@elita.com Dietzenbach" +
+            " Aimee Moody (01582) 01208 at.egestas.a@tristique.net Irricana" +
+            " Gail Rosario (0110) 640 2306 pede.Suspendisse@volutpatNulla.com Namen" +
+            " Whoopi Sharpe 0863 296 7004 diam@Suspendissetristiqueneque.ca Vedrin" +
+            " Judith Mack 070 7687 7888 Donec.nibh@rutrumjusto.ca Ternitz" +
+            " Helen Mckee (023) 3562 7053 vehicula.Pellentesque.tincidunt@temporeratneque.co.uk Canmore" +
+            " Kirestin Ballard (01343) 604851 Donec.consectetuer@ProindolorNulla.ca Nagpur" +
+            " Brianna Pitts 070 8440 6981 eu@temporarcuVestibulum.net Chiniot" +
+            " Daryl Baker 0500 000711 Morbi.non@Quisque.com Seilles" +
+            " Carla Bryant 070 4282 2093 Mauris.magna@vehiculaaliquetlibero.co.uk Freital" +
+            " Rina Nixon 076 0303 9562 Cras.vulputate.velit@utcursus.ca Tiel" +
+            " Ginger Jennings 070 5712 6754 leo@ligula.co.uk Burnpur" +
+            " Cecilia Yates (0110) 316 7904 sollicitudin.adipiscing.ligula@aliquam.co.uk Asse" +
+            " Belle Meyer 0800 249 5308 Donec.egestas@blanditcongue.org İmamoğlu" +
+            " Rebekah Farley (01394) 289332 eget.lacus@convallisante.co.uk Morrinsville" +
+            " Remedios Hernandez 07624 301755 Donec.est@Fusce.edu Guadalajara" +
+            " Breanna Beck 076 3963 3445 nunc.sit@enim.com Saint-Prime" +
+            " Aurelia Miller 070 9147 4394 lorem.ac@ametorciUt.co.uk Matamata" +
+            " Mara Yang (0118) 405 4779 dui.nec.urna@Namnulla.org Wolfenbüttel" +
+            " Candace Roberson 0500 874367 non.justo@lacus.net Stony Plain" +
+            " Adara Le 056 2666 4455 cubilia.Curae.Phasellus@atpretium.edu Sant'Egidio alla Vibrata" +
+            " Aspen Lawson (021) 3113 7798 consequat.purus@ipsumdolorsit.edu Lexington" +
+            " Ursula Burgess 07624 179190 ac.eleifend.vitae@orciin.org Rathenow" +
+            " Dara Meyers (025) 0943 3346 dolor@justo.com Traralgon" +
+            " Galena Joyce (01080) 558650 id@nonummy.org Huntsville" +
+            " Jada Reese (0117) 739 3237 nec.mauris.blandit@auctorodioa.ca Conca Casale" +
+            " Amy Maynard 076 8426 2119 sit@Aliquam.net Geel" +
+            " Sydney Farmer 055 4135 3834 natoque.penatibus.et@etnetus.edu Pinneberg" +
+            " Dai Drake (025) 3091 8842 Cras.lorem@Maurisnondui.org Exeter" +
+            " Janna Sanchez 0800 087282 erat.eget.ipsum@Nullam.org Sart-Eustache" +
+            " Maite Schwartz 056 8184 8460 pharetra.sed.hendrerit@vitaedolor.org Longvilly" +
+            " Amity Coffey 0937 570 2428 laoreet.lectus@dolorsitamet.ca Llangefni" +
+            " Willa Snyder (020) 4175 7353 ullamcorper.eu.euismod@placerat.net Pavone del Mella" +
+            " Regan Patton 0800 086128 elit.Curabitur.sed@Etiamvestibulum.com Paradise" +
+            " Karly Keller (018284) 65790 facilisis.vitae@dictumProin.org Orp-Jauche" +
+            " Ivy Dudley 070 8060 2941 Donec.non@Etiamvestibulummassa.net Borås" +
+            " Hope Hoffman 0845 46 43 vulputate.lacus.Cras@hendreritaarcu.ca Township of Minden Hills" +
+            " Alma Cleveland (0112) 149 7083 ante.dictum.cursus@ad.org Warri" +
+            " Hillary Calhoun (0119) 984 5378 justo.sit.amet@molestiepharetranibh.co.uk Hampstead" +
+            " Blossom Kim (016977) 3756 pellentesque.eget@egestas.edu Belsele" +
+            " Judith Graves 0851 556 3717 Curabitur@dolor.ca Vanderhoof" +
+            " Xerxes Lyons 070 7165 5290 nunc@magnaDuis.co.uk Aurangabad" +
+            " Dominique Parrish 0800 535186 nonummy.Fusce@ultricesDuisvolutpat.net Scarborough" +
+            " Yael Weeks (01813) 26044 nulla@Crasvulputate.com Fairbanks" +
+            " Nicole Summers (01545) 082490 magna@ametdiameu.edu Itapipoca" +
+            " Jana Young 07996 242955 tristique@iaculisneceleifend.net Tiegem" +
+            " Hollee Pruitt 0800 313 9810 faucibus.leo@Seddictum.org Bhopal" +
+            " Kylie Gates 056 2716 8367 luctus.aliquet.odio@utipsum.com San Massimo" +
+            " Ramona Cochran 07722 213674 purus.accumsan@luctuslobortisClass.com Cerro Navia" +
+            " Charissa Rosario 070 4770 6703 amet.orci@nonenimcommodo.co.uk Innisfail" +
+            " Madaline Blanchard (027) 5118 9913 eleifend.nunc@uteros.org Lamont" +
+            " Jemima Ayers 076 0902 8977 urna.Ut.tincidunt@dis.com Sonnino" +
+            " Quinn England 0800 080 0584 et.lacinia@torquent.net Brampton" +
+            " Susan Simon 0800 853 9239 magnis.dis.parturient@milorem.org Marbais" +
+            " Veda Moreno 055 8837 4859 ligula@inhendrerit.net Madrid" +
+            " Brielle Buckner 0800 1111 egestas.a.dui@dictumcursus.org Fürstenwalde" +
+            " Dorothy Brewer (012409) 17477 consequat.purus.Maecenas@convalliserat.net Mansfield-et-Pontefract" +
+            " Roanna Frank 0500 534552 cursus.vestibulum@atrisusNunc.com Serramonacesca" +
+            " Quin Barron (01902) 16701 lacus.Nulla.tincidunt@imperdietnon.net Heusden-Zolder" +
+            " Geraldine Nash (016977) 5728 dui.augue.eu@aodiosemper.co.uk Pessac" +
+            " Hadley Lambert (0114) 565 6236 sed.facilisis.vitae@Integer.co.uk Jandrain-Jandrenouille" +
+            " Chelsea Hubbard 056 2585 7846 in.sodales.elit@tempuseuligula.ca Zaltbommel" +
+            " Yetta Clemons (016977) 1475 et.magnis.dis@quamelementumat.co.uk Knokke" +
+            " Jenna Humphrey 056 5627 7953 Cras.dictum@dignissimpharetra.edu Maple Creek" +
+            " Genevieve Rollins (0101) 162 9782 sed.hendrerit@Cumsociis.org Mazzano Romano" +
+            " Miranda Moon (021) 7795 7957 sagittis.semper@tristiquepellentesque.net Saint John" +
+            " Willow Castillo 070 7358 9294 felis.Nulla.tempor@musDonecdignissim.com Montalto Uffugo" +
+            " Anastasia Mueller (016977) 1314 a@lacuspedesagittis.com Morrinsville" +
+            " Dara Owens 076 6868 7201 tellus.Phasellus@nuncsed.co.uk Waterbury" +
+            " Hanae Rice 0912 095 9668 nunc@aliquetliberoInteger.co.uk Rum" +
+            " Rama Wooten 076 0401 2139 feugiat.tellus@estmaurisrhoncus.co.uk Baidyabati" +
+            " Gisela Solis 070 3439 4629 non@auctorvelit.com Chambord" +
+            " Jana Robinson 07013 834562 libero.Proin@tinciduntnibhPhasellus.org Roccanova" +
+            " Claire West 0800 1111 orci.Ut.sagittis@quamelementum.co.uk Ligosullo" +
+            " Leigh Baldwin 0327 753 1329 quis@euismodenimEtiam.com Teralfene" +
+            " Chastity Mullen (0112) 945 1682 felis.eget.varius@lacinia.ca Mariquina" +
+            " Cara Mooney (0113) 735 6895 felis.purus@fermentumvelmauris.com Palagano" +
+            " Zenia Mcmillan (015652) 02443 eu.turpis.Nulla@nascetur.ca Civitacampomarano" +
+            " Portia Hill (01983) 17408 a.arcu.Sed@arcuvelquam.org Colobraro" +
+            " Brynne Brewer 0800 832 1988 amet@vitaerisus.edu Athens" +
+            " Kiayada Hendricks 07779 546753 interdum@dignissimtemporarcu.co.uk Lachine" +
+            " Lillith Reese 07624 007787 dolor.tempus@ultriciesdignissim.com Freux" +
+            " Keelie Gallagher (01586) 42913 dapibus.ligula@sit.net Campbelltown" +
+            " Ariana Keith 0845 46 40 ipsum.dolor.sit@auctorveliteget.com Karimnagar" +
+            " Jessica Koch 0845 46 42 nec.ante@Praesenteunulla.ca Osgoode" +
+            " Aileen Rodriguez 0845 46 46 mattis.velit.justo@Maurismolestie.com Portico e San Benedetto" +
+            " Germane Brewer 076 5624 2680 malesuada.ut.sem@Lorem.net El Bosque" +
+            " Willow Park 07196 875331 Vivamus.rhoncus.Donec@ProinvelitSed.org Bever Bievene" +
+            " Yen Stevenson 07624 310007 in@Sedeu.edu Imphal" +
+            " Ivana Morse (01207) 692187 eu.metus@quis.edu Pickering" +
+            " Chanda Donaldson 055 5125 3654 sit.amet.luctus@vellectus.ca Vidisha";
 }


### PR DESCRIPTION
This PR contains .travis.yml and reports.sh files that make Travis execute tests against multiple JDKs and publish separate allure report for each version of JDK.

Below is an example of results retreived by [Travis build 5565](https://travis-ci.com/github/jdi-testing/jdi-light/builds/169932280) for openjdk versions from 8 till 13 inclusively.

Links to reports are published as comments from user mf-code:
 
- openjdk8: https://5eda941e4fca8eb116705375--musing-swartz-6fc060.netlify.app/
- openjdk9: https://5eda951b3a487cd0981d89d2--musing-swartz-6fc060.netlify.app/
- openjdk10: https://5eda96174fca8eb0b270588a--musing-swartz-6fc060.netlify.app/
- openjdk11: https://5eda96def5a8b0de7fce7ec8--musing-swartz-6fc060.netlify.app/
- openjdk12: https://5eda9815163295fce1b08a48--musing-swartz-6fc060.netlify.app/
- openjdk13: https://5eda99089834a35de5003853--musing-swartz-6fc060.netlify.app/