### PR TITLE
Codacy solutions

### DIFF
--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/generic/table/DataTableAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/generic/table/DataTableAssert.java
@@ -182,6 +182,7 @@ public class DataTableAssert<L extends PageObject, D>
                 case ATLEAST:
                     jdiAssert(table().dataRows(condition, count), hasSize(count));
                     break;
+                default: break;
             }
             return dtAssert;
         }

--- a/jdi-light/src/main/java/com/epam/jdi/light/asserts/generic/table/IGridAssert.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/asserts/generic/table/IGridAssert.java
@@ -202,6 +202,7 @@ public class IGridAssert<D, T extends IGrid<D>, A extends IGridAssert<D, T, A>> 
                  case ATLEAST:
                      jdiAssert(grid().filter(condition), hasSize(greaterThanOrEqualTo(count)));
                      break;
+                 default: break;
              }
              return dtAssert;
          }


### PR DESCRIPTION
update: IGridAssert.java
Update DataTableAssert.java 
add two missed cases for codacy pattern: Switch statements should have a default label