### PR TITLE
Tsk3542: Fixing naming convention Vuetify

### DIFF
--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/AdvancedCombobox.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/AdvancedCombobox.java
@@ -17,18 +17,18 @@ import static com.epam.jdi.light.driver.get.DriverData.getOs;
 
 public class AdvancedCombobox extends Combobox {
 
-    protected String VALUE_LOCATOR = ".pr-2";
+    protected String valueLocator = ".pr-2";
 
     @Override
     public List<String> selectedValues() {
-        return finds(VALUE_LOCATOR).stream().map(UIElement::getText).collect(Collectors.toList());
+        return finds(valueLocator).stream().map(UIElement::getText).collect(Collectors.toList());
     }
 
     @Override
     public void select(String value) {
         if (!isSelected(value)) {
             expand();
-            find(LIST_LOCATOR + "/..//span[text()[normalize-space() = '" + value + "']]").click();
+            find(listLocator + "/..//span[text()[normalize-space() = '" + value + "']]").click();
             if (isExpanded()) {
                 close();
             }
@@ -40,7 +40,7 @@ public class AdvancedCombobox extends Combobox {
         if (!isSelected(values)) {
             expand();
             values.forEach(x -> {
-                find(LIST_LOCATOR + "/..//span[text()[normalize-space() = '" + x + "']]").click();
+                find(listLocator + "/..//span[text()[normalize-space() = '" + x + "']]").click();
             });
             if (isExpanded()) {
                 close();
@@ -74,7 +74,7 @@ public class AdvancedCombobox extends Combobox {
         if (isSelected(value)) {
             unselect(value);
         }
-        String itemId = find(LIST_LOCATOR + "//..//span[text()[normalize-space() = '" + value + "']]/../..").attr("id");
+        String itemId = find(listLocator + "//..//span[text()[normalize-space() = '" + value + "']]/../..").attr("id");
         UIElement button = find("//ancestor::div[@id = 'app']//div[@id = '" + itemId + "']//button[@type = 'button']");
         UIElement inputField = find("//ancestor::div[@id = 'app']//div[@id = '" + itemId + "']//input");
 

--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/PaginationPage.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/PaginationPage.java
@@ -9,8 +9,7 @@ public class PaginationPage extends VuetifyPage {
             root = "#CirclePagination .v-pagination",
             items = ".v-pagination__item",
             left = ".v-pagination__navigation[1]",
-            right = ".v-pagination__navigation[2]",
-            more = ".v-pagination__more"
+            right = ".v-pagination__navigation[2]"
     )
     public static Pagination circlePagination;
 

--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/VuetifyPage.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/VuetifyPage.java
@@ -31,7 +31,7 @@ import static com.epam.jdi.light.settings.WebSettings.init;
  */
 public abstract class VuetifyPage extends WebPage implements ISetup {
 
-    protected String PAGE_LINK = "";
+    protected String pageLink = "";
 
     /**
      * Custom page object `open` code to support SPA provided by nuxt.
@@ -57,13 +57,13 @@ public abstract class VuetifyPage extends WebPage implements ISetup {
      * As far as nuxt is a vue.js based framework, we can use the same commands.
      */
     private void navigate() {
-        if (PAGE_LINK.isEmpty()) {
+        if (pageLink.isEmpty()) {
             throw new RuntimeException("VuetifyPage url has not been set.");
         }
 
         // use the described way to navigate
         // we take a `$nuxt` object from the global scope and call the page router `push` method with the desired url.
-        js().executeScript("$nuxt.$router.push({'path': arguments[0]})", PAGE_LINK);
+        js().executeScript("$nuxt.$router.push({'path': arguments[0]})", pageLink);
     }
 
     /**
@@ -83,6 +83,6 @@ public abstract class VuetifyPage extends WebPage implements ISetup {
             throw new RuntimeException("VuetifyPage does not have an Url annotation.");
         }
 
-        PAGE_LINK = field.getAnnotation(Url.class).value().substring(1);
+        pageLink = field.getAnnotation(Url.class).value().substring(1);
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/annotations/JDIPagination.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/annotations/JDIPagination.java
@@ -14,5 +14,4 @@ public @interface JDIPagination {
     @MarkupLocator String items() default "";
     @MarkupLocator String left() default "";
     @MarkupLocator String right() default "";
-    @MarkupLocator String more() default "";
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Input.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Input.java
@@ -16,15 +16,15 @@ import static com.epam.jdi.light.driver.get.DriverData.getOs;
 
 public class Input extends UIBaseElement<InputAssert> {
 
-    private final String LABEL = "div label";
-    private final String INPUT = "div input";
-    private final String SLOT = "div .v-input__slot";
-    private final String MESSAGE = "div .v-messages__message";
-    private final String PREPEND_OUTER = ".v-input__prepend-outer";
-    private final String PREPEND_INNER = "div .v-input__prepend-inner";
-    private final String APPEND_OUTER = ".v-input__append-outer";
-    private final String APPEND_INNER = "div .v-input__append-inner";
-    private final String SWITCH_SELECTION_CONTROL = "div .v-input--selection-controls__ripple";
+    private static final String LABEL = "div label";
+    private static final String INPUT = "div input";
+    private static final String SLOT = "div .v-input__slot";
+    private static final String MESSAGE = "div .v-messages__message";
+    private static final String PREPEND_OUTER = ".v-input__prepend-outer";
+    private static final String PREPEND_INNER = "div .v-input__prepend-inner";
+    private static final String APPEND_OUTER = ".v-input__append-outer";
+    private static final String APPEND_INNER = "div .v-input__append-inner";
+    private static final String SWITCH_SELECTION_CONTROL = "div .v-input--selection-controls__ripple";
 
     private UIElement input() {
         return this.find(INPUT);

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Overlay.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Overlay.java
@@ -15,8 +15,6 @@ public class Overlay extends UIBaseElement<OverlayAssert> {
 
     private static final double DEFAULT_OPACITY = 0.46;
     private static final int DEFAULT_Z_INDEX = 5;
-    private String scrimLocator = ".v-overlay__scrim";
-    private String contentLocator = ".v-overlay__content";
 
     Overlay() {
     }
@@ -27,6 +25,7 @@ public class Overlay extends UIBaseElement<OverlayAssert> {
 
     @JDIAction("Get content '{name}'")
     public UIElement content() {
+        String contentLocator = ".v-overlay__content";
         return $$(contentLocator, core()).stream().findFirst().orElse(null);
     }
 
@@ -48,6 +47,7 @@ public class Overlay extends UIBaseElement<OverlayAssert> {
 
     @JDIAction("Get '{name}' opacity")
     public double opacity() {
+        String scrimLocator = ".v-overlay__scrim";
         if (!$(scrimLocator, core()).css("opacity").isEmpty())
             return Double.parseDouble($(scrimLocator, core()).css("opacity"));
         else

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Overlay.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Overlay.java
@@ -13,10 +13,10 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  */
 public class Overlay extends UIBaseElement<OverlayAssert> {
 
-    protected String SCRIM_LOCATOR = ".v-overlay__scrim";
-    protected String CONTENT_LOCATOR = ".v-overlay__content";
-    protected double DEFAULT_OPACITY = 0.46;
-    protected int DEFAULT_Z_INDEX = 5;
+    protected static final double DEFAULT_OPACITY = 0.46;
+    protected static final int DEFAULT_Z_INDEX = 5;
+    protected String scrimLocator = ".v-overlay__scrim";
+    protected String contentLocator = ".v-overlay__content";
 
     Overlay() {
     }
@@ -27,7 +27,7 @@ public class Overlay extends UIBaseElement<OverlayAssert> {
 
     @JDIAction("Get content '{name}'")
     public UIElement content() {
-        return $$(CONTENT_LOCATOR, core()).stream().findFirst().orElse(null);
+        return $$(contentLocator, core()).stream().findFirst().orElse(null);
     }
 
     public boolean isActive() {
@@ -48,8 +48,8 @@ public class Overlay extends UIBaseElement<OverlayAssert> {
 
     @JDIAction("Get '{name}' opacity")
     public double opacity() {
-        if (!$(SCRIM_LOCATOR, core()).css("opacity").isEmpty())
-            return Double.parseDouble($(SCRIM_LOCATOR, core()).css("opacity"));
+        if (!$(scrimLocator, core()).css("opacity").isEmpty())
+            return Double.parseDouble($(scrimLocator, core()).css("opacity"));
         else
             return DEFAULT_OPACITY;
     }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Overlay.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/common/Overlay.java
@@ -13,10 +13,10 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  */
 public class Overlay extends UIBaseElement<OverlayAssert> {
 
-    protected static final double DEFAULT_OPACITY = 0.46;
-    protected static final int DEFAULT_Z_INDEX = 5;
-    protected String scrimLocator = ".v-overlay__scrim";
-    protected String contentLocator = ".v-overlay__content";
+    private static final double DEFAULT_OPACITY = 0.46;
+    private static final int DEFAULT_Z_INDEX = 5;
+    private String scrimLocator = ".v-overlay__scrim";
+    private String contentLocator = ".v-overlay__content";
 
     Overlay() {
     }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
@@ -21,16 +21,16 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class Breadcrumbs extends UIListBase<UISelectAssert<UISelectAssert<?,?>, WebList>> implements ISetup {
 
-    // these locators are default and can be modified by JDIBreadcrumbs annotation
-    protected String ROOT_LOCATOR = ".v-breadcrumbs";
-    protected String ITEMS_LOCATOR = ".v-breadcrumbs__item";
-    protected String DIVIDERS_LOCATOR = ".v-breadcrumbs__divider";
+    protected static String DISABLED_LINK_CLASS = "v-breadcrumbs__item--disabled";
 
-    protected String DISABLED_LINK_CLASS = "v-breadcrumbs__item--disabled";
+    // these locators are default and can be modified by JDIBreadcrumbs annotation
+    protected String rootLocator = ".v-breadcrumbs";
+    protected String itemsLocator = ".v-breadcrumbs__item";
+    protected String dividersLocator = ".v-breadcrumbs__divider";
 
     @Override
     public WebList list() {
-        return $$(ITEMS_LOCATOR, this).setName(getName() + " breadcrumb");
+        return $$(itemsLocator, this).setName(getName() + " breadcrumb");
     }
 
     @JDIAction("Get selected element from '{name}'")
@@ -46,7 +46,7 @@ public class Breadcrumbs extends UIListBase<UISelectAssert<UISelectAssert<?,?>, 
 
     @JDIAction("Get dividers list from '{name}'")
     public WebList dividers() {
-        return $$(DIVIDERS_LOCATOR, this).setName(getName() + " dividers");
+        return $$(dividersLocator, this).setName(getName() + " dividers");
     }
 
     @JDIAction("Get items list from '{name}'")
@@ -60,19 +60,19 @@ public class Breadcrumbs extends UIListBase<UISelectAssert<UISelectAssert<?,?>, 
             JDIBreadcrumbs annotation = field.getAnnotation(JDIBreadcrumbs.class);
             initializeLocators(annotation);
         }
-        this.setCore(Breadcrumbs.class, $(ROOT_LOCATOR));
+        this.setCore(Breadcrumbs.class, $(rootLocator));
         this.setName(String.format("Breadcrumbs container %s", field.getName()));
     }
 
     private void initializeLocators(JDIBreadcrumbs annotation) {
         if (!annotation.root().isEmpty()) {
-            ROOT_LOCATOR = annotation.root();
+            rootLocator = annotation.root();
         }
         if (!annotation.items().isEmpty()) {
-            ITEMS_LOCATOR = annotation.items();
+            itemsLocator = annotation.items();
         }
         if (!annotation.dividers().isEmpty()) {
-            DIVIDERS_LOCATOR = annotation.dividers();
+            dividersLocator = annotation.dividers();
         }
     }
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
@@ -21,7 +21,7 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class Breadcrumbs extends UIListBase<UISelectAssert<UISelectAssert<?,?>, WebList>> implements ISetup {
 
-    protected static String DISABLED_LINK_CLASS = "v-breadcrumbs__item--disabled";
+    protected static final String DISABLED_LINK_CLASS = "v-breadcrumbs__item--disabled";
 
     // these locators are default and can be modified by JDIBreadcrumbs annotation
     protected String rootLocator = ".v-breadcrumbs";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
@@ -24,8 +24,8 @@ public class Breadcrumbs extends UIListBase<UISelectAssert<UISelectAssert<?,?>, 
     protected static final String DISABLED_LINK_CLASS = "v-breadcrumbs__item--disabled";
 
     // these locators are default and can be modified by JDIBreadcrumbs annotation
-    protected String rootLocator = ".v-breadcrumbs";
-    protected String dividersLocator = ".v-breadcrumbs__divider";
+    private String rootLocator = ".v-breadcrumbs";
+    private String dividersLocator = ".v-breadcrumbs__divider";
     private String itemsLocator = ".v-breadcrumbs__item";
 
     @Override

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Breadcrumbs.java
@@ -25,8 +25,8 @@ public class Breadcrumbs extends UIListBase<UISelectAssert<UISelectAssert<?,?>, 
 
     // these locators are default and can be modified by JDIBreadcrumbs annotation
     protected String rootLocator = ".v-breadcrumbs";
-    protected String itemsLocator = ".v-breadcrumbs__item";
     protected String dividersLocator = ".v-breadcrumbs__divider";
+    private String itemsLocator = ".v-breadcrumbs__item";
 
     @Override
     public WebList list() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/ButtonGroup.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/ButtonGroup.java
@@ -30,7 +30,7 @@ public class ButtonGroup extends UIListBase<UISelectAssert<?,?>> implements ISet
 
     private static final String TEXT_FIND_PATTERN = "//*[text() = '%s']";
 
-    protected String buttonsFindStrategy = ".v-btn";
+    private String buttonsFindStrategy = ".v-btn";
 
     @JDIAction("Get Button with index '{0}'")
     public Button getButtonByIndex(int index) {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/ButtonGroup.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/ButtonGroup.java
@@ -28,8 +28,9 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class ButtonGroup extends UIListBase<UISelectAssert<?,?>> implements ISetup {
 
-    protected String BUTTONS_FIND_STRATEGY = ".v-btn";
     private static final String TEXT_FIND_PATTERN = "//*[text() = '%s']";
+
+    protected String buttonsFindStrategy = ".v-btn";
 
     @JDIAction("Get Button with index '{0}'")
     public Button getButtonByIndex(int index) {
@@ -48,7 +49,7 @@ public class ButtonGroup extends UIListBase<UISelectAssert<?,?>> implements ISet
 
     @Override
     public WebList list() {
-        return core().finds(BUTTONS_FIND_STRATEGY);
+        return core().finds(buttonsFindStrategy);
     }
 
     private Button castToButton(UIElement element) {
@@ -65,7 +66,7 @@ public class ButtonGroup extends UIListBase<UISelectAssert<?,?>> implements ISet
             this.setCore(this.getClass(), $(annotation.root()));
         }
         if (!annotation.buttons().isEmpty()) {
-            BUTTONS_FIND_STRATEGY = annotation.buttons();
+            buttonsFindStrategy = annotation.buttons();
         }
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Combobox.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Combobox.java
@@ -23,27 +23,27 @@ import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
 public class Combobox extends UIBaseElement<ComboboxAssert> implements ISetup {
 
-    protected String ROOT_LOCATOR = "div[role = 'combobox']";
-    protected String LIST_LOCATOR = ".v-list-item__title";
-    protected String VALUE_LOCATOR = "div input[type='hidden']";
-    protected String INPUT_LOCATOR = "div input[type='text']";
-    protected String EXPAND_LOCATOR = "div .v-input__append-inner";
-    protected String LABEL_LOCATOR = ".v-label";
-    protected String MESSAGE_LOCATOR = "//following::div[@class = 'v-messages__message']";
+    protected String rootLocator = "div[role = 'combobox']";
+    protected String listLocator = ".v-list-item__title";
+    protected String valueLocator = "div input[type='hidden']";
+    protected String inputLocator = "div input[type='text']";
+    protected String expandLocator = "div .v-input__append-inner";
+    protected String labelLocator = ".v-label";
+    protected String messageLocator = "//following::div[@class = 'v-messages__message']";
 
     @Override
     public void setup(Field field) {
         if (!fieldHasAnnotation(field, JDICombobox.class, Combobox.class)) return;
         JDICombobox j = field.getAnnotation(JDICombobox.class);
         setup(j.root(), j.listItems());
-        this.setCore(Combobox.class, $(ROOT_LOCATOR));
+        this.setCore(Combobox.class, $(rootLocator));
     }
 
     public Combobox setup(String comboboxLocator, String listItemsLocator) {
         if (isNotBlank(comboboxLocator))
-            ROOT_LOCATOR = comboboxLocator;
+            rootLocator = comboboxLocator;
         if (isNotBlank(listItemsLocator)) {
-            LIST_LOCATOR = listItemsLocator;
+            listLocator = listItemsLocator;
         }
         return this;
     }
@@ -54,27 +54,27 @@ public class Combobox extends UIBaseElement<ComboboxAssert> implements ISetup {
     }
 
     public List<String> selectedValues() {
-        return Arrays.asList(core().find(VALUE_LOCATOR).attr("value").split(","));
+        return Arrays.asList(core().find(valueLocator).attr("value").split(","));
     }
 
     private UIElement input() {
-        return core().find(INPUT_LOCATOR);
+        return core().find(inputLocator);
     }
 
     private UIElement expander() {
-        return core().find(EXPAND_LOCATOR);
+        return core().find(expandLocator);
     }
 
     public WebList listItems() {
-        return finds(LIST_LOCATOR);
+        return finds(listLocator);
     }
 
     public UIElement label() {
-        return core().find(LABEL_LOCATOR);
+        return core().find(labelLocator);
     }
 
     public UIElement message() {
-        return find(MESSAGE_LOCATOR);
+        return find(messageLocator);
     }
 
     @JDIAction("Expand '{name}'")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Hover.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Hover.java
@@ -21,7 +21,7 @@ import static com.epam.jdi.light.elements.init.UIFactory.$;
  */
 public class Hover extends UIBaseElement<TextAssert> implements ISetup, IsText {
 
-    protected String HOVER_TARGET_SELECTOR = "";
+    protected String hoverTargetSelector = "";
 
     @JDIAction("Move cursor inside '{name}' target element")
     public void show() {
@@ -39,10 +39,10 @@ public class Hover extends UIBaseElement<TextAssert> implements ISetup, IsText {
     }
 
     private UIElement getHoverTarget() {
-        if (HOVER_TARGET_SELECTOR.isEmpty()) {
+        if (hoverTargetSelector.isEmpty()) {
             return core();
         }
-        return $(HOVER_TARGET_SELECTOR);
+        return $(hoverTargetSelector);
     }
 
     @Override
@@ -50,7 +50,7 @@ public class Hover extends UIBaseElement<TextAssert> implements ISetup, IsText {
         if (!field.isAnnotationPresent(JDIHover.class)) {
             return;
         }
-        HOVER_TARGET_SELECTOR = field.getAnnotation(JDIHover.class).value();
+        hoverTargetSelector = field.getAnnotation(JDIHover.class).value();
     }
 
     @Override

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
@@ -19,8 +19,8 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class Pagination extends UIListBase<PaginationAssert> implements ISetup {
 
-    protected static String CORE_CLASS_DISABLED = "v-pagination--disabled";
-    protected static String ITEM_CLASS_SELECTED = "v-pagination__item--active";
+    protected static final String CORE_CLASS_DISABLED = "v-pagination--disabled";
+    protected static final String ITEM_CLASS_SELECTED = "v-pagination__item--active";
 
     protected String rootLocator = ".v-pagination";
     protected String itemsLocator = ".v-pagination__item";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
@@ -24,9 +24,9 @@ public class Pagination extends UIListBase<PaginationAssert> implements ISetup {
 
     protected String rootLocator = ".v-pagination";
     protected String itemsLocator = ".v-pagination__item";
-    protected String leftNavigationLocator = ".v-pagination__navigation[1]";
-    protected String rightNavigationLocator = ".v-pagination__navigation[2]";
     protected String moreItemsLocator = ".v-pagination__more";
+    private String rightNavigationLocator = ".v-pagination__navigation[2]";
+    private String leftNavigationLocator = ".v-pagination__navigation[1]";
 
     @Override
     @JDIAction("Get '{name}' list of all buttons ")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
@@ -22,9 +22,9 @@ public class Pagination extends UIListBase<PaginationAssert> implements ISetup {
     protected static final String CORE_CLASS_DISABLED = "v-pagination--disabled";
     protected static final String ITEM_CLASS_SELECTED = "v-pagination__item--active";
 
-    protected String rootLocator = ".v-pagination";
-    protected String itemsLocator = ".v-pagination__item";
-    protected String moreItemsLocator = ".v-pagination__more";
+    private String rootLocator = ".v-pagination";
+    private String itemsLocator = ".v-pagination__item";
+    private String moreItemsLocator = ".v-pagination__more";
     private String rightNavigationLocator = ".v-pagination__navigation[2]";
     private String leftNavigationLocator = ".v-pagination__navigation[1]";
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
@@ -24,7 +24,6 @@ public class Pagination extends UIListBase<PaginationAssert> implements ISetup {
 
     private String rootLocator = ".v-pagination";
     private String itemsLocator = ".v-pagination__item";
-    private String moreItemsLocator = ".v-pagination__more";
     private String rightNavigationLocator = ".v-pagination__navigation[2]";
     private String leftNavigationLocator = ".v-pagination__navigation[1]";
 
@@ -129,9 +128,6 @@ public class Pagination extends UIListBase<PaginationAssert> implements ISetup {
         }
         if (!annotation.right().isEmpty()) {
             rightNavigationLocator = annotation.right();
-        }
-        if (!annotation.more().isEmpty()) {
-            moreItemsLocator = annotation.more();
         }
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Pagination.java
@@ -19,29 +19,29 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class Pagination extends UIListBase<PaginationAssert> implements ISetup {
 
-    protected String ROOT_LOCATOR = ".v-pagination";
-    protected String ITEMS_LOCATOR = ".v-pagination__item";
-    protected String LEFT_NAVIGATION_LOCATOR = ".v-pagination__navigation[1]";
-    protected String RIGHT_NAVIGATION_LOCATOR = ".v-pagination__navigation[2]";
-    protected String MORE_ITEMS_LOCATOR = ".v-pagination__more";
+    protected static String CORE_CLASS_DISABLED = "v-pagination--disabled";
+    protected static String ITEM_CLASS_SELECTED = "v-pagination__item--active";
 
-    protected String CORE_CLASS_DISABLED = "v-pagination--disabled";
-    protected String ITEM_CLASS_SELECTED = "v-pagination__item--active";
+    protected String rootLocator = ".v-pagination";
+    protected String itemsLocator = ".v-pagination__item";
+    protected String leftNavigationLocator = ".v-pagination__navigation[1]";
+    protected String rightNavigationLocator = ".v-pagination__navigation[2]";
+    protected String moreItemsLocator = ".v-pagination__more";
 
     @Override
     @JDIAction("Get '{name}' list of all buttons ")
     public WebList list() {
-        return finds(ITEMS_LOCATOR).setName(getName() + " pagination");
+        return finds(itemsLocator).setName(getName() + " pagination");
     }
 
     @JDIAction("Get '{name}' left navigation button")
     public UIElement leftNavigation() {
-        return find(LEFT_NAVIGATION_LOCATOR);
+        return find(leftNavigationLocator);
     }
 
     @JDIAction("Get '{name}' right navigation button")
     public UIElement rightNavigation() {
-        return find(RIGHT_NAVIGATION_LOCATOR);
+        return find(rightNavigationLocator);
     }
 
     @Override
@@ -113,25 +113,25 @@ public class Pagination extends UIListBase<PaginationAssert> implements ISetup {
             JDIPagination annotation = field.getAnnotation(JDIPagination.class);
             initializeLocators(annotation);
         }
-        this.setCore(Pagination.class, $(ROOT_LOCATOR));
+        this.setCore(Pagination.class, $(rootLocator));
         this.setName(String.format("Pagination %s", field.getName()));
     }
 
     private void initializeLocators(JDIPagination annotation) {
         if (!annotation.root().isEmpty()) {
-            ROOT_LOCATOR = annotation.root();
+            rootLocator = annotation.root();
         }
         if (!annotation.items().isEmpty()) {
-            ITEMS_LOCATOR = annotation.items();
+            itemsLocator = annotation.items();
         }
         if (!annotation.left().isEmpty()) {
-            LEFT_NAVIGATION_LOCATOR = annotation.left();
+            leftNavigationLocator = annotation.left();
         }
         if (!annotation.right().isEmpty()) {
-            RIGHT_NAVIGATION_LOCATOR = annotation.right();
+            rightNavigationLocator = annotation.right();
         }
         if (!annotation.more().isEmpty()) {
-            MORE_ITEMS_LOCATOR = annotation.more();
+            moreItemsLocator = annotation.more();
         }
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
@@ -19,21 +19,21 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  */
 public class RangeSlider extends UIBaseElement<RangeSliderAssert> {
 
-    protected static final String DISABLED = "v-slider--disabled";
-    protected static final String VERTICAL = "v-slider--vertical";
+    private static final String DISABLED = "v-slider--disabled";
+    private static final String VERTICAL = "v-slider--vertical";
 
     private String thumbContainerLocator = ".v-slider__thumb-container";
-    protected String thumbLocator = ".v-slider__thumb";
-    protected String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
-    protected String thumbLabelLocator = ".v-slider__thumb-label";
+    private String thumbLocator = ".v-slider__thumb";
+    private String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
+    private String thumbLabelLocator = ".v-slider__thumb-label";
 
-    protected String trackContainerLocator = ".v-slider__track-container";
-    protected String trackBackgroundLocator = ".v-slider__track-background";
-    protected String trackFillLocator = ".v-slider__track-fill";
+    private String trackContainerLocator = ".v-slider__track-container";
+    private String trackBackgroundLocator = ".v-slider__track-background";
+    private String trackFillLocator = ".v-slider__track-fill";
 
     private String ticksContainerLocator = ".v-slider__ticks-container";
-    protected String tickLocator = ".v-slider__tick";
-    protected String alwaysShow = "v-slider__ticks-container--always-show";
+    private String tickLocator = ".v-slider__tick";
+    private String alwaysShow = "v-slider__ticks-container--always-show";
     private String tickLabelLocator = ".v-slider__tick-label";
 
     @JDIAction("Get track container from '{name}'")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
@@ -22,7 +22,7 @@ public class RangeSlider extends UIBaseElement<RangeSliderAssert> {
     protected static final String DISABLED = "v-slider--disabled";
     protected static final String VERTICAL = "v-slider--vertical";
 
-    protected String thumbContainerLocator = ".v-slider__thumb-container";
+    private String thumbContainerLocator = ".v-slider__thumb-container";
     protected String thumbLocator = ".v-slider__thumb";
     protected String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
     protected String thumbLabelLocator = ".v-slider__thumb-label";
@@ -31,10 +31,10 @@ public class RangeSlider extends UIBaseElement<RangeSliderAssert> {
     protected String trackBackgroundLocator = ".v-slider__track-background";
     protected String trackFillLocator = ".v-slider__track-fill";
 
-    protected String ticksContainerLocator = ".v-slider__ticks-container";
+    private String ticksContainerLocator = ".v-slider__ticks-container";
     protected String tickLocator = ".v-slider__tick";
     protected String alwaysShow = "v-slider__ticks-container--always-show";
-    protected String tickLabelLocator = ".v-slider__tick-label";
+    private String tickLabelLocator = ".v-slider__tick-label";
 
     @JDIAction("Get track container from '{name}'")
     protected UIElement getTrackContainer() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
@@ -18,56 +18,57 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  * To see an example of Range Slider web element please visit https://vuetifyjs.com/en/components/range-sliders
  */
 public class RangeSlider extends UIBaseElement<RangeSliderAssert> {
-    protected String THUMB_CONTAINER_LOCATOR = ".v-slider__thumb-container";
-    protected String THUMB_LOCATOR = ".v-slider__thumb";
-    protected String THUMB_LABEL_CONTAINER_LOCATOR = ".v-slider__thumb-label-container";
-    protected String THUMB_LABEL_LOCATOR = ".v-slider__thumb-label";
 
-    protected String TRACK_CONTAINER_LOCATOR = ".v-slider__track-container";
-    protected String TRACK_BACKGROUND_LOCATOR = ".v-slider__track-background";
-    protected String TRACK_FILL_LOCATOR = ".v-slider__track-fill";
+    protected static String DISABLED = "v-slider--disabled";
+    protected static String VERTICAL = "v-slider--vertical";
 
-    protected String TICKS_CONTAINER_LOCATOR = ".v-slider__ticks-container";
-    protected String TICK_LOCATOR = ".v-slider__tick";
-    protected String ALWAYS_SHOW = "v-slider__ticks-container--always-show";
-    protected String TICK_LABEL_LOCATOR = ".v-slider__tick-label";
+    protected String thumbContainerLocator = ".v-slider__thumb-container";
+    protected String thumbLocator = ".v-slider__thumb";
+    protected String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
+    protected String thumbLabelLocator = ".v-slider__thumb-label";
 
-    protected String DISABLED = "v-slider--disabled";
-    protected String VERTICAL = "v-slider--vertical";
+    protected String trackContainerLocator = ".v-slider__track-container";
+    protected String trackBackgroundLocator = ".v-slider__track-background";
+    protected String trackFillLocator = ".v-slider__track-fill";
+
+    protected String ticksContainerLocator = ".v-slider__ticks-container";
+    protected String tickLocator = ".v-slider__tick";
+    protected String alwaysShow = "v-slider__ticks-container--always-show";
+    protected String tickLabelLocator = ".v-slider__tick-label";
 
     @JDIAction("Get track container from '{name}'")
     protected UIElement getTrackContainer() {
-        return $(TRACK_CONTAINER_LOCATOR, this);
+        return $(trackContainerLocator, this);
     }
 
     @JDIAction("Get track background from '{name}'")
     public WebList getBackground() {
-        return $$(TRACK_BACKGROUND_LOCATOR, getTrackContainer());
+        return $$(trackBackgroundLocator, getTrackContainer());
     }
 
     @JDIAction("Get thumb container from '{name}'")
     protected WebList getThumbContainer() {
-        return $$(THUMB_CONTAINER_LOCATOR, this);
+        return $$(thumbContainerLocator, this);
     }
 
     @JDIAction("Get left thumb from '{name}'")
     public UIElement getLeftThumb() {
-        return $(THUMB_LOCATOR, getThumbContainer().get(1));
+        return $(thumbLocator, getThumbContainer().get(1));
     }
 
     @JDIAction("Get right thumb from '{name}'")
     public UIElement getRightThumb() {
-        return $(THUMB_LOCATOR, getThumbContainer().get(2));
+        return $(thumbLocator, getThumbContainer().get(2));
     }
 
     @JDIAction("Get thumb label from '{name}'")
     public WebList getThumbLabel() {
-        return $$(THUMB_LABEL_LOCATOR, this);
+        return $$(thumbLabelLocator, this);
     }
 
     @JDIAction("Get tick label value from '{name}'")
     public String getTickLabel(int index) {
-        return $$(TICK_LABEL_LOCATOR, this).get(index).getValue();
+        return $$(tickLabelLocator, this).get(index).getValue();
     }
 
     @JDIAction("Get value from '{name}'")
@@ -129,12 +130,12 @@ public class RangeSlider extends UIBaseElement<RangeSliderAssert> {
 
     @JDIAction("Check if ticks of '{name}' always show")
     public boolean isAlwaysShow() {
-        return $(TICKS_CONTAINER_LOCATOR, this).hasClass(ALWAYS_SHOW);
+        return $(ticksContainerLocator, this).hasClass(alwaysShow);
     }
 
     @JDIAction("Check if thumb label of '{name}' displayed")
     public boolean isThumbLabelDisplayed() {
-        return new WebList(core().findElements(By.cssSelector(THUMB_LABEL_CONTAINER_LOCATOR)))
+        return new WebList(core().findElements(By.cssSelector(thumbLabelContainerLocator)))
                 .stream()
                 .noneMatch(label -> label.getAttribute("style").contains("display: none"));
     }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
@@ -19,8 +19,8 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  */
 public class RangeSlider extends UIBaseElement<RangeSliderAssert> {
 
-    protected static String DISABLED = "v-slider--disabled";
-    protected static String VERTICAL = "v-slider--vertical";
+    protected static final String DISABLED = "v-slider--disabled";
+    protected static final String VERTICAL = "v-slider--vertical";
 
     protected String thumbContainerLocator = ".v-slider__thumb-container";
     protected String thumbLocator = ".v-slider__thumb";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/RangeSlider.java
@@ -29,10 +29,8 @@ public class RangeSlider extends UIBaseElement<RangeSliderAssert> {
 
     private String trackContainerLocator = ".v-slider__track-container";
     private String trackBackgroundLocator = ".v-slider__track-background";
-    private String trackFillLocator = ".v-slider__track-fill";
 
     private String ticksContainerLocator = ".v-slider__ticks-container";
-    private String tickLocator = ".v-slider__tick";
     private String alwaysShow = "v-slider__ticks-container--always-show";
     private String tickLabelLocator = ".v-slider__tick-label";
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
@@ -23,14 +23,14 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class Rating extends UIBaseElement<RatingAssert> implements ISetup, IBaseElement {
 
-    protected static final int DEFAULT_SIZE = 24;
+    private static final int DEFAULT_SIZE = 24;
 
-    protected String rootLocator = ".v-rating";
-    protected String emptyIconLocator = "";
-    protected String fullIconLocator = "";
-    protected String halfIconLocator = "";
-    protected String colorLocator = "";
-    protected String backgroundColorLocator = "";
+    private String rootLocator = ".v-rating";
+    private String emptyIconLocator = "";
+    private String fullIconLocator = "";
+    private String halfIconLocator = "";
+    private String colorLocator = "";
+    private String backgroundColorLocator = "";
     private String backgroundDarkenLocator = "";
 
     @JDIAction("Get {name} rating buttons")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
@@ -23,7 +23,7 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class Rating extends UIBaseElement<RatingAssert> implements ISetup, IBaseElement {
 
-    protected static int DEFAULT_SIZE = 24;
+    protected static final int DEFAULT_SIZE = 24;
 
     protected String rootLocator = ".v-rating";
     protected String emptyIconLocator = "";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
@@ -31,7 +31,7 @@ public class Rating extends UIBaseElement<RatingAssert> implements ISetup, IBase
     protected String halfIconLocator = "";
     protected String colorLocator = "";
     protected String backgroundColorLocator = "";
-    protected String backgroundDarkenLocator = "";
+    private String backgroundDarkenLocator = "";
 
     @JDIAction("Get {name} rating buttons")
     public WebList getRatingButtons() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Rating.java
@@ -23,14 +23,15 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class Rating extends UIBaseElement<RatingAssert> implements ISetup, IBaseElement {
 
-    protected String ROOT_LOCATOR = ".v-rating";
-    protected String EMPTY_ICON_LOCATOR = "";
-    protected String FULL_ICON_LOCATOR = "";
-    protected String HALF_ICON_LOCATOR = "";
-    protected String COLOR_LOCATOR = "";
-    protected String BACKGROUND_COLOR_LOCATOR = "";
-    protected String BACKGROUND_DARKEN_LOCATOR = "";
-    protected int DEFAULT_SIZE = 24;
+    protected static int DEFAULT_SIZE = 24;
+
+    protected String rootLocator = ".v-rating";
+    protected String emptyIconLocator = "";
+    protected String fullIconLocator = "";
+    protected String halfIconLocator = "";
+    protected String colorLocator = "";
+    protected String backgroundColorLocator = "";
+    protected String backgroundDarkenLocator = "";
 
     @JDIAction("Get {name} rating buttons")
     public WebList getRatingButtons() {
@@ -92,29 +93,29 @@ public class Rating extends UIBaseElement<RatingAssert> implements ISetup, IBase
     @JDIAction("Get {name} rating")
     public Double getValue() {
 
-        if (!HALF_ICON_LOCATOR.isEmpty()) {
-            UIElement distinctiveElement = distinctiveElement(HALF_ICON_LOCATOR);
+        if (!halfIconLocator.isEmpty()) {
+            UIElement distinctiveElement = distinctiveElement(halfIconLocator);
             if (distinctiveElement != null) {
                 return rating(distinctiveElement) + 0.5;
             }
         }
-        if (!Objects.equals(FULL_ICON_LOCATOR, EMPTY_ICON_LOCATOR)) {
-            UIElement distinctiveElement = distinctiveElement(EMPTY_ICON_LOCATOR);
+        if (!Objects.equals(fullIconLocator, emptyIconLocator)) {
+            UIElement distinctiveElement = distinctiveElement(emptyIconLocator);
             if (distinctiveElement != null) {
                 return rating(distinctiveElement);
             }
-            if (FULL_ICON_LOCATOR != null && !FULL_ICON_LOCATOR.isEmpty() && distinctiveElement(FULL_ICON_LOCATOR) != null) {
+            if (fullIconLocator != null && !fullIconLocator.isEmpty() && distinctiveElement(fullIconLocator) != null) {
                 return (double) length();
             }
         }
-        if (!Objects.equals(BACKGROUND_COLOR_LOCATOR, COLOR_LOCATOR)) {
-            UIElement distinctiveElement = distinctiveElement(BACKGROUND_COLOR_LOCATOR);
+        if (!Objects.equals(backgroundColorLocator, colorLocator)) {
+            UIElement distinctiveElement = distinctiveElement(backgroundColorLocator);
             if (distinctiveElement != null) {
                 return rating(distinctiveElement);
             }
         }
-        if (!BACKGROUND_DARKEN_LOCATOR.isEmpty()) {
-            UIElement distinctiveElement = distinctiveElement(BACKGROUND_DARKEN_LOCATOR);
+        if (!backgroundDarkenLocator.isEmpty()) {
+            UIElement distinctiveElement = distinctiveElement(backgroundDarkenLocator);
             if (distinctiveElement != null) {
                 return rating(distinctiveElement);
             }
@@ -138,31 +139,31 @@ public class Rating extends UIBaseElement<RatingAssert> implements ISetup, IBase
             JDIRating annotation = field.getAnnotation(JDIRating.class);
             initializeLocators(annotation);
         }
-        this.setCore(Breadcrumbs.class, $(ROOT_LOCATOR));
+        this.setCore(Breadcrumbs.class, $(rootLocator));
         this.setName(String.format("Rating container %s", field.getName()));
     }
 
     private void initializeLocators(JDIRating annotation) {
         if (!annotation.root().isEmpty()) {
-            ROOT_LOCATOR = annotation.root();
+            rootLocator = annotation.root();
         }
         if (!annotation.emptyIcon().isEmpty()) {
-            EMPTY_ICON_LOCATOR = annotation.emptyIcon();
+            emptyIconLocator = annotation.emptyIcon();
         }
         if (!annotation.fullIcon().isEmpty()) {
-            FULL_ICON_LOCATOR = annotation.fullIcon();
+            fullIconLocator = annotation.fullIcon();
         }
         if (!annotation.halfIcon().isEmpty()) {
-            HALF_ICON_LOCATOR = annotation.halfIcon();
+            halfIconLocator = annotation.halfIcon();
         }
         if (!annotation.backgroundColor().isEmpty()) {
-            BACKGROUND_COLOR_LOCATOR = annotation.backgroundColor();
+            backgroundColorLocator = annotation.backgroundColor();
         }
         if (!annotation.color().isEmpty()) {
-            COLOR_LOCATOR = annotation.color();
+            colorLocator = annotation.color();
         }
         if (!annotation.backgroundDarken().isEmpty()) {
-            BACKGROUND_DARKEN_LOCATOR = annotation.backgroundDarken();
+            backgroundDarkenLocator = annotation.backgroundDarken();
         }
     }
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
@@ -22,7 +22,7 @@ public class Slider extends UIBaseElement<SliderAssert> {
     protected String thumbContainerLocator = ".v-slider__thumb-container";
     protected String thumbLocator = ".v-slider__thumb";
     protected String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
-    protected String thumbLabelLocator = ".v-slider__thumb-label";
+    private String thumbLabelLocator = ".v-slider__thumb-label";
 
     protected String trackContainerLocator = ".v-slider__track-container";
     protected String trackBackgroundLocator = ".v-slider__track-background";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
@@ -14,10 +14,10 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  */
 public class Slider extends UIBaseElement<SliderAssert> {
 
-    protected static String DISABLED = "v-slider--disabled";
-    protected static String READONLY = "v-slider--readonly";
-    protected static String VERTICAL = "v-slider--vertical";
-    protected static String ALWAYS_SHOW = "v-slider__ticks-container--always-show";
+    protected static final String DISABLED = "v-slider--disabled";
+    protected static final String READONLY = "v-slider--readonly";
+    protected static final String VERTICAL = "v-slider--vertical";
+    protected static final String ALWAYS_SHOW = "v-slider__ticks-container--always-show";
 
     protected String thumbContainerLocator = ".v-slider__thumb-container";
     protected String thumbLocator = ".v-slider__thumb";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
@@ -14,62 +14,62 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  */
 public class Slider extends UIBaseElement<SliderAssert> {
 
-    protected String THUMB_CONTAINER_LOCATOR = ".v-slider__thumb-container";
-    protected String THUMB_LOCATOR = ".v-slider__thumb";
-    protected String THUMB_LABEL_CONTAINER_LOCATOR = ".v-slider__thumb-label-container";
-    protected String THUMB_LABEL_LOCATOR = ".v-slider__thumb-label";
+    protected static String DISABLED = "v-slider--disabled";
+    protected static String READONLY = "v-slider--readonly";
+    protected static String VERTICAL = "v-slider--vertical";
+    protected static String ALWAYS_SHOW = "v-slider__ticks-container--always-show";
 
-    protected String TRACK_CONTAINER_LOCATOR = ".v-slider__track-container";
-    protected String TRACK_BACKGROUND_LOCATOR = ".v-slider__track-background";
-    protected String TRACK_FILL_LOCATOR = ".v-slider__track-fill";
+    protected String thumbContainerLocator = ".v-slider__thumb-container";
+    protected String thumbLocator = ".v-slider__thumb";
+    protected String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
+    protected String thumbLabelLocator = ".v-slider__thumb-label";
 
-    protected String TICKS_CONTAINER_LOCATOR = ".v-slider__ticks-container";
-    protected String TICK_LOCATOR = ".v-slider__tick";
-    protected String ALWAYS_SHOW = "v-slider__ticks-container--always-show";
-    protected String TICK_LABEL_LOCATOR = ".v-slider__tick-label";
+    protected String trackContainerLocator = ".v-slider__track-container";
+    protected String trackBackgroundLocator = ".v-slider__track-background";
+    protected String trackFillLocator = ".v-slider__track-fill";
 
-    protected String DISABLED = "v-slider--disabled";
-    protected String READONLY = "v-slider--readonly";
-    protected String VERTICAL = "v-slider--vertical";
+    protected String ticksContainerLocator = ".v-slider__ticks-container";
+    protected String tickLocator = ".v-slider__tick";
+    protected String tickLabelLocator = ".v-slider__tick-label";
 
     @JDIAction("Get track container from '{name}'")
     protected UIElement getTrackContainer() {
-        return $(TRACK_CONTAINER_LOCATOR, this);
+        return $(trackContainerLocator, this);
     }
 
     @JDIAction("Get thumb container from '{name}'")
     protected UIElement getThumbContainer() {
-        return $(THUMB_CONTAINER_LOCATOR, this);
+        return $(thumbContainerLocator, this);
     }
 
     @JDIAction("Get track fill from '{name}'")
     public UIElement getFill() {
-        return $(TRACK_FILL_LOCATOR, getTrackContainer());
+        return $(trackFillLocator, getTrackContainer());
     }
 
     @JDIAction("Get track background from '{name}'")
     public UIElement getBackground() {
-        return $(TRACK_BACKGROUND_LOCATOR, getTrackContainer());
+        return $(trackBackgroundLocator, getTrackContainer());
     }
 
     @JDIAction("Get thumb from '{name}'")
     public UIElement getThumb() {
-        return $(THUMB_LOCATOR, getThumbContainer());
+        return $(thumbLocator, getThumbContainer());
     }
 
     @JDIAction("Get thumb label from '{name}'")
     public UIElement getThumbLabel() {
-        return $(THUMB_LABEL_LOCATOR, getThumbContainer());
+        return $(thumbLabelLocator, getThumbContainer());
     }
 
     @JDIAction("Get tick from '{name}'")
     public WebList getTicks() {
-        return $$(TICK_LOCATOR, this);
+        return $$(tickLocator, this);
     }
 
     @JDIAction("Get tick label value from '{name}'")
     public String getTickLabel(int index) {
-        return $$(TICK_LABEL_LOCATOR, this).get(index).getValue();
+        return $$(tickLabelLocator, this).get(index).getValue();
     }
 
     @JDIAction("Get value from '{name}'")
@@ -122,12 +122,12 @@ public class Slider extends UIBaseElement<SliderAssert> {
 
     @JDIAction("Check if ticks of '{name}' always show")
     public boolean isAlwaysShow() {
-        return $(TICKS_CONTAINER_LOCATOR, this).hasClass(ALWAYS_SHOW);
+        return $(ticksContainerLocator, this).hasClass(ALWAYS_SHOW);
     }
 
     @JDIAction("Check if thumb lable of '{name}' displayed")
     public boolean isThumbLabelDisplayed() {
-        return !$(THUMB_LABEL_CONTAINER_LOCATOR, getThumbContainer()).getAttribute("style").contains("display: none");
+        return !$(thumbLabelContainerLocator, getThumbContainer()).getAttribute("style").contains("display: none");
     }
 
     @Override

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/Slider.java
@@ -14,23 +14,23 @@ import static com.epam.jdi.light.elements.init.UIFactory.$$;
  */
 public class Slider extends UIBaseElement<SliderAssert> {
 
-    protected static final String DISABLED = "v-slider--disabled";
-    protected static final String READONLY = "v-slider--readonly";
-    protected static final String VERTICAL = "v-slider--vertical";
-    protected static final String ALWAYS_SHOW = "v-slider__ticks-container--always-show";
+    private static final String DISABLED = "v-slider--disabled";
+    private static final String READONLY = "v-slider--readonly";
+    private static final String VERTICAL = "v-slider--vertical";
+    private static final String ALWAYS_SHOW = "v-slider__ticks-container--always-show";
 
-    protected String thumbContainerLocator = ".v-slider__thumb-container";
-    protected String thumbLocator = ".v-slider__thumb";
-    protected String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
+    private String thumbContainerLocator = ".v-slider__thumb-container";
+    private String thumbLocator = ".v-slider__thumb";
+    private String thumbLabelContainerLocator = ".v-slider__thumb-label-container";
     private String thumbLabelLocator = ".v-slider__thumb-label";
 
-    protected String trackContainerLocator = ".v-slider__track-container";
-    protected String trackBackgroundLocator = ".v-slider__track-background";
-    protected String trackFillLocator = ".v-slider__track-fill";
+    private String trackContainerLocator = ".v-slider__track-container";
+    private String trackBackgroundLocator = ".v-slider__track-background";
+    private String trackFillLocator = ".v-slider__track-fill";
 
-    protected String ticksContainerLocator = ".v-slider__ticks-container";
-    protected String tickLocator = ".v-slider__tick";
-    protected String tickLabelLocator = ".v-slider__tick-label";
+    private String ticksContainerLocator = ".v-slider__ticks-container";
+    private String tickLocator = ".v-slider__tick";
+    private String tickLabelLocator = ".v-slider__tick-label";
 
     @JDIAction("Get track container from '{name}'")
     protected UIElement getTrackContainer() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
@@ -35,12 +35,12 @@ public class TextArea extends UIBaseElement<TextAreaAssert>
     protected String textArea = ".v-input__slot textarea";
     protected String details = ".v-text-field__details";
     protected String message = ".v-messages__message";
-    protected String counter = ".v-counter";
+    private String counter = ".v-counter";
 
     protected String prependOuterIcon = ".v-input__prepend-outer .v-icon";
     protected String prependInnerIcon = ".v-input__prepend-inner .v-icon";
     protected String appendOuterIcon = ".v-input__append-outer .v-icon";
-    protected String appendInnerIcon = ".v-input__append-inner .v-icon";
+    private String appendInnerIcon = ".v-input__append-inner .v-icon";
 
     @JDIAction("Check if '{name}' is filled")
     public boolean isFilled() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
@@ -26,10 +26,10 @@ import static java.util.Arrays.asList;
 public class TextArea extends UIBaseElement<TextAreaAssert>
         implements HasLabel, HasPlaceholder, IsInput {
 
-    protected static String FILLED_CLASS = "v-text-field--filled";
-    protected static String OUTLINED_CLASS = "v-text-field--outlined";
-    protected static String AUTO_GROW_CLASS = "v-textarea--auto-grow";
-    protected static String NO_RESIZE_CLASS = "v-textarea--no-resize";
+    protected static final String FILLED_CLASS = "v-text-field--filled";
+    protected static final String OUTLINED_CLASS = "v-text-field--outlined";
+    protected static final String AUTO_GROW_CLASS = "v-textarea--auto-grow";
+    protected static final String NO_RESIZE_CLASS = "v-textarea--no-resize";
 
     protected String slot = ".v-input__slot";
     protected String textArea = ".v-input__slot textarea";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
@@ -26,20 +26,21 @@ import static java.util.Arrays.asList;
 public class TextArea extends UIBaseElement<TextAreaAssert>
         implements HasLabel, HasPlaceholder, IsInput {
 
-    protected String SLOT = ".v-input__slot";
-    protected String TEXT_AREA = ".v-input__slot textarea";
-    protected String DETAILS = ".v-text-field__details";
-    protected String PREPEND_OUTER_ICON = ".v-input__prepend-outer .v-icon";
-    protected String PREPEND_INNER_ICON = ".v-input__prepend-inner .v-icon";
-    protected String APPEND_OUTER_ICON = ".v-input__append-outer .v-icon";
-    protected String APPEND_INNER_ICON = ".v-input__append-inner .v-icon";
-    protected String MESSAGE = ".v-messages__message";
-    protected String COUNTER = ".v-counter";
+    protected static String FILLED_CLASS = "v-text-field--filled";
+    protected static String OUTLINED_CLASS = "v-text-field--outlined";
+    protected static String AUTO_GROW_CLASS = "v-textarea--auto-grow";
+    protected static String NO_RESIZE_CLASS = "v-textarea--no-resize";
 
-    protected String FILLED_CLASS = "v-text-field--filled";
-    protected String OUTLINED_CLASS = "v-text-field--outlined";
-    protected String AUTO_GROW_CLASS = "v-textarea--auto-grow";
-    protected String NO_RESIZE_CLASS = "v-textarea--no-resize";
+    protected String slot = ".v-input__slot";
+    protected String textArea = ".v-input__slot textarea";
+    protected String details = ".v-text-field__details";
+    protected String message = ".v-messages__message";
+    protected String counter = ".v-counter";
+
+    protected String prependOuterIcon = ".v-input__prepend-outer .v-icon";
+    protected String prependInnerIcon = ".v-input__prepend-inner .v-icon";
+    protected String appendOuterIcon = ".v-input__append-outer .v-icon";
+    protected String appendInnerIcon = ".v-input__append-inner .v-icon";
 
     @JDIAction("Check if '{name}' is filled")
     public boolean isFilled() {
@@ -63,47 +64,47 @@ public class TextArea extends UIBaseElement<TextAreaAssert>
 
     @JDIAction(value = "Get '{name}' slot", level = DEBUG)
     public UIElement slot() {
-        return core().find(SLOT);
+        return core().find(slot);
     }
 
     @JDIAction(value = "Get '{name}' textarea", level = DEBUG)
     public UIElement textArea() {
-        return core().find(TEXT_AREA);
+        return core().find(textArea);
     }
 
     @JDIAction(value = "Get '{name}' details", level = DEBUG)
     public UIElement details() {
-        return core().find(DETAILS);
+        return core().find(details);
     }
 
     @JDIAction(value = "Get '{name}' prepend outer icon", level = DEBUG)
     public Icon prependOuter() {
-        return new Icon().setCore(Icon.class, core().find(PREPEND_OUTER_ICON));
+        return new Icon().setCore(Icon.class, core().find(prependOuterIcon));
     }
 
     @JDIAction(value = "Get '{name}' prepend inner icon", level = DEBUG)
     public Icon prependInner() {
-        return new Icon().setCore(Icon.class, core().find(PREPEND_INNER_ICON));
+        return new Icon().setCore(Icon.class, core().find(prependInnerIcon));
     }
 
     @JDIAction(value = "Get '{name}' append outer icon", level = DEBUG)
     public Icon appendOuter() {
-        return new Icon().setCore(Icon.class, core().find(APPEND_OUTER_ICON));
+        return new Icon().setCore(Icon.class, core().find(appendOuterIcon));
     }
 
     @JDIAction(value = "Get '{name}' append inner icon", level = DEBUG)
     public Icon appendInner() {
-        return new Icon().setCore(Icon.class, core().find(APPEND_INNER_ICON));
+        return new Icon().setCore(Icon.class, core().find(appendInnerIcon));
     }
 
     @JDIAction("Get '{name}' message")
     public UIElement message() {
-        return details().find(MESSAGE);
+        return details().find(message);
     }
 
     @JDIAction("Get '{name}' counter")
     public UIElement counter() {
-        return details().find(COUNTER);
+        return details().find(counter);
     }
 
     @Override

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextArea.java
@@ -26,20 +26,20 @@ import static java.util.Arrays.asList;
 public class TextArea extends UIBaseElement<TextAreaAssert>
         implements HasLabel, HasPlaceholder, IsInput {
 
-    protected static final String FILLED_CLASS = "v-text-field--filled";
-    protected static final String OUTLINED_CLASS = "v-text-field--outlined";
-    protected static final String AUTO_GROW_CLASS = "v-textarea--auto-grow";
-    protected static final String NO_RESIZE_CLASS = "v-textarea--no-resize";
+    private static final String FILLED_CLASS = "v-text-field--filled";
+    private static final String OUTLINED_CLASS = "v-text-field--outlined";
+    private static final String AUTO_GROW_CLASS = "v-textarea--auto-grow";
+    private static final String NO_RESIZE_CLASS = "v-textarea--no-resize";
 
-    protected String slot = ".v-input__slot";
-    protected String textArea = ".v-input__slot textarea";
-    protected String details = ".v-text-field__details";
-    protected String message = ".v-messages__message";
+    private String slot = ".v-input__slot";
+    private String textArea = ".v-input__slot textarea";
+    private String details = ".v-text-field__details";
+    private String message = ".v-messages__message";
     private String counter = ".v-counter";
 
-    protected String prependOuterIcon = ".v-input__prepend-outer .v-icon";
-    protected String prependInnerIcon = ".v-input__prepend-inner .v-icon";
-    protected String appendOuterIcon = ".v-input__append-outer .v-icon";
+    private String prependOuterIcon = ".v-input__prepend-outer .v-icon";
+    private String prependInnerIcon = ".v-input__prepend-inner .v-icon";
+    private String appendOuterIcon = ".v-input__append-outer .v-icon";
     private String appendInnerIcon = ".v-input__append-inner .v-icon";
 
     @JDIAction("Check if '{name}' is filled")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
@@ -24,14 +24,14 @@ import static com.epam.jdi.light.driver.get.DriverData.getOs;
 public class TextField extends UIBaseElement<TextFieldAssert>
         implements HasLabel, HasPlaceholder, IsInput {
 
-    protected static String DISABLED_CLASS = "v-input--is-disabled";
-    protected static String READ_ONLY_CLASS = "v-input--is-readonly";
-    protected static String FOCUSED_CLASS = "v-input--is-focused";
-    protected static String FILLED_CLASS = "v-text-field--filled";
-    protected static String OUTLINED_CLASS = "v-text-field--outlined";
-    protected static String SHAPED_CLASS = "v-text-field--shaped";
-    protected static String SOLO_CLASS = "v-text-field--solo";
-    protected static String FULL_WIDTH_CLASS = "v-text-field--full-width";
+    protected static final String DISABLED_CLASS = "v-input--is-disabled";
+    protected static final String READ_ONLY_CLASS = "v-input--is-readonly";
+    protected static final String FOCUSED_CLASS = "v-input--is-focused";
+    protected static final String FILLED_CLASS = "v-text-field--filled";
+    protected static final String OUTLINED_CLASS = "v-text-field--outlined";
+    protected static final String SHAPED_CLASS = "v-text-field--shaped";
+    protected static final String SOLO_CLASS = "v-text-field--solo";
+    protected static final String FULL_WIDTH_CLASS = "v-text-field--full-width";
 
     protected String input = ".//input|.//textarea";
     protected String slot = ".v-input__slot";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
@@ -34,7 +34,7 @@ public class TextField extends UIBaseElement<TextFieldAssert>
     protected static final String FULL_WIDTH_CLASS = "v-text-field--full-width";
 
     protected String input = ".//input|.//textarea";
-    protected String slot = ".v-input__slot";
+    private String slot = ".v-input__slot";
     protected String message = ".v-messages__message";
     protected String counter = ".v-counter";
     protected String prependOuter = ".v-input__prepend-outer";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
@@ -24,25 +24,25 @@ import static com.epam.jdi.light.driver.get.DriverData.getOs;
 public class TextField extends UIBaseElement<TextFieldAssert>
         implements HasLabel, HasPlaceholder, IsInput {
 
-    protected static final String DISABLED_CLASS = "v-input--is-disabled";
-    protected static final String READ_ONLY_CLASS = "v-input--is-readonly";
-    protected static final String FOCUSED_CLASS = "v-input--is-focused";
-    protected static final String FILLED_CLASS = "v-text-field--filled";
-    protected static final String OUTLINED_CLASS = "v-text-field--outlined";
-    protected static final String SHAPED_CLASS = "v-text-field--shaped";
-    protected static final String SOLO_CLASS = "v-text-field--solo";
-    protected static final String FULL_WIDTH_CLASS = "v-text-field--full-width";
+    private static final String DISABLED_CLASS = "v-input--is-disabled";
+    private static final String READ_ONLY_CLASS = "v-input--is-readonly";
+    private static final String FOCUSED_CLASS = "v-input--is-focused";
+    private static final String FILLED_CLASS = "v-text-field--filled";
+    private static final String OUTLINED_CLASS = "v-text-field--outlined";
+    private static final String SHAPED_CLASS = "v-text-field--shaped";
+    private static final String SOLO_CLASS = "v-text-field--solo";
+    private static final String FULL_WIDTH_CLASS = "v-text-field--full-width";
 
-    protected String input = ".//input|.//textarea";
+    private String input = ".//input|.//textarea";
     private String slot = ".v-input__slot";
-    protected String message = ".v-messages__message";
-    protected String counter = ".v-counter";
-    protected String prependOuter = ".v-input__prepend-outer";
-    protected String prependInner = ".v-input__prepend-inner";
-    protected String appendOuter = ".v-input__append-outer";
-    protected String appendInner = ".v-input__append-inner";
-    protected String prefix = ".v-text-field__prefix";
-    protected String suffix = ".v-text-field__suffix";
+    private String message = ".v-messages__message";
+    private String counter = ".v-counter";
+    private String prependOuter = ".v-input__prepend-outer";
+    private String prependInner = ".v-input__prepend-inner";
+    private String appendOuter = ".v-input__append-outer";
+    private String appendInner = ".v-input__append-inner";
+    private String prefix = ".v-text-field__prefix";
+    private String suffix = ".v-text-field__suffix";
 
     @Override
     @JDIAction("Check that '{name}' is enabled")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TextField.java
@@ -24,25 +24,25 @@ import static com.epam.jdi.light.driver.get.DriverData.getOs;
 public class TextField extends UIBaseElement<TextFieldAssert>
         implements HasLabel, HasPlaceholder, IsInput {
 
-    protected String INPUT = ".//input|.//textarea";
-    protected String SLOT = ".v-input__slot";
-    protected String MESSAGE = ".v-messages__message";
-    protected String COUNTER = ".v-counter";
-    protected String PREPEND_OUTER = ".v-input__prepend-outer";
-    protected String PREPEND_INNER = ".v-input__prepend-inner";
-    protected String APPEND_OUTER = ".v-input__append-outer";
-    protected String APPEND_INNER = ".v-input__append-inner";
-    protected String PREFIX = ".v-text-field__prefix";
-    protected String SUFFIX = ".v-text-field__suffix";
+    protected static String DISABLED_CLASS = "v-input--is-disabled";
+    protected static String READ_ONLY_CLASS = "v-input--is-readonly";
+    protected static String FOCUSED_CLASS = "v-input--is-focused";
+    protected static String FILLED_CLASS = "v-text-field--filled";
+    protected static String OUTLINED_CLASS = "v-text-field--outlined";
+    protected static String SHAPED_CLASS = "v-text-field--shaped";
+    protected static String SOLO_CLASS = "v-text-field--solo";
+    protected static String FULL_WIDTH_CLASS = "v-text-field--full-width";
 
-    protected String DISABLED_CLASS = "v-input--is-disabled";
-    protected String READ_ONLY_CLASS = "v-input--is-readonly";
-    protected String FOCUSED_CLASS = "v-input--is-focused";
-    protected String FILLED_CLASS = "v-text-field--filled";
-    protected String OUTLINED_CLASS = "v-text-field--outlined";
-    protected String SHAPED_CLASS = "v-text-field--shaped";
-    protected String SOLO_CLASS = "v-text-field--solo";
-    protected String FULL_WIDTH_CLASS = "v-text-field--full-width";
+    protected String input = ".//input|.//textarea";
+    protected String slot = ".v-input__slot";
+    protected String message = ".v-messages__message";
+    protected String counter = ".v-counter";
+    protected String prependOuter = ".v-input__prepend-outer";
+    protected String prependInner = ".v-input__prepend-inner";
+    protected String appendOuter = ".v-input__append-outer";
+    protected String appendInner = ".v-input__append-inner";
+    protected String prefix = ".v-text-field__prefix";
+    protected String suffix = ".v-text-field__suffix";
 
     @Override
     @JDIAction("Check that '{name}' is enabled")
@@ -87,32 +87,32 @@ public class TextField extends UIBaseElement<TextFieldAssert>
 
     @JDIAction("Get '{name}' text input field")
     public UIElement textInputField() {
-        return find(INPUT);
+        return find(input);
     }
 
     @JDIAction("Get '{name}' slot")
     public UIElement slot() {
-        return find(SLOT);
+        return find(slot);
     }
 
     @JDIAction("Get '{name}' message")
     public UIElement message() {
-        return find(MESSAGE);
+        return find(message);
     }
 
     @JDIAction("Get '{name}' counter")
     public UIElement counter() {
-        return find(COUNTER);
+        return find(counter);
     }
 
     @JDIAction("Get '{name}' prefix")
     public UIElement prefix() {
-        return find(PREFIX);
+        return find(prefix);
     }
 
     @JDIAction("Get '{name}' suffix")
     public UIElement suffix() {
-        return find(SUFFIX);
+        return find(suffix);
     }
 
     protected List<Icon> getIconByLocator(String locator) {
@@ -125,22 +125,22 @@ public class TextField extends UIBaseElement<TextFieldAssert>
 
     @JDIAction("Get '{name}' prepend outer icons")
     public List<Icon> prependOuterIcons() {
-        return getIconByLocator(PREPEND_OUTER);
+        return getIconByLocator(prependOuter);
     }
 
     @JDIAction("Get '{name}' prepend inner icons")
     public List<Icon> prependInnerIcons() {
-        return getIconByLocator(PREPEND_INNER);
+        return getIconByLocator(prependInner);
     }
 
     @JDIAction("Get '{name}' append inner icons")
     public List<Icon> appendInnerIcons() {
-        return getIconByLocator(APPEND_INNER);
+        return getIconByLocator(appendInner);
     }
 
     @JDIAction("Get '{name}' append outer icons")
     public List<Icon> appendOuterIcons() {
-        return getIconByLocator(APPEND_OUTER);
+        return getIconByLocator(appendOuter);
     }
 
     @JDIAction("Get '{name}' prepend outer icon")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
@@ -33,29 +33,30 @@ import static com.epam.jdi.tools.PrintUtils.print;
 public class TreeView extends Dropdown
         implements IMultiSelector, CanBeSelected, HasCheck, IListSelector<TreeView> {
 
-    protected String NODES_IN_CORE_LOCATOR = "./*[contains(@class, 'v-treeview-node')]";
-    protected String NODES_IN_NODE_LOCATOR = "./*[contains(@class, 'v-treeview-node__children')]/*[contains(@class, 'v-treeview-node')]";
-    protected String ROOT_IN_NODE_LOCATOR = "./*[contains(@class, 'v-treeview-node__root')]";
-    protected String TOGGLE_IN_ROOT_LOCATOR = ".v-treeview-node__toggle";
-    protected String CHECKBOX_IN_ROOT_LOCATOR = ".v-treeview-node__checkbox";
-    protected String CONTENT_IN_ROOT_LOCATOR = ".v-treeview-node__content";
-    protected String CORE_FROM_NODE_LOCATOR = "//ancestor::*[" +
+    protected static String CORE_CLASS = "v-treeview";
+    protected static String HOVERABLE_CORE_CLASS = "v-treeview--hoverable";
+    protected static String LEAF_NODE_CLASS = "v-treeview-node--leaf";
+    protected static String SELECTED_NODE_CLASS = "v-treeview-node--selected";
+    protected static String DISABLED_NODE_CLASS = "v-treeview-node--disabled";
+    protected static String SHAPED_NODE_CLASS = "v-treeview-node--shaped";
+    protected static String ROUNDED_NODE_CLASS = "v-treeview-node--rounded";
+    protected static String ACTIVE_ROOT_CLASS = "v-treeview-node--active";
+
+    protected String checkboxFullyMarkedClass = "mdi-checkbox-marked";
+    protected String checkboxPartlyMarkedClass = "mdi-minus-box";
+    protected String checkboxNotMarkedClass = "mdi-checkbox-blank-outline";
+
+    protected String nodesInCoreLocator = "./*[contains(@class, 'v-treeview-node')]";
+    protected String nodesInNodeLocator = "./*[contains(@class, 'v-treeview-node__children')]/*[contains(@class, 'v-treeview-node')]";
+    protected String rootInNodeLocator = "./*[contains(@class, 'v-treeview-node__root')]";
+    protected String toggleInRootLocator = ".v-treeview-node__toggle";
+    protected String checkboxInRootLocator = ".v-treeview-node__checkbox";
+    protected String contentInRootLocator = ".v-treeview-node__content";
+    protected String coreFromNodeLocator = "//ancestor::*[" +
             "@class='v-treeview' or " +
             "starts-with(@class, 'v-treeview ') or " +
             "contains(@class, ' v-treeview ') or " +
             "substring(@class, string-length(@class) - string-length('v-treeview') + 1) = 'v-treeview']";
-
-    protected String CORE_CLASS = "v-treeview";
-    protected String HOVERABLE_CORE_CLASS = "v-treeview--hoverable";
-    protected String LEAF_NODE_CLASS = "v-treeview-node--leaf";
-    protected String SELECTED_NODE_CLASS = "v-treeview-node--selected";
-    protected String DISABLED_NODE_CLASS = "v-treeview-node--disabled";
-    protected String SHAPED_NODE_CLASS = "v-treeview-node--shaped";
-    protected String ROUNDED_NODE_CLASS = "v-treeview-node--rounded";
-    protected String ACTIVE_ROOT_CLASS = "v-treeview-node--active";
-    protected String CHECKBOX_FULLY_MARKED_CLASS = "mdi-checkbox-marked";
-    protected String CHECKBOX_PARTLY_MARKED_CLASS = "mdi-minus-box";
-    protected String CHECKBOX_NOT_MARKED_CLASS = "mdi-checkbox-blank-outline";
 
     protected String delimiter = "/";
 
@@ -94,17 +95,17 @@ public class TreeView extends Dropdown
 
     @JDIAction("Check if '{name}' is fully marked")
     public boolean isFullyMarked() {
-        return checkbox().hasClass(CHECKBOX_FULLY_MARKED_CLASS);
+        return checkbox().hasClass(checkboxFullyMarkedClass);
     }
 
     @JDIAction("Check if '{name}' is partly marked")
     public boolean isPartlyMarked() {
-        return checkbox().hasClass(CHECKBOX_PARTLY_MARKED_CLASS);
+        return checkbox().hasClass(checkboxPartlyMarkedClass);
     }
 
     @JDIAction("Check if '{name}' is not marked")
     public boolean isNotMarked() {
-        return checkbox().hasClass(CHECKBOX_NOT_MARKED_CLASS);
+        return checkbox().hasClass(checkboxNotMarkedClass);
     }
 
     @Override
@@ -130,7 +131,7 @@ public class TreeView extends Dropdown
 
     @JDIAction("Get main pseudo core TreeView from '{name}'")
     public TreeView pseudoCore() {
-        return create(core().find(CORE_FROM_NODE_LOCATOR));
+        return create(core().find(coreFromNodeLocator));
     }
 
     @JDIAction("Get root from '{name}'")
@@ -138,17 +139,17 @@ public class TreeView extends Dropdown
         if (isPseudoCore()) {
             return null;
         }
-        return core().find(ROOT_IN_NODE_LOCATOR).setName("root " + getName());
+        return core().find(rootInNodeLocator).setName("root " + getName());
     }
 
     @JDIAction("Get root expander from '{name}'")
     public UIElement expander() {
-        return root().find(TOGGLE_IN_ROOT_LOCATOR).setName("expander " + getName());
+        return root().find(toggleInRootLocator).setName("expander " + getName());
     }
 
     @JDIAction("Get root checkbox from '{name}'")
     public UIElement checkbox() {
-        return root().find(CHECKBOX_IN_ROOT_LOCATOR).setName("checkbox " + getName());
+        return root().find(checkboxInRootLocator).setName("checkbox " + getName());
     }
 
     @Override
@@ -160,7 +161,7 @@ public class TreeView extends Dropdown
     @Override
     @JDIAction("Get root value from '{name}'")
     public UIElement iCore() {
-        return core().find(ROOT_IN_NODE_LOCATOR).find(CONTENT_IN_ROOT_LOCATOR);
+        return core().find(rootInNodeLocator).find(contentInRootLocator);
     }
 
     @Override
@@ -188,13 +189,13 @@ public class TreeView extends Dropdown
     @JDIAction("Get list from '{name}'")
     public WebList list() {
         if (isPseudoCore()) {
-            return core().finds(NODES_IN_CORE_LOCATOR);
+            return core().finds(nodesInCoreLocator);
         }
         if (isLeaf()) {
             return new WebList();
         }
         expand();
-        return core().finds(NODES_IN_NODE_LOCATOR);
+        return core().finds(nodesInNodeLocator);
     }
 
     @JDIAction("Get list of nodes from '{name}'")
@@ -411,15 +412,15 @@ public class TreeView extends Dropdown
 
     protected TreeView create(UIElement base) {
         TreeView created = new TreeView().setCore(TreeView.class, base);
-        created.NODES_IN_CORE_LOCATOR = NODES_IN_CORE_LOCATOR;
-        created.NODES_IN_NODE_LOCATOR = NODES_IN_NODE_LOCATOR;
-        created.ROOT_IN_NODE_LOCATOR = ROOT_IN_NODE_LOCATOR;
-        created.TOGGLE_IN_ROOT_LOCATOR = TOGGLE_IN_ROOT_LOCATOR;
-        created.CHECKBOX_IN_ROOT_LOCATOR = CHECKBOX_IN_ROOT_LOCATOR;
-        created.CONTENT_IN_ROOT_LOCATOR = CONTENT_IN_ROOT_LOCATOR;
-        created.CHECKBOX_FULLY_MARKED_CLASS = CHECKBOX_FULLY_MARKED_CLASS;
-        created.CHECKBOX_PARTLY_MARKED_CLASS = CHECKBOX_PARTLY_MARKED_CLASS;
-        created.CHECKBOX_NOT_MARKED_CLASS = CHECKBOX_NOT_MARKED_CLASS;
+        created.nodesInCoreLocator = nodesInCoreLocator;
+        created.nodesInNodeLocator = nodesInNodeLocator;
+        created.rootInNodeLocator = rootInNodeLocator;
+        created.toggleInRootLocator = toggleInRootLocator;
+        created.checkboxInRootLocator = checkboxInRootLocator;
+        created.contentInRootLocator = contentInRootLocator;
+        created.checkboxFullyMarkedClass = checkboxFullyMarkedClass;
+        created.checkboxPartlyMarkedClass = checkboxPartlyMarkedClass;
+        created.checkboxNotMarkedClass = checkboxNotMarkedClass;
         created.setName(String.format("TreeView %s", created.getValue()));
         return created;
     }
@@ -441,31 +442,31 @@ public class TreeView extends Dropdown
             setCore(TreeView.class, $(annotation.core()));
         }
         if (!annotation.coreNodes().isEmpty()) {
-            NODES_IN_CORE_LOCATOR = annotation.coreNodes();
+            nodesInCoreLocator = annotation.coreNodes();
         }
         if (!annotation.nodeNodes().isEmpty()) {
-            NODES_IN_NODE_LOCATOR = annotation.nodeNodes();
+            nodesInNodeLocator = annotation.nodeNodes();
         }
         if (!annotation.root().isEmpty()) {
-            ROOT_IN_NODE_LOCATOR = annotation.root();
+            rootInNodeLocator = annotation.root();
         }
         if (!annotation.toggle().isEmpty()) {
-            TOGGLE_IN_ROOT_LOCATOR = annotation.toggle();
+            toggleInRootLocator = annotation.toggle();
         }
         if (!annotation.checkbox().isEmpty()) {
-            CHECKBOX_IN_ROOT_LOCATOR = annotation.checkbox();
+            checkboxInRootLocator = annotation.checkbox();
         }
         if (!annotation.content().isEmpty()) {
-            CONTENT_IN_ROOT_LOCATOR = annotation.content();
+            contentInRootLocator = annotation.content();
         }
         if (!annotation.full().isEmpty()) {
-            CHECKBOX_FULLY_MARKED_CLASS = annotation.full();
+            checkboxFullyMarkedClass = annotation.full();
         }
         if (!annotation.part().isEmpty()) {
-            CHECKBOX_PARTLY_MARKED_CLASS = annotation.part();
+            checkboxPartlyMarkedClass = annotation.part();
         }
         if (!annotation.not().isEmpty()) {
-            CHECKBOX_NOT_MARKED_CLASS = annotation.not();
+            checkboxNotMarkedClass = annotation.not();
         }
     }
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
@@ -33,14 +33,14 @@ import static com.epam.jdi.tools.PrintUtils.print;
 public class TreeView extends Dropdown
         implements IMultiSelector, CanBeSelected, HasCheck, IListSelector<TreeView> {
 
-    protected static String CORE_CLASS = "v-treeview";
-    protected static String HOVERABLE_CORE_CLASS = "v-treeview--hoverable";
-    protected static String LEAF_NODE_CLASS = "v-treeview-node--leaf";
-    protected static String SELECTED_NODE_CLASS = "v-treeview-node--selected";
-    protected static String DISABLED_NODE_CLASS = "v-treeview-node--disabled";
-    protected static String SHAPED_NODE_CLASS = "v-treeview-node--shaped";
-    protected static String ROUNDED_NODE_CLASS = "v-treeview-node--rounded";
-    protected static String ACTIVE_ROOT_CLASS = "v-treeview-node--active";
+    protected static final String CORE_CLASS = "v-treeview";
+    protected static final String HOVERABLE_CORE_CLASS = "v-treeview--hoverable";
+    protected static final String LEAF_NODE_CLASS = "v-treeview-node--leaf";
+    protected static final String SELECTED_NODE_CLASS = "v-treeview-node--selected";
+    protected static final String DISABLED_NODE_CLASS = "v-treeview-node--disabled";
+    protected static final String SHAPED_NODE_CLASS = "v-treeview-node--shaped";
+    protected static final String ROUNDED_NODE_CLASS = "v-treeview-node--rounded";
+    protected static final String ACTIVE_ROOT_CLASS = "v-treeview-node--active";
 
     protected String checkboxFullyMarkedClass = "mdi-checkbox-marked";
     protected String checkboxPartlyMarkedClass = "mdi-minus-box";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
@@ -42,9 +42,9 @@ public class TreeView extends Dropdown
     protected static final String ROUNDED_NODE_CLASS = "v-treeview-node--rounded";
     protected static final String ACTIVE_ROOT_CLASS = "v-treeview-node--active";
 
-    protected String checkboxFullyMarkedClass = "mdi-checkbox-marked";
-    protected String checkboxPartlyMarkedClass = "mdi-minus-box";
-    protected String checkboxNotMarkedClass = "mdi-checkbox-blank-outline";
+    private String checkboxFullyMarkedClass = "mdi-checkbox-marked";
+    private String checkboxPartlyMarkedClass = "mdi-minus-box";
+    private String checkboxNotMarkedClass = "mdi-checkbox-blank-outline";
 
     protected String nodesInCoreLocator = "./*[contains(@class, 'v-treeview-node')]";
     protected String nodesInNodeLocator = "./*[contains(@class, 'v-treeview-node__children')]/*[contains(@class, 'v-treeview-node')]";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
@@ -33,32 +33,32 @@ import static com.epam.jdi.tools.PrintUtils.print;
 public class TreeView extends Dropdown
         implements IMultiSelector, CanBeSelected, HasCheck, IListSelector<TreeView> {
 
-    protected static final String CORE_CLASS = "v-treeview";
-    protected static final String HOVERABLE_CORE_CLASS = "v-treeview--hoverable";
-    protected static final String LEAF_NODE_CLASS = "v-treeview-node--leaf";
-    protected static final String SELECTED_NODE_CLASS = "v-treeview-node--selected";
-    protected static final String DISABLED_NODE_CLASS = "v-treeview-node--disabled";
-    protected static final String SHAPED_NODE_CLASS = "v-treeview-node--shaped";
-    protected static final String ROUNDED_NODE_CLASS = "v-treeview-node--rounded";
-    protected static final String ACTIVE_ROOT_CLASS = "v-treeview-node--active";
+    private static final String CORE_CLASS = "v-treeview";
+    private static final String HOVERABLE_CORE_CLASS = "v-treeview--hoverable";
+    private static final String LEAF_NODE_CLASS = "v-treeview-node--leaf";
+    private static final String SELECTED_NODE_CLASS = "v-treeview-node--selected";
+    private static final String DISABLED_NODE_CLASS = "v-treeview-node--disabled";
+    private static final String SHAPED_NODE_CLASS = "v-treeview-node--shaped";
+    private static final String ROUNDED_NODE_CLASS = "v-treeview-node--rounded";
+    private static final String ACTIVE_ROOT_CLASS = "v-treeview-node--active";
 
     private String checkboxFullyMarkedClass = "mdi-checkbox-marked";
     private String checkboxPartlyMarkedClass = "mdi-minus-box";
     private String checkboxNotMarkedClass = "mdi-checkbox-blank-outline";
 
-    protected String nodesInCoreLocator = "./*[contains(@class, 'v-treeview-node')]";
-    protected String nodesInNodeLocator = "./*[contains(@class, 'v-treeview-node__children')]/*[contains(@class, 'v-treeview-node')]";
-    protected String rootInNodeLocator = "./*[contains(@class, 'v-treeview-node__root')]";
-    protected String toggleInRootLocator = ".v-treeview-node__toggle";
-    protected String checkboxInRootLocator = ".v-treeview-node__checkbox";
-    protected String contentInRootLocator = ".v-treeview-node__content";
-    protected String coreFromNodeLocator = "//ancestor::*[" +
+    private String nodesInCoreLocator = "./*[contains(@class, 'v-treeview-node')]";
+    private String nodesInNodeLocator = "./*[contains(@class, 'v-treeview-node__children')]/*[contains(@class, 'v-treeview-node')]";
+    private String rootInNodeLocator = "./*[contains(@class, 'v-treeview-node__root')]";
+    private String toggleInRootLocator = ".v-treeview-node__toggle";
+    private String checkboxInRootLocator = ".v-treeview-node__checkbox";
+    private String contentInRootLocator = ".v-treeview-node__content";
+    private String coreFromNodeLocator = "//ancestor::*[" +
             "@class='v-treeview' or " +
             "starts-with(@class, 'v-treeview ') or " +
             "contains(@class, ' v-treeview ') or " +
             "substring(@class, string-length(@class) - string-length('v-treeview') + 1) = 'v-treeview']";
 
-    protected String delimiter = "/";
+    private String delimiter = "/";
 
     @JDIAction("Check if '{name}' is a pseudo core node")
     public boolean isPseudoCore() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
@@ -11,8 +11,8 @@ public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
     protected static final String OPEN_PANEL_CLASS = "v-expansion-panel--active";
     protected static final String DISABLED_PANEL_CLASS = "v-expansion-panel--disabled";
 
-    protected String iconLocator = ".v-expansion-panel-header__icon .v-icon";
-    protected String contentLocator = ".v-expansion-panel-content";
+    private String iconLocator = ".v-expansion-panel-header__icon .v-icon";
+    private String contentLocator = ".v-expansion-panel-content";
     private String headerLocator = ".v-expansion-panel-header";
 
     //Access only as part of ExpansionPanels or if you want to create yours custom panel
@@ -71,5 +71,13 @@ public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
 
     public void setHeaderLocator(String headerLocator) {
         this.headerLocator = headerLocator;
+    }
+
+    public void setIconLocator(String iconLocator) {
+        this.iconLocator = iconLocator;
+    }
+
+    public void setContentLocator(String contentLocator) {
+        this.contentLocator = contentLocator;
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
@@ -8,8 +8,8 @@ import com.epam.jdi.light.vuetify.elements.common.Icon;
 
 public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
 
-    protected static String OPEN_PANEL_CLASS = "v-expansion-panel--active";
-    protected static String DISABLED_PANEL_CLASS = "v-expansion-panel--disabled";
+    protected static final String OPEN_PANEL_CLASS = "v-expansion-panel--active";
+    protected static final String DISABLED_PANEL_CLASS = "v-expansion-panel--disabled";
 
     protected String headerLocator = ".v-expansion-panel-header";
     protected String iconLocator = ".v-expansion-panel-header__icon .v-icon";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
@@ -11,9 +11,9 @@ public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
     protected static final String OPEN_PANEL_CLASS = "v-expansion-panel--active";
     protected static final String DISABLED_PANEL_CLASS = "v-expansion-panel--disabled";
 
-    private String headerLocator = ".v-expansion-panel-header";
     protected String iconLocator = ".v-expansion-panel-header__icon .v-icon";
     protected String contentLocator = ".v-expansion-panel-content";
+    private String headerLocator = ".v-expansion-panel-header";
 
     //Access only as part of ExpansionPanels or if you want to create yours custom panel
     protected ExpansionPanel() {}
@@ -67,10 +67,6 @@ public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
     @Override
     public ExpansionPanelAssert is() {
         return new ExpansionPanelAssert().set(this);
-    }
-
-    public String getHeaderLocator() {
-        return headerLocator;
     }
 
     public void setHeaderLocator(String headerLocator) {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
@@ -11,7 +11,7 @@ public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
     protected static final String OPEN_PANEL_CLASS = "v-expansion-panel--active";
     protected static final String DISABLED_PANEL_CLASS = "v-expansion-panel--disabled";
 
-    protected String headerLocator = ".v-expansion-panel-header";
+    private String headerLocator = ".v-expansion-panel-header";
     protected String iconLocator = ".v-expansion-panel-header__icon .v-icon";
     protected String contentLocator = ".v-expansion-panel-content";
 
@@ -67,5 +67,13 @@ public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
     @Override
     public ExpansionPanelAssert is() {
         return new ExpansionPanelAssert().set(this);
+    }
+
+    public String getHeaderLocator() {
+        return headerLocator;
+    }
+
+    public void setHeaderLocator(String headerLocator) {
+        this.headerLocator = headerLocator;
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanel.java
@@ -8,30 +8,30 @@ import com.epam.jdi.light.vuetify.elements.common.Icon;
 
 public class ExpansionPanel extends UIBaseElement<ExpansionPanelAssert> {
 
-    protected String HEADER_LOCATOR = ".v-expansion-panel-header";
-    protected String ICON_LOCATOR = ".v-expansion-panel-header__icon .v-icon";
-    protected String CONTENT_LOCATOR = ".v-expansion-panel-content";
+    protected static String OPEN_PANEL_CLASS = "v-expansion-panel--active";
+    protected static String DISABLED_PANEL_CLASS = "v-expansion-panel--disabled";
 
-    protected String OPEN_PANEL_CLASS = "v-expansion-panel--active";
-    protected String DISABLED_PANEL_CLASS = "v-expansion-panel--disabled";
+    protected String headerLocator = ".v-expansion-panel-header";
+    protected String iconLocator = ".v-expansion-panel-header__icon .v-icon";
+    protected String contentLocator = ".v-expansion-panel-content";
 
     //Access only as part of ExpansionPanels or if you want to create yours custom panel
     protected ExpansionPanel() {}
 
     @JDIAction("Get '{name}' header")
     public UIElement header() {
-        return find(HEADER_LOCATOR);
+        return find(headerLocator);
     }
 
     @JDIAction("Get '{name}' expander icon")
     public Icon expander() {
-        return new Icon().setCore(Icon.class, find(ICON_LOCATOR));
+        return new Icon().setCore(Icon.class, find(iconLocator));
     }
 
     @JDIAction("Get '{name}' content")
     public UIElement content() {
         expand();
-        return find(CONTENT_LOCATOR);
+        return find(contentLocator);
     }
 
     @JDIAction("Expand '{name}'")

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
@@ -20,12 +20,12 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class ExpansionPanels extends UIListBase<UISelectAssert<UISelectAssert<?, ?>, WebList>> implements ISetup {
 
-    protected String rootLocator = ".v-expansion-panels";
-    protected String panelsLocator = ".v-expansion-panel";
+    private String rootLocator = ".v-expansion-panels";
+    private String panelsLocator = ".v-expansion-panel";
 
-    protected String headerLocator = ".v-expansion-panel-header";
-    protected String iconLocator = ".v-expansion-panel-header__icon .v-icon";
-    protected String contentLocator = ".v-expansion-panel-content";
+    private String headerLocator = ".v-expansion-panel-header";
+    private String iconLocator = ".v-expansion-panel-header__icon .v-icon";
+    private String contentLocator = ".v-expansion-panel-content";
 
     @Override
     public WebList list() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
@@ -74,7 +74,7 @@ public class ExpansionPanels extends UIListBase<UISelectAssert<UISelectAssert<?,
 
     private ExpansionPanel createPanel(UIElement panelCore) {
         ExpansionPanel panel = new ExpansionPanel().setCore(ExpansionPanel.class, panelCore);
-        panel.headerLocator = headerLocator;
+        panel.setHeaderLocator(headerLocator);
         panel.iconLocator = iconLocator;
         panel.contentLocator = contentLocator;
         panel.setName(String.format("Expansion panel %s", panel.header().text()));

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
@@ -75,8 +75,8 @@ public class ExpansionPanels extends UIListBase<UISelectAssert<UISelectAssert<?,
     private ExpansionPanel createPanel(UIElement panelCore) {
         ExpansionPanel panel = new ExpansionPanel().setCore(ExpansionPanel.class, panelCore);
         panel.setHeaderLocator(headerLocator);
-        panel.iconLocator = iconLocator;
-        panel.contentLocator = contentLocator;
+        panel.setIconLocator(iconLocator);
+        panel.setContentLocator(contentLocator);
         panel.setName(String.format("Expansion panel %s", panel.header().text()));
         return panel;
     }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/panels/ExpansionPanels.java
@@ -20,16 +20,16 @@ import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFr
  */
 public class ExpansionPanels extends UIListBase<UISelectAssert<UISelectAssert<?, ?>, WebList>> implements ISetup {
 
-    protected String ROOT_LOCATOR = ".v-expansion-panels";
-    protected String PANELS_LOCATOR = ".v-expansion-panel";
+    protected String rootLocator = ".v-expansion-panels";
+    protected String panelsLocator = ".v-expansion-panel";
 
-    protected String HEADER_LOCATOR = ".v-expansion-panel-header";
-    protected String ICON_LOCATOR = ".v-expansion-panel-header__icon .v-icon";
-    protected String CONTENT_LOCATOR = ".v-expansion-panel-content";
+    protected String headerLocator = ".v-expansion-panel-header";
+    protected String iconLocator = ".v-expansion-panel-header__icon .v-icon";
+    protected String contentLocator = ".v-expansion-panel-content";
 
     @Override
     public WebList list() {
-        return finds(PANELS_LOCATOR).setName(getName() + " expansion panels");
+        return finds(panelsLocator).setName(getName() + " expansion panels");
     }
 
     @JDIAction("Get Panels from '{name}'")
@@ -50,33 +50,33 @@ public class ExpansionPanels extends UIListBase<UISelectAssert<UISelectAssert<?,
             JDIExpansionPanels annotation = field.getAnnotation(JDIExpansionPanels.class);
             initializeLocators(annotation);
         }
-        this.setCore(ExpansionPanels.class, $(ROOT_LOCATOR));
+        this.setCore(ExpansionPanels.class, $(rootLocator));
         this.setName(String.format("Expansion panels container %s", field.getName()));
     }
 
     private void initializeLocators(JDIExpansionPanels annotation) {
         if (!annotation.root().isEmpty()) {
-            ROOT_LOCATOR = annotation.root();
+            rootLocator = annotation.root();
         }
         if (!annotation.panels().isEmpty()) {
-            PANELS_LOCATOR = annotation.panels();
+            panelsLocator = annotation.panels();
         }
         if (!annotation.header().isEmpty()) {
-            HEADER_LOCATOR = annotation.header();
+            headerLocator = annotation.header();
         }
         if (!annotation.icon().isEmpty()) {
-            ICON_LOCATOR = annotation.icon();
+            iconLocator = annotation.icon();
         }
         if (!annotation.content().isEmpty()) {
-            CONTENT_LOCATOR = annotation.content();
+            contentLocator = annotation.content();
         }
     }
 
     private ExpansionPanel createPanel(UIElement panelCore) {
         ExpansionPanel panel = new ExpansionPanel().setCore(ExpansionPanel.class, panelCore);
-        panel.HEADER_LOCATOR = HEADER_LOCATOR;
-        panel.ICON_LOCATOR = ICON_LOCATOR;
-        panel.CONTENT_LOCATOR = CONTENT_LOCATOR;
+        panel.headerLocator = headerLocator;
+        panel.iconLocator = iconLocator;
+        panel.contentLocator = contentLocator;
         panel.setName(String.format("Expansion panel %s", panel.header().text()));
         return panel;
     }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
@@ -23,18 +23,18 @@ import static com.epam.jdi.tools.ReflectionUtils.getGenericTypes;
  */
 public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UIListBase<TimeLineAssert> implements ISetup {
 
-    protected static final String ALIGN_TOP_CLASS = "v-timeline--align-top";
-    protected static final String DENSE_CLASS = "v-timeline--dense";
-    protected static final String REVERSE_CLASS = "v-timeline--reverse";
+    private static final String ALIGN_TOP_CLASS = "v-timeline--align-top";
+    private static final String DENSE_CLASS = "v-timeline--dense";
+    private static final String REVERSE_CLASS = "v-timeline--reverse";
 
-    protected String rootLocator = ".v-timeline";
+    private String rootLocator = ".v-timeline";
     private String itemsLocator = ".v-timeline-item";
-    protected String bodyLocator = ".v-timeline-item__body";
-    protected String dividerLocator = ".v-timeline-item__divider";
-    protected String oppositeLocator = ".v-timeline-item__opposite";
+    private String bodyLocator = ".v-timeline-item__body";
+    private String dividerLocator = ".v-timeline-item__divider";
+    private String oppositeLocator = ".v-timeline-item__opposite";
 
-    protected Class<T> bodyClass;
-    protected Class<U> dividerClass;
+    private Class<T> bodyClass;
+    private Class<U> dividerClass;
 
     @JDIAction("Check if '{name}' is align to top")
     public boolean isAlignTop() {
@@ -75,10 +75,10 @@ public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UI
     protected <C extends ICoreElement, D extends ICoreElement> TimeLineItem<C, D> createItem(UIElement root, Class<C> body, Class<D> divider) {
         TimeLineItem<C, D> timeLineItem = new TimeLineItem<>();
         timeLineItem.setCore(TimeLineItem.class, root);
-        timeLineItem.bodyClass = body;
-        timeLineItem.dividerClass = divider;
-        timeLineItem.bodyLocator = bodyLocator;
-        timeLineItem.dividerLocator = dividerLocator;
+        timeLineItem.setBodyClass(body);
+        timeLineItem.setDividerClass(divider);
+        timeLineItem.setBodyLocator(bodyLocator);
+        timeLineItem.setDividerLocator(dividerLocator);
         timeLineItem.setOppositeLocator(oppositeLocator);
         return timeLineItem;
     }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
@@ -28,7 +28,7 @@ public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UI
     protected static final String REVERSE_CLASS = "v-timeline--reverse";
 
     protected String rootLocator = ".v-timeline";
-    protected String itemsLocator = ".v-timeline-item";
+    private String itemsLocator = ".v-timeline-item";
     protected String bodyLocator = ".v-timeline-item__body";
     protected String dividerLocator = ".v-timeline-item__divider";
     protected String oppositeLocator = ".v-timeline-item__opposite";
@@ -79,7 +79,7 @@ public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UI
         timeLineItem.dividerClass = divider;
         timeLineItem.bodyLocator = bodyLocator;
         timeLineItem.dividerLocator = dividerLocator;
-        timeLineItem.oppositeLocator = oppositeLocator;
+        timeLineItem.setOppositeLocator(oppositeLocator);
         return timeLineItem;
     }
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
@@ -23,15 +23,15 @@ import static com.epam.jdi.tools.ReflectionUtils.getGenericTypes;
  */
 public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UIListBase<TimeLineAssert> implements ISetup {
 
-    protected String ROOT_LOCATOR = ".v-timeline";
-    protected String ITEMS_LOCATOR = ".v-timeline-item";
-    protected String BODY_LOCATOR = ".v-timeline-item__body";
-    protected String DIVIDER_LOCATOR = ".v-timeline-item__divider";
-    protected String OPPOSITE_LOCATOR = ".v-timeline-item__opposite";
+    protected static String ALIGN_TOP_CLASS = "v-timeline--align-top";
+    protected static String DENSE_CLASS = "v-timeline--dense";
+    protected static String REVERSE_CLASS = "v-timeline--reverse";
 
-    protected String ALIGN_TOP_CLASS = "v-timeline--align-top";
-    protected String DENSE_CLASS = "v-timeline--dense";
-    protected String REVERSE_CLASS = "v-timeline--reverse";
+    protected String rootLocator = ".v-timeline";
+    protected String itemsLocator = ".v-timeline-item";
+    protected String bodyLocator = ".v-timeline-item__body";
+    protected String dividerLocator = ".v-timeline-item__divider";
+    protected String oppositeLocator = ".v-timeline-item__opposite";
 
     protected Class<T> bodyClass;
     protected Class<U> dividerClass;
@@ -54,7 +54,7 @@ public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UI
     @Override
     @JDIAction("Get list from '{name}'")
     public WebList list() {
-        return finds(ITEMS_LOCATOR).setName(getName() + " Time line");
+        return finds(itemsLocator).setName(getName() + " Time line");
     }
 
     @JDIAction("Get list of items from '{name}'")
@@ -77,9 +77,9 @@ public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UI
         timeLineItem.setCore(TimeLineItem.class, root);
         timeLineItem.bodyClass = body;
         timeLineItem.dividerClass = divider;
-        timeLineItem.BODY_LOCATOR = BODY_LOCATOR;
-        timeLineItem.DIVIDER_LOCATOR = DIVIDER_LOCATOR;
-        timeLineItem.OPPOSITE_LOCATOR = OPPOSITE_LOCATOR;
+        timeLineItem.bodyLocator = bodyLocator;
+        timeLineItem.dividerLocator = dividerLocator;
+        timeLineItem.oppositeLocator = oppositeLocator;
         return timeLineItem;
     }
 
@@ -94,26 +94,26 @@ public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UI
             JDITimeLine annotation = field.getAnnotation(JDITimeLine.class);
             initializeLocators(annotation);
         }
-        setCore(TimeLine.class, $(ROOT_LOCATOR));
+        setCore(TimeLine.class, $(rootLocator));
         setName(String.format("Time line %s", field.getName()));
         initializeGenerics(field);
     }
 
     private void initializeLocators(JDITimeLine annotation) {
         if (!annotation.root().isEmpty()) {
-            ROOT_LOCATOR = annotation.root();
+            rootLocator = annotation.root();
         }
         if (!annotation.items().isEmpty()) {
-            ITEMS_LOCATOR = annotation.items();
+            itemsLocator = annotation.items();
         }
         if (!annotation.body().isEmpty()) {
-            BODY_LOCATOR = annotation.body();
+            bodyLocator = annotation.body();
         }
         if (!annotation.divider().isEmpty()) {
-            DIVIDER_LOCATOR = annotation.divider();
+            dividerLocator = annotation.divider();
         }
         if (!annotation.opposite().isEmpty()) {
-            OPPOSITE_LOCATOR = annotation.opposite();
+            oppositeLocator = annotation.opposite();
         }
     }
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLine.java
@@ -23,9 +23,9 @@ import static com.epam.jdi.tools.ReflectionUtils.getGenericTypes;
  */
 public class TimeLine<T extends ICoreElement, U extends ICoreElement> extends UIListBase<TimeLineAssert> implements ISetup {
 
-    protected static String ALIGN_TOP_CLASS = "v-timeline--align-top";
-    protected static String DENSE_CLASS = "v-timeline--dense";
-    protected static String REVERSE_CLASS = "v-timeline--reverse";
+    protected static final String ALIGN_TOP_CLASS = "v-timeline--align-top";
+    protected static final String DENSE_CLASS = "v-timeline--dense";
+    protected static final String REVERSE_CLASS = "v-timeline--reverse";
 
     protected String rootLocator = ".v-timeline";
     protected String itemsLocator = ".v-timeline-item";

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
@@ -9,14 +9,14 @@ import static com.epam.jdi.light.common.UIUtils.initT;
 
 public class TimeLineItem<T extends ICoreElement, U extends ICoreElement> extends UIBaseElement<TimeLineItemAssert> {
 
-    protected String BODY_LOCATOR;
-    protected String DIVIDER_LOCATOR;
-    protected String OPPOSITE_LOCATOR;
-    protected String DOT_LOCATOR = ".v-timeline-item__dot";
-    protected String INNER_DOT_LOCATOR = ".v-timeline-item__inner-dot";
+    protected static String SMALL_CLASS = "v-timeline-item__dot--small";
+    protected static String LARGE_CLASS = "v-timeline-item__dot--large";
 
-    protected String SMALL_CLASS = "v-timeline-item__dot--small";
-    protected String LARGE_CLASS = "v-timeline-item__dot--large";
+    protected String bodyLocator;
+    protected String dividerLocator;
+    protected String oppositeLocator;
+    protected String dotLocator = ".v-timeline-item__dot";
+    protected String innerDotLocator = ".v-timeline-item__inner-dot";
 
     protected Class<T> bodyClass;
     protected Class<U> dividerClass;
@@ -24,27 +24,27 @@ public class TimeLineItem<T extends ICoreElement, U extends ICoreElement> extend
     TimeLineItem() {}
 
     public T body() {
-        return initT(find(BODY_LOCATOR), this, bodyClass);
+        return initT(find(bodyLocator), this, bodyClass);
     }
 
     public U divider() {
-        return initT(find(DIVIDER_LOCATOR), this, dividerClass);
+        return initT(find(dividerLocator), this, dividerClass);
     }
 
     public UIElement opposite() {
-        return find(OPPOSITE_LOCATOR);
+        return find(oppositeLocator);
     }
 
     public boolean isSmall() {
-        return find(DOT_LOCATOR).hasClass(SMALL_CLASS);
+        return find(dotLocator).hasClass(SMALL_CLASS);
     }
 
     public boolean isLarge() {
-        return find(DOT_LOCATOR).hasClass(LARGE_CLASS);
+        return find(dotLocator).hasClass(LARGE_CLASS);
     }
 
     public String dotColor() {
-        return find(INNER_DOT_LOCATOR).css("background-color");
+        return find(innerDotLocator).css("background-color");
     }
 
     @Override

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
@@ -14,7 +14,7 @@ public class TimeLineItem<T extends ICoreElement, U extends ICoreElement> extend
 
     protected String bodyLocator;
     protected String dividerLocator;
-    protected String oppositeLocator;
+    private String oppositeLocator;
     protected String dotLocator = ".v-timeline-item__dot";
     protected String innerDotLocator = ".v-timeline-item__inner-dot";
 
@@ -50,5 +50,9 @@ public class TimeLineItem<T extends ICoreElement, U extends ICoreElement> extend
     @Override
     public TimeLineItemAssert is() {
         return new TimeLineItemAssert().set(this);
+    }
+
+    public void setOppositeLocator(String oppositeLocator) {
+        this.oppositeLocator = oppositeLocator;
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
@@ -9,17 +9,17 @@ import static com.epam.jdi.light.common.UIUtils.initT;
 
 public class TimeLineItem<T extends ICoreElement, U extends ICoreElement> extends UIBaseElement<TimeLineItemAssert> {
 
-    protected static final String SMALL_CLASS = "v-timeline-item__dot--small";
-    protected static final String LARGE_CLASS = "v-timeline-item__dot--large";
+    private static final String SMALL_CLASS = "v-timeline-item__dot--small";
+    private static final String LARGE_CLASS = "v-timeline-item__dot--large";
 
-    protected String bodyLocator;
-    protected String dividerLocator;
+    private String bodyLocator;
+    private String dividerLocator;
     private String oppositeLocator;
-    protected String dotLocator = ".v-timeline-item__dot";
-    protected String innerDotLocator = ".v-timeline-item__inner-dot";
+    private String dotLocator = ".v-timeline-item__dot";
+    private String innerDotLocator = ".v-timeline-item__inner-dot";
 
-    protected Class<T> bodyClass;
-    protected Class<U> dividerClass;
+    private Class<T> bodyClass;
+    private Class<U> dividerClass;
 
     TimeLineItem() {}
 
@@ -54,5 +54,29 @@ public class TimeLineItem<T extends ICoreElement, U extends ICoreElement> extend
 
     public void setOppositeLocator(String oppositeLocator) {
         this.oppositeLocator = oppositeLocator;
+    }
+
+    public void setBodyLocator(String bodyLocator) {
+        this.bodyLocator = bodyLocator;
+    }
+
+    public void setDividerLocator(String dividerLocator) {
+        this.dividerLocator = dividerLocator;
+    }
+
+    public void setDotLocator(String dotLocator) {
+        this.dotLocator = dotLocator;
+    }
+
+    public void setInnerDotLocator(String innerDotLocator) {
+        this.innerDotLocator = innerDotLocator;
+    }
+
+    public void setBodyClass(Class<T> bodyClass) {
+        this.bodyClass = bodyClass;
+    }
+
+    public void setDividerClass(Class<U> dividerClass) {
+        this.dividerClass = dividerClass;
     }
 }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/timelines/TimeLineItem.java
@@ -9,8 +9,8 @@ import static com.epam.jdi.light.common.UIUtils.initT;
 
 public class TimeLineItem<T extends ICoreElement, U extends ICoreElement> extends UIBaseElement<TimeLineItemAssert> {
 
-    protected static String SMALL_CLASS = "v-timeline-item__dot--small";
-    protected static String LARGE_CLASS = "v-timeline-item__dot--large";
+    protected static final String SMALL_CLASS = "v-timeline-item__dot--small";
+    protected static final String LARGE_CLASS = "v-timeline-item__dot--large";
 
     protected String bodyLocator;
     protected String dividerLocator;

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/composite/BottomSheet.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/composite/BottomSheet.java
@@ -16,7 +16,7 @@ public class BottomSheet extends Sheet {
 
     // Element could be presented on a page and isDisplayed would return true but all sheet content is hidden
     // with z-index tricks if the element does not have this css class
-    protected static final String ACTIVE_SHEET_CLASSNAME = "v-dialog__content--active";
+    private static final String ACTIVE_SHEET_CLASSNAME = "v-dialog__content--active";
 
     @Override
     public boolean isDisplayed() {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/composite/BottomSheet.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/composite/BottomSheet.java
@@ -16,7 +16,7 @@ public class BottomSheet extends Sheet {
 
     // Element could be presented on a page and isDisplayed would return true but all sheet content is hidden
     // with z-index tricks if the element does not have this css class
-    protected final String ACTIVE_SHEET_CLASSNAME = "v-dialog__content--active";
+    protected static final String ACTIVE_SHEET_CLASSNAME = "v-dialog__content--active";
 
     @Override
     public boolean isDisplayed() {


### PR DESCRIPTION
Names of elements locators are rewritten in mixed case with the first letter lowercase, with the first letter of each internal word capitalized.
Names of elements classes are rewritten as all uppercase with words separated by underscores.