### PR TITLE
Paper: add functionality for style verification

### DIFF
--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/PaperTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/PaperTests.java
@@ -7,7 +7,6 @@ import org.testng.annotations.Test;
 import static io.github.com.StaticSite.paperPage;
 import static io.github.com.pages.surfaces.PaperPage.defaultElevationPaper;
 import static io.github.com.pages.surfaces.PaperPage.elevationThreePaper;
-import static io.github.com.pages.surfaces.PaperPage.infoPaper;
 import static io.github.com.pages.surfaces.PaperPage.outlinedRoundedPaper;
 import static io.github.com.pages.surfaces.PaperPage.outlinedSquarePaper;
 import static io.github.com.pages.surfaces.PaperPage.zeroElevationPaper;
@@ -19,13 +18,6 @@ import static io.github.com.pages.surfaces.PaperPage.zeroElevationPaper;
 
 public class PaperTests extends TestsInit {
 
-    private final String ZERO_ELEVATION = "Paper with elevation = 0";
-    private final String DEFAULT_ELEVATION = "Paper with default elavation";
-    private final String ELEVATION_EQUALS_THREE = "Paper with elevation = 3";
-    private final String OUTLINED_ROUNDED = "Outlined paper";
-    private final String OUTLINED_SQUARE = "Outlined square paper";
-    private final String YOU_CLICKED = "You clicked: ";
-
     @BeforeMethod
     public void beforeTest() {
         paperPage.open();
@@ -35,35 +27,34 @@ public class PaperTests extends TestsInit {
     @Test
     public void zeroElevationPaperTest() {
         zeroElevationPaper.is().displayed();
-        zeroElevationPaper.click();
-        infoPaper.has().text(YOU_CLICKED + ZERO_ELEVATION);
+        zeroElevationPaper.has().elevation(0);
     }
 
     @Test
     public void defaultElevationPaperTest() {
         defaultElevationPaper.is().displayed();
-        defaultElevationPaper.click();
-        infoPaper.has().text(YOU_CLICKED + DEFAULT_ELEVATION);
+        defaultElevationPaper.has().elevation(1);
+        defaultElevationPaper.is().rounded();
     }
 
     @Test
     public void elevationThreePaperTest() {
         elevationThreePaper.is().displayed();
-        elevationThreePaper.click();
-        infoPaper.has().text(YOU_CLICKED + ELEVATION_EQUALS_THREE);
+        elevationThreePaper.has().elevation(3);
+        elevationThreePaper.is().rounded();
     }
 
     @Test
     public void outlinedRoundedPaperPaperTest() {
         outlinedRoundedPaper.is().displayed();
-        outlinedRoundedPaper.click();
-        infoPaper.has().text(YOU_CLICKED + OUTLINED_ROUNDED);
+        outlinedRoundedPaper.is().rounded();
+        outlinedRoundedPaper.is().outlined();
     }
 
     @Test
     public void outlinedSquarePaperTest() {
         outlinedSquarePaper.is().displayed();
-        outlinedSquarePaper.click();
-        infoPaper.has().text(YOU_CLICKED + OUTLINED_SQUARE);
+        outlinedSquarePaper.is().outlined();
+        outlinedSquarePaper.is().square();
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/surfaces/PaperAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/surfaces/PaperAssert.java
@@ -1,0 +1,39 @@
+package com.epam.jdi.light.material.asserts.surfaces;
+
+import com.epam.jdi.light.asserts.generic.UIAssert;
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.material.elements.surfaces.Paper;
+import org.hamcrest.Matchers;
+
+import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
+
+public class PaperAssert extends UIAssert<PaperAssert, Paper> {
+
+    @JDIAction("Assert that '{name}' is rounded")
+    public PaperAssert rounded() {
+        jdiAssert(element().core().classes().toString(),
+                Matchers.containsString("MuiPaper-rounded"));
+        return this;
+    }
+
+    @JDIAction("Assert that '{name}' is square")
+    public PaperAssert square() {
+        jdiAssert(element().core().classes().toString(),
+                Matchers.not(Matchers.containsString("MuiPaper-rounded")));
+        return this;
+    }
+
+    @JDIAction("Assert that '{name}' has elevation {0}")
+    public PaperAssert elevation(int expectedElevation) {
+        jdiAssert(element().core().classes().toString(),
+                Matchers.containsString("MuiPaper-elevation" + expectedElevation));
+        return this;
+    }
+
+    @JDIAction("Assert that '{name}' is outlined")
+    public PaperAssert outlined() {
+        jdiAssert(element().core().classes().toString(),
+                Matchers.containsString("MuiPaper-outlined"));
+        return this;
+    }
+}

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/Paper.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/Paper.java
@@ -1,19 +1,25 @@
 package com.epam.jdi.light.material.elements.surfaces;
 
 import com.epam.jdi.light.asserts.generic.TextAssert;
+import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.base.UIBaseElement;
+import com.epam.jdi.light.elements.common.UIElement;
 import com.epam.jdi.light.elements.interfaces.base.HasClick;
 import com.epam.jdi.light.elements.interfaces.common.IsText;
+import com.epam.jdi.light.material.asserts.surfaces.PaperAssert;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 
 /**
  * To see an example of Paper web element please visit
  * https://mui.com/components/paper/
  */
 
-public class Paper extends UIBaseElement<TextAssert> implements IsText, HasClick {
+public class Paper extends UIBaseElement<PaperAssert> {
 
     @Override
-    public TextAssert is() {
-        return new TextAssert().set(this);
+    public PaperAssert is() {
+        return new PaperAssert().set(this);
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/Paper.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/Paper.java
@@ -1,15 +1,7 @@
 package com.epam.jdi.light.material.elements.surfaces;
 
-import com.epam.jdi.light.asserts.generic.TextAssert;
-import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.base.UIBaseElement;
-import com.epam.jdi.light.elements.common.UIElement;
-import com.epam.jdi.light.elements.interfaces.base.HasClick;
-import com.epam.jdi.light.elements.interfaces.common.IsText;
 import com.epam.jdi.light.material.asserts.surfaces.PaperAssert;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.not;
 
 /**
  * To see an example of Paper web element please visit


### PR DESCRIPTION
Implemented PaperAssert to assert that Paper element:
- has elevation equal to X
- is rounded
- is square (not rounded)
- is outlined

Changed tests accordingly