### PR TITLE
Material UI rework: Dialog- reworked #3454

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/DialogPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/DialogPage.java
@@ -4,7 +4,6 @@ import com.epam.jdi.light.elements.composite.WebPage;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 import com.epam.jdi.light.ui.html.elements.common.Button;
 import com.epam.jdi.light.ui.html.elements.common.Text;
-import com.epam.jdi.light.ui.html.elements.common.TextArea;
 import com.epam.jdi.light.ui.html.elements.common.TextField;
 
 public class DialogPage extends WebPage {
@@ -19,13 +18,11 @@ public class DialogPage extends WebPage {
     public static Text simpleDialogField;
 
 
-
     @UI("//span[text()='Open alert dialog']/parent::*[contains(@class,'MuiButtonBase-root')]")
     public static Button alertDialogButton;
 
     @UI("#alertDialogSelection")
     public static Text alertDialogField;
-
 
 
     @UI("//span[text()='Open form dialog']/parent::*[contains(@class,'MuiButtonBase-root')]")
@@ -36,7 +33,6 @@ public class DialogPage extends WebPage {
 
     @UI("//input[@type='email']")
     public static TextField dialogEmailInputForm;
-
 
 
     @UI("//span[text()='Phone ringtone']/parent::div")
@@ -52,21 +48,14 @@ public class DialogPage extends WebPage {
     public static Button confirmationDialogCancelButton;
 
 
-
     @UI("//span[text()='scroll=paper']/parent::*[contains(@class,'MuiButtonBase-root')]")
     public static Button scrollPaperDialogButton;
-
-    @UI("//span[text()='scroll=body']/parent::*[contains(@class,'MuiButtonBase-root')]")
-    public static Button scrollBodyDialogButton;
 
     @UI("#scrollableAction")
     public static Text scrollableDialogField;
 
     @UI("//div[@id='scroll-dialog-title']/following::span[text()='Cancel']")
     public static Button scrollableDialogCancelButton;
-
-    @UI("//div[@id='scroll-dialog-title']/following::div[contains(@class,'MuiDialogContent-dividers')]")
-    public static TextArea dialogScrollableContent;
 
 
     @UI("//h2[contains(@class,'MuiTypography-h6')]")
@@ -77,7 +66,6 @@ public class DialogPage extends WebPage {
 
     @UI("//div[@class='MuiFormGroup-root']//span[text()='Luna']")
     public static Button dialogLunaRingtone;
-
 
 
     @UI("//h2[contains(@class,'MuiTypography-h6') and not (text()='Phone Ringtone')]")
@@ -94,5 +82,4 @@ public class DialogPage extends WebPage {
 
     @UI("//span[text()='Subscribe']")
     public static Button subscribeButton;
-
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/DialogTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/DialogTests.java
@@ -1,35 +1,27 @@
 package io.github.epam.material.tests.feedback;
 
 import static io.github.com.StaticSite.dialogPage;
+import static org.hamcrest.Matchers.containsString;
 import static io.github.com.pages.feedback.DialogPage.alertDialogButton;
 import static io.github.com.pages.feedback.DialogPage.alertDialogField;
 import static io.github.com.pages.feedback.DialogPage.confirmationDialogButton;
-import static io.github.com.pages.feedback.DialogPage.confirmationDialogCancelButton;
 import static io.github.com.pages.feedback.DialogPage.confirmationDialogField;
-import static io.github.com.pages.feedback.DialogPage.confirmationDialogOkButton;
-import static io.github.com.pages.feedback.DialogPage.dialogCallistoRingtone;
-import static io.github.com.pages.feedback.DialogPage.dialogCloseButton;
 import static io.github.com.pages.feedback.DialogPage.dialogContent;
 import static io.github.com.pages.feedback.DialogPage.dialogEmailInputForm;
-import static io.github.com.pages.feedback.DialogPage.dialogLunaRingtone;
 import static io.github.com.pages.feedback.DialogPage.dialogOkButton;
-import static io.github.com.pages.feedback.DialogPage.dialogScrollableContent;
 import static io.github.com.pages.feedback.DialogPage.dialogTitle;
 import static io.github.com.pages.feedback.DialogPage.formDialogButton;
 import static io.github.com.pages.feedback.DialogPage.formDialogField;
 import static io.github.com.pages.feedback.DialogPage.phoneRingtoneDialogTitle;
-import static io.github.com.pages.feedback.DialogPage.scrollBodyDialogButton;
 import static io.github.com.pages.feedback.DialogPage.scrollPaperDialogButton;
-import static io.github.com.pages.feedback.DialogPage.scrollableDialogCancelButton;
 import static io.github.com.pages.feedback.DialogPage.scrollableDialogField;
 import static io.github.com.pages.feedback.DialogPage.simpleDialogButton;
 import static io.github.com.pages.feedback.DialogPage.simpleDialogField;
 import static io.github.com.pages.feedback.DialogPage.simpleDialogListButton;
-import static io.github.com.pages.feedback.DialogPage.subscribeButton;
-import static org.hamcrest.Matchers.containsString;
 
-import com.jdiai.tools.Timer;
+import com.epam.jdi.light.ui.html.elements.common.Button;
 import io.github.epam.TestsInit;
+import io.github.epam.test.data.DialogDataProvider;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -40,96 +32,57 @@ import org.testng.annotations.Test;
 
 public class DialogTests extends TestsInit {
 
-    private static Timer timer = new Timer(1000L);
-    private static String dialogTextContent = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultricesurna tortor, " +
-            "ac pharetra tortor venenatis id. Praesent consecteturtempor fringilla." +
-            " Cras laoreet sodales pellentesque. Ut nibh leo,auctor id massa vitae," +
-            " consequat congue turpis.";
-    private static String dialogScrollableTextContent = "Cras mattis consectetur purus sit amet fermentum. " +
-            "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac consectetur ac, vestibulum at eros. " +
-            "Praesent commodo cursus magna, vel scelerisque nisl consectetur et.";
-
     @BeforeMethod
     public void before() {
         dialogPage.open();
     }
 
-
-    @Test
-    public void simpleDialogTest() {
-
+    @Test(dataProviderClass = DialogDataProvider.class, dataProvider = "simpleDialogDataProvider")
+    public void simpleDialogTest(String dialogTitleText, String dialogResultFieldText) {
         simpleDialogButton.click();
-        dialogTitle.is().text("Set backup account");
+        dialogTitle.is().text(dialogTitleText);
         simpleDialogListButton.click();
-        simpleDialogField.is().text("Selected: username@gmail.com");
+        simpleDialogField.is().text(dialogResultFieldText);
     }
 
-    @Test
-    public void alertDialogTest() {
-
+    @Test(dataProviderClass = DialogDataProvider.class, dataProvider = "alertDialogDataProvider")
+    public void alertDialogTest(String dialogTitleText, String dialogContentText,
+                                Button selectedButton, String dialogResultFieldText) {
         alertDialogButton.click();
-        dialogTitle.is().text("Alert dialog question?");
-        dialogContent.is().text(dialogTextContent);
-        dialogOkButton.click();
-        timer.wait(() -> dialogContent.is().notVisible());
-        alertDialogField.is().text("Selected: ok");
-        alertDialogButton.click();
-        dialogCloseButton.click();
-        timer.wait(() -> dialogContent.is().notVisible());
-        alertDialogField.is().text("Selected: close");
+        dialogTitle.is().text(dialogTitleText);
+        dialogContent.is().text(dialogContentText);
+        selectedButton.click();
+        alertDialogField.is().text(dialogResultFieldText);
     }
 
-    @Test
-    public void formDialogsTest() {
-
+    @Test(dataProviderClass = DialogDataProvider.class, dataProvider = "formDialogDataProvider")
+    public void formDialogsTest(String dialogTitleText, String dialogContentText,
+                                String email, String dialogResultFieldText) {
         formDialogButton.click();
-        dialogTitle.is().text("Form Dialog");
-        dialogContent.is().text(dialogTextContent);
-        dialogEmailInputForm.input("email@example.com");
+        dialogTitle.is().text(dialogTitleText);
+        dialogContent.is().text(dialogContentText);
+        dialogEmailInputForm.input(email);
         dialogOkButton.click();
-        formDialogField.is().text("Entered email: email@example.com");
-        formDialogButton.click();
-        dialogCloseButton.click();
-        formDialogField.is().text("Entered email:");
+        formDialogField.is().text(dialogResultFieldText);
     }
 
-    @Test
-    public void confirmationDialogTest() {
-
+    @Test(dataProviderClass = DialogDataProvider.class, dataProvider = "confirmationDialogDataProvider")
+    public void confirmationDialogTest(String dialogTitleText, Button selectedButton,
+                                       Button selectedCloseButton, String dialogResultFieldText) {
         confirmationDialogButton.click();
-        phoneRingtoneDialogTitle.is().text("Phone Ringtone");
-        dialogCallistoRingtone.click();
-        confirmationDialogOkButton.click();
-        confirmationDialogField.is().text("Callisto");
-        confirmationDialogButton.click();
-        dialogLunaRingtone.click();
-        confirmationDialogCancelButton.click();
-        confirmationDialogField.is().text("Callisto");
+        phoneRingtoneDialogTitle.is().text(dialogTitleText);
+        selectedButton.click();
+        selectedCloseButton.click();
+        confirmationDialogField.is().text(dialogResultFieldText);
     }
 
-    @Test
-    public void scrollableDialogTest() {
-
+    @Test(dataProviderClass = DialogDataProvider.class, dataProvider = "scrollableDialogDataProvider")
+    public void scrollableDialogTest(String dialogTitleText, String dialogContentText,
+                                     Button selectedButton, String dialogResultFieldText) {
         scrollPaperDialogButton.click();
-        dialogTitle.is().text("Subscribe");
-        dialogScrollableContent.core()
-                .jsExecute("scrollTo(0, document.body.scrollHeight)");
-        dialogContent.is().text(containsString(dialogScrollableTextContent));
-        subscribeButton.click();
-        scrollableDialogField.is().text("Last clicked button: Subscribe");
-        scrollPaperDialogButton.click();
-        scrollableDialogCancelButton.click();
-        scrollableDialogField.is().text("Last clicked button: Cancel");
-
-        scrollBodyDialogButton.click();
-        dialogTitle.is().text("Subscribe");
-        subscribeButton.core()
-                .jsExecute("scrollIntoView()");
-        dialogContent.is().text(containsString(dialogScrollableTextContent));
-        subscribeButton.click();
-        scrollableDialogField.is().text("Last clicked button: Subscribe");
-        scrollPaperDialogButton.click();
-        scrollableDialogCancelButton.click();
-        scrollableDialogField.is().text("Last clicked button: Cancel");
+        dialogTitle.is().text(dialogTitleText);
+        dialogContent.is().text(containsString(dialogContentText));
+        selectedButton.click();
+        scrollableDialogField.is().text(dialogResultFieldText);
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/DialogDataProvider.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/DialogDataProvider.java
@@ -1,0 +1,65 @@
+package io.github.epam.test.data;
+
+import org.testng.annotations.DataProvider;
+
+import static io.github.com.pages.feedback.DialogPage.confirmationDialogCancelButton;
+import static io.github.com.pages.feedback.DialogPage.confirmationDialogOkButton;
+import static io.github.com.pages.feedback.DialogPage.dialogCallistoRingtone;
+import static io.github.com.pages.feedback.DialogPage.dialogCloseButton;
+import static io.github.com.pages.feedback.DialogPage.dialogLunaRingtone;
+import static io.github.com.pages.feedback.DialogPage.dialogOkButton;
+import static io.github.com.pages.feedback.DialogPage.scrollableDialogCancelButton;
+import static io.github.com.pages.feedback.DialogPage.subscribeButton;
+
+public class DialogDataProvider {
+    private final String dialogTextContent =
+            "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ultricesurna tortor, " +
+                    "ac pharetra tortor venenatis id. Praesent consecteturtempor fringilla." +
+                    " Cras laoreet sodales pellentesque. Ut nibh leo,auctor id massa vitae," +
+                    " consequat congue turpis.";
+
+    @DataProvider
+    public Object[][] simpleDialogDataProvider() {
+        return new Object[][]{
+                {"Set backup account", "Selected: username@gmail.com"},
+        };
+    }
+
+    @DataProvider
+    public Object[][] alertDialogDataProvider() {
+        return new Object[][]{
+                {"Alert dialog question?", dialogTextContent, dialogOkButton, "Selected: ok"},
+                {"Alert dialog question?", dialogTextContent, dialogCloseButton, "Selected: close"},
+        };
+    }
+
+    @DataProvider
+    public Object[][] formDialogDataProvider() {
+        return new Object[][]{
+                {"Form Dialog", dialogTextContent, "email@example.com", "Entered email: email@example.com"},
+                {"Form Dialog", dialogTextContent, "", "Entered email:"},
+        };
+    }
+
+    @DataProvider
+    public Object[][] confirmationDialogDataProvider() {
+        return new Object[][]{
+                {"Phone Ringtone", dialogCallistoRingtone, confirmationDialogOkButton, "Callisto"},
+                {"Phone Ringtone", dialogLunaRingtone, confirmationDialogCancelButton, "Dione"},
+        };
+    }
+
+    @DataProvider
+    public Object[][] scrollableDialogDataProvider() {
+        String dialogScrollableTextContent = "Cras mattis consectetur purus sit amet fermentum. " +
+                "Cras justo odio, dapibus ac facilisis in, egestas eget quam. Morbi leo risus, porta ac " +
+                "consectetur ac, vestibulum at eros. Praesent commodo cursus magna, vel scelerisque nisl" +
+                " consectetur et.";
+
+        return new Object[][]{
+                {"Subscribe", dialogScrollableTextContent, subscribeButton, "Last clicked button: Subscribe"},
+                {"Subscribe", dialogScrollableTextContent,
+                        scrollableDialogCancelButton, "Last clicked button: Cancel"},
+        };
+    }
+}


### PR DESCRIPTION
Added:
DialogDataProvider.java

Updated:
DialogPage.java (unused elements deleted)
DialogTests.java (false-positive tests deleted, data providers added, tests shortened because of data provider implementation)

Notes: 
The element itself can not be implemented as custom element because there's no common behavior in all of his different implementations and it can not extend section because it has no sense and not all section's elements (such as Text (html element)) methods (such as is().visible(), is(). enable(), etc.) work.