### PR TITLE
3577 material UI refactor lists

### DIFF
--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/ListTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/ListTests.java
@@ -61,7 +61,6 @@ public class ListTests extends TestsInit {
     public void avatarWithTextTests() {
         secondaryTextCheckbox.check();
         avatarWithTextList.items().get(0).has().secondaryText("Secondary text");
-        System.out.println(avatarWithTextList.items().get(0).getText());
     }
 
     @Test
@@ -74,7 +73,7 @@ public class ListTests extends TestsInit {
     }
 
     @Test
-    public void selectedListTests(){
+    public void selectedListTests() {
         selectedListUpperHalf.selectItemByText("Inbox");
         selectedListUpperHalf.getItemByText("Inbox").is().selected();
         selectedListLowerHalf.selectItemByText("Spam");

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/List.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/List.java
@@ -79,9 +79,9 @@ public class List extends UIBaseElement<ListAssert> implements ISetup {
         }
     }
 
-    @JDIAction("Return Java list containing Material UI lists nested within '{name}'")
+    @JDIAction("Return Java list containing Material UI lists nested directly within '{name}'")
     public java.util.List<List> nestedLists() {
-        return finds("ul").stream()
+        return finds("//ul[not(parent::ul)]").stream() // targets only the first layer of nested lists
                 .map(nestedList -> new List().setCore(List.class, nestedList))
                 .collect(Collectors.toList());
     }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/List.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/List.java
@@ -81,7 +81,7 @@ public class List extends UIBaseElement<ListAssert> implements ISetup {
 
     @JDIAction("Return Java list containing Material UI lists nested directly within '{name}'")
     public java.util.List<List> nestedLists() {
-        return finds("//ul[not(parent::ul)]").stream() // targets only the first layer of nested lists
+        return finds(".//ul[not(parent::ul)]").stream() // targets only the first layer of nested lists
                 .map(nestedList -> new List().setCore(List.class, nestedList))
                 .collect(Collectors.toList());
     }


### PR DESCRIPTION
Updated nestedLists() method so it doesn't return lists nested more than 1 layer deep.