### PR TITLE
fixed ButtonGroupTests

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/inputs/ButtonGroupPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/inputs/ButtonGroupPage.java
@@ -13,6 +13,7 @@ public class ButtonGroupPage extends WebPage {
     @UI("//*[@id=\"__next\"]/div/div/div[2]/div/div/div/div[2]/div")
     public ButtonGroup verticalButtonGroup;
 
+
     @JDIButtonGroup(
             root = "#root",
             mainButton = ".MuiButton-root[1]",

--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/inputs/ButtonGroupPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/inputs/ButtonGroupPage.java
@@ -13,7 +13,6 @@ public class ButtonGroupPage extends WebPage {
     @UI("//*[@id=\"__next\"]/div/div/div[2]/div/div/div/div[2]/div")
     public ButtonGroup verticalButtonGroup;
 
-
     @JDIButtonGroup(
             root = "#root",
             mainButton = ".MuiButton-root[1]",

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/ButtonGroupTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/ButtonGroupTests.java
@@ -38,8 +38,8 @@ public class ButtonGroupTests extends TestsInit {
         buttonGroupPage.verticalButtonGroup.getButtonByText("Two").click();
         buttonGroupPage.verticalButtonGroup.getButtonByText("One").click();
 
-        buttonGroupPage.basicButtonGroup.getButtonByIndex(1).is().enabled();
-        buttonGroupPage.basicButtonGroup.getButtonByIndex(1).has().text("ONE");
+        buttonGroupPage.basicButtonGroup.getButtonByIndex(2).is().enabled();
+        buttonGroupPage.basicButtonGroup.getButtonByIndex(2).has().text("TWO");
     }
 
     @Test
@@ -58,6 +58,6 @@ public class ButtonGroupTests extends TestsInit {
         buttonGroupPage.splitButtonGroup.select("Update project");
         buttonGroupPage.splitButtonGroup.getMainButton()
                 .has().text("UPDATE PROJECT");
-        
+
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/ButtonGroupTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/ButtonGroupTests.java
@@ -38,8 +38,8 @@ public class ButtonGroupTests extends TestsInit {
         buttonGroupPage.verticalButtonGroup.getButtonByText("Two").click();
         buttonGroupPage.verticalButtonGroup.getButtonByText("One").click();
 
-        buttonGroupPage.basicButtonGroup.getButtonByIndex(2).is().enabled();
-        buttonGroupPage.basicButtonGroup.getButtonByIndex(2).has().text("TWO");
+        buttonGroupPage.basicButtonGroup.getButtonByIndex(1).is().enabled();
+        buttonGroupPage.basicButtonGroup.getButtonByIndex(1).has().text("ONE");
     }
 
     @Test


### PR DESCRIPTION
* The URL has been changed so that the web page opens correctly.
* The Frame has been removed. Now the page is being accessed.
* ButtonGroupPage class was created, extended from WebPage. Variables required for the test have been added in this class: basicButtonGroup and verticalButtonGroup.
* The class splitButtonGroupFrame has been removed. The variables of this class have been moved to the class ButtonGroupPage.
* defaultButtonGroupTest has been modified. Two tests were created based on this test: basicButtonGroupTest and verticalButtonGroupTest.