### PR TITLE
3736: Resolving unused imports

### DIFF
--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/utils/Popper.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/utils/Popper.java
@@ -2,8 +2,6 @@ package com.epam.jdi.light.material.elements.utils;
 
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.base.UIBaseElement;
-import com.epam.jdi.light.elements.common.UIElement;
-import static com.epam.jdi.light.elements.init.UIFactory.$;
 import com.epam.jdi.light.elements.interfaces.common.IsText;
 import com.epam.jdi.light.material.asserts.utils.PopperAssert;
 


### PR DESCRIPTION
Unused imports in Popper are deleted.