### PR TITLE
Material UI: refactor Accordion element

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/surfaces/AccordionPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/surfaces/AccordionPage.java
@@ -11,12 +11,32 @@ public class AccordionPage extends WebPage {
             value = ".MuiButtonBase-root.MuiAccordionSummary-root",
             list = ".MuiAccordionDetails-root",
             expand = ".MuiIconButton-label")
-    public static Accordion enabledAccordion;
+    public static Accordion generalSettingsAccordion;
+
+    @JDropdown(
+            root = ".MuiAccordion-root[2]",
+            value = ".MuiButtonBase-root.MuiAccordionSummary-root",
+            list = ".MuiAccordionDetails-root",
+            expand = ".MuiIconButton-label")
+    public static Accordion usersAccordion;
+
+    @JDropdown(
+            root = ".MuiAccordion-root[3]",
+            value = ".MuiButtonBase-root.MuiAccordionSummary-root",
+            list = ".MuiAccordionDetails-root",
+            expand = ".MuiIconButton-label")
+    public static Accordion advancedSettingsAccordion;
+
+    @JDropdown(
+            root = ".MuiAccordion-root[4]",
+            value = ".MuiButtonBase-root.MuiAccordionSummary-root",
+            list = ".MuiAccordionDetails-root",
+            expand = ".MuiIconButton-label")
+    public static Accordion personalDataAccordion;
 
     @JDropdown(
             root = ".MuiAccordion-root[5]",
             value = ".MuiButtonBase-root.MuiAccordionSummary-root",
-            expand = ".MuiIconButton-label"
-            )
+            expand = ".MuiIconButton-label")
     public static Accordion disabledAccordion;
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/AccordionTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/AccordionTests.java
@@ -1,52 +1,62 @@
 package io.github.epam.material.tests.surfaces;
 
-import com.jdiai.tools.Timer;
 import io.github.epam.TestsInit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
 import static io.github.com.StaticSite.accordionPage;
+import static io.github.com.pages.surfaces.AccordionPage.advancedSettingsAccordion;
 import static io.github.com.pages.surfaces.AccordionPage.disabledAccordion;
-import static io.github.com.pages.surfaces.AccordionPage.enabledAccordion;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+import static io.github.com.pages.surfaces.AccordionPage.generalSettingsAccordion;
+import static io.github.com.pages.surfaces.AccordionPage.personalDataAccordion;
+import static io.github.com.pages.surfaces.AccordionPage.usersAccordion;
+import static org.hamcrest.Matchers.containsString;
 
 /**
  * To see an example of Accordion web element please visit
- * https://material-ui.com/components/accordion
+ * https://mui.com/components/accordion/
  */
 
 public class AccordionTests extends TestsInit {
 
-    private static Timer timer = new Timer(1000L);
-
     @BeforeMethod
-    public void before(){
+    public void before() {
         accordionPage.open();
-        accordionPage.isOpened();
+        accordionPage.checkOpened();
     }
 
     @Test
-    public void disableAccordionTest(){
-        assertTrue(disabledAccordion.isDisabled());
+    public void disabledAccordionTest() {
+        disabledAccordion.is().displayed();
+        disabledAccordion.is().disabled();
+        disabledAccordion.list().is().hidden();
     }
 
     @Test
-    public void defaultAccordionTest() {
-        assertTrue(enabledAccordion.isEnabled());
-        enabledAccordion.expand();
-        assertTrue(enabledAccordion.list().isDisplayed());
-        enabledAccordion.close();
-        timer.wait(() -> enabledAccordion.is().collapsed());
-        timer.wait(() -> assertFalse(enabledAccordion.list().isDisplayed()));
+    public void accordionExpandTest() {
+        generalSettingsAccordion.is().enabled();
+        generalSettingsAccordion.list().is().hidden();
+        generalSettingsAccordion.expand();
+        generalSettingsAccordion.list().is().displayed();
+        generalSettingsAccordion.close();
+        generalSettingsAccordion.is().collapsed();
+        generalSettingsAccordion.list().is().hidden();
     }
 
     @Test
-    public void textAccordionTest(){
-        String rootContent = enabledAccordion.getText();
-        assertTrue(rootContent.contains("General settings"));
-        enabledAccordion.expand();
-        String listContent = enabledAccordion.list().get(1).getText();
-        assertTrue(listContent.contains("Nulla facilisi."));
+    public void accordionTextTest() {
+        usersAccordion.is().displayed();
+        usersAccordion.has().text("Users\nYou are currently not an owner");
+        usersAccordion.expand();
+        usersAccordion.list().get(1).has().text(containsString("Donec placerat, lectus sed mattis semper"));
     }
 
+    @Test
+    public void severalAccordionsExpandTest() {
+        advancedSettingsAccordion.expand();
+        advancedSettingsAccordion.list().is().displayed();
+        personalDataAccordion.expand();
+        personalDataAccordion.list().is().displayed();
+        advancedSettingsAccordion.list().is().hidden();
+    }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/Accordion.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/Accordion.java
@@ -9,9 +9,9 @@ import com.epam.jdi.light.elements.complex.dropdown.Dropdown;
  */
 public class Accordion extends Dropdown {
 
-    @JDIAction("Is '{name} disabled")
+    @JDIAction("Is '{name} enabled")
     @Override
-    public boolean isDisabled() {
-        return value().hasClass("Mui-disabled");
+    public boolean isEnabled() {
+        return !value().hasClass("Mui-disabled");
     }
 }


### PR DESCRIPTION
- Replaced assertTrue()'s with element assertions
- Added test for collapsing one Accordion when expanding another
- Created different elements for different Accordions on  AccordionPage, not just "enabledAccordion"