### PR TITLE
Material UI: Tooltip tests were refactored

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/displaydata/TooltipPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/displaydata/TooltipPage.java
@@ -3,23 +3,15 @@ package io.github.com.pages.displaydata;
 import com.epam.jdi.light.elements.composite.WebPage;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 import io.github.com.custom.TooltipButton;
+import java.util.List;
 
 public class TooltipPage extends WebPage {
 
-    @UI("//*[contains(@class, 'MuiIconButton-root')]")
-    public static TooltipButton deleteButtonWithTooltip;
+    @UI("//h2[text()='Simple tooltips']/following-sibling::div[1]/button")
+    public static List<TooltipButton> simpleTooltipsButton;
 
-    @UI("(//button[contains(@title, 'Add')])[1]")
-    public static TooltipButton addButtonWithTooltip;
-
-    @UI("//h2[contains(text(), 'Customizable tooltips')]/following::button[1]")
-    public static TooltipButton buttonWithLightTooltip;
-
-    @UI("//h2[contains(text(), 'Customizable tooltips')]/following::button[2]")
-    public static TooltipButton buttonWithBootstrapTooltip;
-
-    @UI("//h2[contains(text(), 'Customizable tooltips')]/following::button[3]")
-    public static TooltipButton buttonWithHtmlTooltip;
+    @UI("//h2[contains(text(), 'Customizable tooltips')]/following::div[1]/button")
+    public static List<TooltipButton> customizableTooltipsButton;
 
     @UI("//div[@id='touchItem']/button")
     public static TooltipButton hoverOrTouchButtonWithTooltip;
@@ -32,5 +24,4 @@ public class TooltipPage extends WebPage {
 
     @UI("#disabledBtn")
     public static TooltipButton disabledButtonWithTooltip;
-
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TooltipTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TooltipTests.java
@@ -1,20 +1,17 @@
 package io.github.epam.material.tests.displaydata;
 
-import io.github.epam.TestsInit;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import static io.github.com.StaticSite.tooltipPage;
-import static io.github.com.pages.displaydata.TooltipPage.addButtonWithTooltip;
-import static io.github.com.pages.displaydata.TooltipPage.buttonWithBootstrapTooltip;
-import static io.github.com.pages.displaydata.TooltipPage.buttonWithHtmlTooltip;
-import static io.github.com.pages.displaydata.TooltipPage.buttonWithLightTooltip;
 import static io.github.com.pages.displaydata.TooltipPage.clickButtonWithTooltip;
-import static io.github.com.pages.displaydata.TooltipPage.deleteButtonWithTooltip;
+import static io.github.com.pages.displaydata.TooltipPage.customizableTooltipsButton;
 import static io.github.com.pages.displaydata.TooltipPage.disabledButtonWithTooltip;
 import static io.github.com.pages.displaydata.TooltipPage.hoverButtonWithTooltip;
 import static io.github.com.pages.displaydata.TooltipPage.hoverOrTouchButtonWithTooltip;
+import static io.github.com.pages.displaydata.TooltipPage.simpleTooltipsButton;
+import io.github.epam.TestsInit;
 import static org.hamcrest.Matchers.containsString;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 /**
  * To see an example of Tooltip web element please visit
@@ -29,44 +26,18 @@ public class TooltipTests extends TestsInit {
         tooltipPage.isOpened();
     }
 
-    @Test
-    public void deleteButtonWithTooltipTest() {
-        deleteButtonWithTooltip.is().visible();
-        deleteButtonWithTooltip.hover();
-        deleteButtonWithTooltip.tooltip().is().visible();
-        deleteButtonWithTooltip.tooltip().has().text("Delete");
+    @Test(dataProvider = "simpleTooltipsTestData")
+    public void simpleTooltipsTest(int number, String text) {
+        simpleTooltipsButton.get(number).hover();
+        simpleTooltipsButton.get(number).tooltip().is().visible();
+        simpleTooltipsButton.get(number).tooltip().has().text(text);
     }
 
-    @Test
-    public void addButtonWithTooltipTest() {
-        addButtonWithTooltip.is().visible();
-        addButtonWithTooltip.hover();
-        addButtonWithTooltip.tooltip().is().visible();
-        addButtonWithTooltip.tooltip().has().text("Add");
-    }
-
-    @Test
-    public void buttonWithLightTooltipTest() {
-        buttonWithLightTooltip.is().visible();
-        buttonWithLightTooltip.hover();
-        buttonWithLightTooltip.tooltip().is().visible();
-        buttonWithLightTooltip.tooltip().has().text("Add");
-    }
-
-    @Test
-    public void buttonWithBootstrapTooltipTest() {
-        buttonWithBootstrapTooltip.is().visible();
-        buttonWithBootstrapTooltip.hover();
-        buttonWithBootstrapTooltip.tooltip().is().visible();
-        buttonWithBootstrapTooltip.tooltip().has().text("Add");
-    }
-
-    @Test
-    public void buttonWithHtmlTooltipTest() {
-        buttonWithHtmlTooltip.is().visible();
-        buttonWithHtmlTooltip.hover();
-        buttonWithHtmlTooltip.tooltip().is().visible();
-        buttonWithHtmlTooltip.tooltip().has().text(containsString("Tooltip with HTML"));
+    @Test(dataProvider = "customizableTooltipsTestData")
+    public void customizableTooltipsTest(int number, String text) {
+        customizableTooltipsButton.get(number).hover();
+        customizableTooltipsButton.get(number).tooltip().is().visible();
+        customizableTooltipsButton.get(number).tooltip().has().text(containsString(text));
     }
 
     @Test
@@ -100,4 +71,19 @@ public class TooltipTests extends TestsInit {
         disabledButtonWithTooltip.tooltip().is().visible();
         disabledButtonWithTooltip.tooltip().has().text("You don't have permission to do this");
     }
+
+    @DataProvider
+    public Object[][] simpleTooltipsTestData() {
+        return new Object[][]{
+                {1, "Delete"}, {2, "Add"}, {3, "Add"}
+        };
+    }
+
+    @DataProvider
+    public Object[][] customizableTooltipsTestData() {
+        return new Object[][]{
+                {1, "Add"}, {2, "Add"}, {3, "Tooltip with HTML"}
+        };
+    }
 }
+

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TooltipTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TooltipTests.java
@@ -1,6 +1,8 @@
 package io.github.epam.material.tests.displaydata;
 
+import com.epam.jdi.light.material.elements.displaydata.Tooltip;
 import static io.github.com.StaticSite.tooltipPage;
+import io.github.com.custom.TooltipButton;
 import static io.github.com.pages.displaydata.TooltipPage.clickButtonWithTooltip;
 import static io.github.com.pages.displaydata.TooltipPage.customizableTooltipsButton;
 import static io.github.com.pages.displaydata.TooltipPage.disabledButtonWithTooltip;
@@ -8,6 +10,7 @@ import static io.github.com.pages.displaydata.TooltipPage.hoverButtonWithTooltip
 import static io.github.com.pages.displaydata.TooltipPage.hoverOrTouchButtonWithTooltip;
 import static io.github.com.pages.displaydata.TooltipPage.simpleTooltipsButton;
 import io.github.epam.TestsInit;
+import java.awt.Button;
 import static org.hamcrest.Matchers.containsString;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -28,32 +31,22 @@ public class TooltipTests extends TestsInit {
 
     @Test(dataProvider = "simpleTooltipsTestData")
     public void simpleTooltipsTest(int number, String text) {
-        simpleTooltipsButton.get(number).hover();
-        simpleTooltipsButton.get(number).tooltip().is().visible();
-        simpleTooltipsButton.get(number).tooltip().has().text(text);
+        checkTooltip(simpleTooltipsButton.get(number), text);
     }
 
     @Test(dataProvider = "customizableTooltipsTestData")
     public void customizableTooltipsTest(int number, String text) {
-        customizableTooltipsButton.get(number).hover();
-        customizableTooltipsButton.get(number).tooltip().is().visible();
-        customizableTooltipsButton.get(number).tooltip().has().text(containsString(text));
+        checkTooltip(customizableTooltipsButton.get(number), text);
     }
 
     @Test
     public void hoverOrTouchTooltip() {
-        hoverOrTouchButtonWithTooltip.is().visible();
-        hoverOrTouchButtonWithTooltip.hover();
-        hoverOrTouchButtonWithTooltip.tooltip().is().visible();
-        hoverOrTouchButtonWithTooltip.tooltip().has().text("Add");
+        checkTooltip(hoverOrTouchButtonWithTooltip, "Add");
     }
 
     @Test
     public void hoverButtonTooltipTest() {
-        hoverButtonWithTooltip.is().visible();
-        hoverButtonWithTooltip.hover();
-        hoverButtonWithTooltip.tooltip().is().visible();
-        hoverButtonWithTooltip.tooltip().has().text("Add");
+        checkTooltip(hoverButtonWithTooltip, "Add");
     }
 
     @Test
@@ -66,10 +59,13 @@ public class TooltipTests extends TestsInit {
 
     @Test
     public void disabledButtonWithTooltipTest() {
-        disabledButtonWithTooltip.is().visible();
-        disabledButtonWithTooltip.hover();
-        disabledButtonWithTooltip.tooltip().is().visible();
-        disabledButtonWithTooltip.tooltip().has().text("You don't have permission to do this");
+        checkTooltip(disabledButtonWithTooltip, "You don't have permission to do this");
+    }
+
+    private static void checkTooltip(TooltipButton tooltipButton, String expectedText) {
+        tooltipButton.hover();
+        tooltipButton.tooltip().is().visible();
+        tooltipButton.tooltip().has().text(containsString(expectedText));
     }
 
     @DataProvider

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TooltipTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TooltipTests.java
@@ -1,6 +1,5 @@
 package io.github.epam.material.tests.displaydata;
 
-import com.epam.jdi.light.material.elements.displaydata.Tooltip;
 import static io.github.com.StaticSite.tooltipPage;
 import io.github.com.custom.TooltipButton;
 import static io.github.com.pages.displaydata.TooltipPage.clickButtonWithTooltip;
@@ -10,7 +9,6 @@ import static io.github.com.pages.displaydata.TooltipPage.hoverButtonWithTooltip
 import static io.github.com.pages.displaydata.TooltipPage.hoverOrTouchButtonWithTooltip;
 import static io.github.com.pages.displaydata.TooltipPage.simpleTooltipsButton;
 import io.github.epam.TestsInit;
-import java.awt.Button;
 import static org.hamcrest.Matchers.containsString;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/Tooltip.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/Tooltip.java
@@ -21,9 +21,6 @@ public class Tooltip extends UIBaseElement<TooltipAssert> {
 
     @JDIAction("Get value of '{name}'")
     public String getValue() {
-//        return core().find(By.xpath("/ancestor::body//div[contains(@class,'MuiTooltip-tooltip')]")).getText();
-//        return core().find(By.xpath("//div[contains(@class,'MuiTooltip-tooltip')]")).getText();
-//        doesn't work and I don't know why
         return core().driver().findElement(TOOLTIP_PLACEHOLDER_LOCATOR).getText();
     }
 

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/Tooltip.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/Tooltip.java
@@ -30,15 +30,12 @@ public class Tooltip extends UIBaseElement<TooltipAssert> {
     }
 
     @Override
-    public TooltipAssert has() {
-        return this.is();
-    }
-
-    @Override
+    @JDIAction("Shows that {name} is visible")
     public boolean isVisible() {
         return core().isExist();
     }
 
+    @JDIAction("Shows that {name} is interactive")
     public boolean isInteractive() {
         return core().hasClass("MuiTooltip-popperInteractive");
     }


### PR DESCRIPTION
-Deleted unnecessary code in Tooltip's "getValue()" method
-"deleteButtonWithTooltipTest" and "addButtonWithTooltipTest" were merged into "simpleTooltipsTest"
-"buttonWithLightTooltipTest", "buttonWithBootstrapTooltipTest" and "buttonWithHtmlTooltipTest" were merged into "customizableTooltipsTest"
-Added DataProvider for "simpleTooltipsTest" and "customizableTooltipsTest"