### PR TITLE
3203 - Duplicate (old) webpage declarations

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/StaticSite.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/StaticSite.java
@@ -246,19 +246,6 @@ public class StaticSite {
     @Url("/use_media_query")
     public static UseMediaQueryPage useMediaQueryPage;
 
-    // utils
-    // Click away listener
-
-    @Frame("storybook-preview-iframe")
-    public static ClickAwayListenerPage clickAwayListenerFrame;
-
-
-    @Url("/material-ui-utils-click-away-listener--default")
-    public static WebPage utilsClickAwayListenerDefaultPage;
-
-    @Url("/material-ui-utils-click-away-listener--portal-example")
-    public static WebPage utilsClickAwayListenerPortalExamplePage;
-
     // portal
     @Url("/portal")
     public static PortalPage portalPage;


### PR DESCRIPTION
Old declarations of `utilsClickAwayListenerDefaultPage` and `utilsClickAwayListenerPortalExamplePage` were removed. The provided links are not valid (intuitively by their format) and return a 404 code error. The functionality of the pages was implemented by `ClickAwayListenerPage clickAwayListenerPage` and `PortalPage portalPage` with appropriate links respectively. The pages are covered by `ClickAwayListenerTests` and `PortalTests`. Removing these old declarations solves issue #3203 