### PR TITLE
3212 - MaterialUI Check Backdrop component

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/BackdropPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/BackdropPage.java
@@ -2,7 +2,7 @@ package io.github.com.pages.feedback;
 
 import com.epam.jdi.light.elements.composite.WebPage;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
-import com.epam.jdi.light.material.elements.feedback.ProgressBar;
+import com.epam.jdi.light.material.elements.feedback.Backdrop;
 import com.epam.jdi.light.material.elements.inputs.Button;
 
 public class BackdropPage extends WebPage {
@@ -11,6 +11,6 @@ public class BackdropPage extends WebPage {
     public static Button showBackdropButton;
 
     @UI(".MuiBackdrop-root")
-    public static ProgressBar backdrop;
+    public static Backdrop backdrop;
 
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/BackdropAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/BackdropAssert.java
@@ -1,23 +1,8 @@
 package com.epam.jdi.light.material.asserts.feedback;
 
 import com.epam.jdi.light.asserts.generic.UIAssert;
-import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.material.elements.feedback.Backdrop;
-import org.hamcrest.Matchers;
-
-import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
 public class BackdropAssert extends UIAssert<BackdropAssert, Backdrop> {
 
-    @JDIAction("Assert that '{name}' text is visible")
-    public BackdropAssert visible() {
-        jdiAssert(element().isVisible(), Matchers.is(true));
-        return this;
-    }
-
-    @JDIAction("Assert that '{name}' text is hidden")
-    public BackdropAssert hidden() {
-        jdiAssert(element().isHidden(), Matchers.is(true));
-        return this;
-    }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/BackdropAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/BackdropAssert.java
@@ -1,0 +1,23 @@
+package com.epam.jdi.light.material.asserts.feedback;
+
+import com.epam.jdi.light.asserts.generic.UIAssert;
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.material.elements.feedback.Backdrop;
+import org.hamcrest.Matchers;
+
+import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
+
+public class BackdropAssert extends UIAssert<BackdropAssert, Backdrop> {
+
+    @JDIAction("Assert that '{name}' text is visible")
+    public BackdropAssert visible() {
+        jdiAssert(element().isVisible(), Matchers.is(true));
+        return this;
+    }
+
+    @JDIAction("Assert that '{name}' text is hidden")
+    public BackdropAssert hidden() {
+        jdiAssert(element().isHidden(), Matchers.is(true));
+        return this;
+    }
+}

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/Backdrop.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/Backdrop.java
@@ -1,0 +1,13 @@
+package com.epam.jdi.light.material.elements.feedback;
+
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.elements.base.UIBaseElement;
+import com.epam.jdi.light.material.asserts.feedback.BackdropAssert;
+
+public class Backdrop extends UIBaseElement<BackdropAssert> {
+
+    @JDIAction("Click '{name}'")
+    public void click() {
+        core().click();
+    }
+}

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/Backdrop.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/Backdrop.java
@@ -1,13 +1,13 @@
 package com.epam.jdi.light.material.elements.feedback;
 
-import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.base.UIBaseElement;
+import com.epam.jdi.light.elements.interfaces.base.HasClick;
 import com.epam.jdi.light.material.asserts.feedback.BackdropAssert;
 
-public class Backdrop extends UIBaseElement<BackdropAssert> {
+public class Backdrop extends UIBaseElement<BackdropAssert> implements HasClick {
 
-    @JDIAction("Click '{name}'")
-    public void click() {
-        core().click();
+    @Override
+    public BackdropAssert is() {
+        return new BackdropAssert().set(this);
     }
 }


### PR DESCRIPTION
Resolve [issue#3212](https://github.com/jdi-testing/jdi-light/issues/3212)
- Add Backdrop component in `jdi.light.material.elements.feedback`
- Update Backdrop tests