### PR TITLE
3287 - MaterialAction aspect

### DIFF
--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/actions/MaterialActions.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/actions/MaterialActions.java
@@ -1,0 +1,56 @@
+package com.epam.jdi.light.material.actions;
+
+import com.epam.jdi.light.actions.ActionObject;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+
+import static com.epam.jdi.light.actions.ActionHelper.ACTION_FAILED;
+import static com.epam.jdi.light.actions.ActionHelper.AFTER_JDI_ACTION;
+import static com.epam.jdi.light.actions.ActionHelper.BEFORE_JDI_ACTION;
+import static com.epam.jdi.light.actions.ActionHelper.defaultAction;
+import static com.epam.jdi.light.actions.ActionHelper.failedMethods;
+import static com.epam.jdi.light.actions.ActionHelper.getJpClass;
+import static com.epam.jdi.light.actions.ActionHelper.getMethodName;
+import static com.epam.jdi.light.actions.ActionHelper.newInfo;
+import static com.epam.jdi.light.actions.ActionHelper.stableAction;
+import static com.epam.jdi.light.actions.ActionProcessor.isTop;
+import static com.epam.jdi.light.settings.WebSettings.logger;
+import static com.epam.jdi.tools.LinqUtils.safeException;
+
+
+@SuppressWarnings("unused")
+@Aspect
+public class MaterialActions {
+    @Pointcut("within(com.epam.jdi.light.material..*) && @annotation(com.epam.jdi.light.common.JDIAction)")
+    protected void jdiPointcut() {
+        // this method is created only for passing as a parameter in the annotation @Around
+    }
+
+    @Around("jdiPointcut()")
+    public Object jdiAround(final ProceedingJoinPoint jp) {        String classMethod = "";
+        try {
+            classMethod = getJpClass(jp).getSimpleName() + "." + getMethodName(jp);
+            logger.trace("<>@AA: " + classMethod);
+        } catch (Exception ignore) { }
+        ActionObject jInfo = newInfo(jp, "AO");
+        failedMethods.clear();
+        try {
+            BEFORE_JDI_ACTION.execute(jInfo);
+            Object result = isTop.get()
+                    ? stableAction(jInfo)
+                    : defaultAction(jInfo);
+            logger.trace("<>@AA: %s >>> %s",classMethod, (result == null ? "NO RESULT" : result));
+            AFTER_JDI_ACTION.execute(jInfo, result);
+            return result;
+        } catch (Throwable ex) {
+            logger.debug("<>@AA exception:" + safeException(ex));
+            throw ACTION_FAILED.execute(jInfo, ex);
+        }
+        finally {
+            if (jInfo != null)
+                jInfo.clear();
+        }
+    }
+}


### PR DESCRIPTION
Aspect annotated class for the material-ui module was created. 

It is a full copy of `AngularActions` except for the package path in `Pointcut` annotation.

Run `mvn clean install` to weave.

So after rebuild, I got the right log for `basicButtonGroupTest`:
```
...
04:52.938 [JDI:INFO]: Page 'Button Group Page' opened
04:53.51 [JDI:STEP]: == Test 'ButtonGroupTests.basicButtonGroupTest' START ==
04:53.63 [JDI:STEP]: Get Button with index '1'
04:53.241 [JDI:STEP]: >>> WebElement->xpath: .//div[@aria-label = 'outlined primary button group...
04:53.251 [JDI:STEP]: Click on '.MuiButtonBase-root[2]'
04:53.370 [JDI:STEP]: Get Button with index '2'
...
```