### PR TITLE
3718 - Table refactoring

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/displaydata/TablePage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/displaydata/TablePage.java
@@ -7,7 +7,6 @@ import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 import com.epam.jdi.light.material.elements.inputs.Checkbox;
 import com.epam.jdi.light.ui.html.elements.common.Button;
 import com.epam.jdi.light.ui.html.elements.common.Text;
-
 import java.util.List;
 
 public class TablePage extends WebPage {
@@ -53,8 +52,8 @@ public class TablePage extends WebPage {
     )
     public static Table collapsibleTable;
 
-    @UI("//table[contains(@aria-label, 'purchases')]")
-    public static List<Table> purchaseTables;
+    @UI("//table[contains(@aria-label, 'purchases')][1]")
+    public static Table purchaseTables;
 
     @UI("(//table[contains(@class, 'MuiTable-root')])[5]")
     public static Table spanningTable;

--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/displaydata/TablePage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/displaydata/TablePage.java
@@ -24,7 +24,7 @@ public class TablePage extends WebPage {
     public static Table sortingSelectingTable;
 
     @UI("//div[contains(@class, 'MuiSelect-selectMenu')]")
-    public static Button rowsPerPageBtn;
+    public static Button rowsPerPageButton;
 
     @UI("//li[contains(@class, 'MuiTablePagination-menuItem')]")
     public static List<Button> rowsPerPageValues;
@@ -53,7 +53,7 @@ public class TablePage extends WebPage {
     public static Table collapsibleTable;
 
     @UI("//table[contains(@aria-label, 'purchases')][1]")
-    public static Table purchaseTables;
+    public static Table purchaseTable;
 
     @UI("(//table[contains(@class, 'MuiTable-root')])[5]")
     public static Table spanningTable;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TableTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TableTests.java
@@ -6,8 +6,8 @@ import static io.github.com.pages.displaydata.TablePage.collapsibleTable;
 import static io.github.com.pages.displaydata.TablePage.dataTableCells;
 import static io.github.com.pages.displaydata.TablePage.densePaddingSwitch;
 import static io.github.com.pages.displaydata.TablePage.denseTable;
-import static io.github.com.pages.displaydata.TablePage.purchaseTables;
-import static io.github.com.pages.displaydata.TablePage.rowsPerPageBtn;
+import static io.github.com.pages.displaydata.TablePage.purchaseTable;
+import static io.github.com.pages.displaydata.TablePage.rowsPerPageButton;
 import static io.github.com.pages.displaydata.TablePage.rowsPerPageValues;
 import static io.github.com.pages.displaydata.TablePage.scrollButtons;
 import static io.github.com.pages.displaydata.TablePage.selectedRowCounter;
@@ -108,9 +108,9 @@ public class TableTests extends TestsInit {
         scrollButtons.get(3).click();
 
         sortingSelectingTable.headerUI().get(2).find(".MuiTableSortLabel-root").click();
-        rowsPerPageBtn.click();
+        rowsPerPageButton.click();
         rowsPerPageValues.get(2).click();
-        rowsPerPageBtn.has().text("10");
+        rowsPerPageButton.has().text("10");
 
         sortingSelectingTable.getCell(2, 10).has().text("392");
 
@@ -129,9 +129,9 @@ public class TableTests extends TestsInit {
         showSubTable.is().displayed();
         showSubTable.hover();
         showSubTable.click();
-        timer.wait(() -> purchaseTables.getRow(1).get(1).has().text("11091700"));
+        timer.wait(() -> purchaseTable.getRow(1).get(1).has().text("11091700"));
         showSubTable.click();
-        timer.wait(() -> purchaseTables.is().notVisible());
+        timer.wait(() -> purchaseTable.is().notVisible());
     }
 
     @Test

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TableTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TableTests.java
@@ -1,18 +1,5 @@
 package io.github.epam.material.tests.displaydata;
 
-import com.epam.jdi.light.elements.common.UIElement;
-import com.epam.jdi.light.ui.html.elements.common.Button;
-import com.epam.jdi.light.ui.html.elements.common.Text;
-import com.jdiai.tools.Timer;
-import io.github.epam.TestsInit;
-import org.openqa.selenium.By;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import static io.github.com.StaticSite.tablePage;
 import static io.github.com.pages.displaydata.TablePage.basicTable;
 import static io.github.com.pages.displaydata.TablePage.collapsibleTable;
@@ -32,6 +19,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
+import com.epam.jdi.light.elements.common.UIElement;
+import com.epam.jdi.light.ui.html.elements.common.Button;
+import com.epam.jdi.light.ui.html.elements.common.Text;
+import com.jdiai.tools.Timer;
+import io.github.epam.TestsInit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.openqa.selenium.By;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 /**
  * To see an example of Tables web element please visit
  * https://material-ui.com/components/tables/
@@ -42,7 +41,7 @@ public class TableTests extends TestsInit {
     private static final List<String> EXPECTED_TABLE_HEADERS = new ArrayList<>(Arrays.asList("Dessert (100g serving)",
             "Calories", "Fat (g)", "Carbs (g)", "Protein (g)"));
 
-    private final Timer timer = new Timer(2000L);
+    private final Timer timer = new Timer(16000L);
 
     @BeforeMethod
     public void beforeTest() {
@@ -52,14 +51,12 @@ public class TableTests extends TestsInit {
 
     @Test
     public void basicTableTest() {
-        basicTable.has().columns(EXPECTED_TABLE_HEADERS);
-        assertThat(basicTable.count(), equalTo(13));
+        basicTable.has().columns(EXPECTED_TABLE_HEADERS).and().size(13);
         basicTable.getCell(1, 1).has().text("305");
     }
 
     @Test
     public void dataTableTest() {
-
         getDataTableCell(1, 3).click();
         getDataTableCell(3, 3).has().text("Arya");
 
@@ -71,20 +68,24 @@ public class TableTests extends TestsInit {
         getDataTableCell(2, 1).click();
         selectedRowCounter.has().text(containsString("6"));
 
-        scrollButtons.get(1).is().displayed();
-        scrollButtons.get(1).is().disabled();
+        scrollButtons.get(1).is().displayed().and().disabled();
         scrollButtons.get(2).is().displayed();
         scrollButtons.get(2).click();
 
         getDataTableCell(2, 3).has().text("Harvey");
     }
 
+    private Button getDataTableCell(int row, int coll) {
+        return dataTableCells.get((row - 1) * 6 + coll);
+    }
+
     @Test
     public void denseTableTest() {
-        denseTable.has().columns(EXPECTED_TABLE_HEADERS);
-        assertThat(denseTable.count(), equalTo(5));
-        denseTable.getCell(1, 1).has().text("159");
-        denseTable.getCell(2, 3).has().text("16");
+        denseTable.has().columns(EXPECTED_TABLE_HEADERS).and().size(5);
+        denseTable.getCell(1, 1).has().text("159")
+                .and().classValue(containsString("sizeSmall"));
+        denseTable.getCell(2, 3).has().text("16")
+                .and().classValue(containsString("sizeSmall"));
     }
 
     @Test
@@ -100,8 +101,7 @@ public class TableTests extends TestsInit {
         sortingSelectingTable.getRow(3).get(1).check();
         sortingSelectingTableTitle.has().text(containsString("10"));
 
-        scrollButtons.get(4).is().displayed();
-        scrollButtons.get(4).is().enabled();
+        scrollButtons.get(4).is().displayed().and().enabled();
         scrollButtons.get(4).hover();
         scrollButtons.get(4).click();
         scrollButtons.get(3).hover();
@@ -129,9 +129,9 @@ public class TableTests extends TestsInit {
         showSubTable.is().displayed();
         showSubTable.hover();
         showSubTable.click();
-        timer.wait(() -> purchaseTables.get(1).getRow(1).get(1).has().text("2020-01-05"));
+        timer.wait(() -> purchaseTables.getRow(1).get(1).has().text("11091700"));
         showSubTable.click();
-        timer.wait(() -> assertThat(purchaseTables.size(), equalTo(0)));
+        timer.wait(() -> purchaseTables.is().notVisible());
     }
 
     @Test
@@ -145,12 +145,8 @@ public class TableTests extends TestsInit {
 
     @Test
     public void virtualizedTable() {
-        getTableCell(virtualizedTable, 1, 1).hasClass("ReactVirtualized__Table__rowColumn");
+        getTableCell(virtualizedTable, 1, 1).has().cssClass("ReactVirtualized__Table__rowColumn");
         assertThat(virtualizedTable.size(), equalTo(90));
-    }
-
-    private Button getDataTableCell(int row, int coll) {
-        return dataTableCells.get((row - 1) * 6 + coll);
     }
 
     private Text getTableCell(List<Text> tableCells, int row, int col) {

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TableTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/TableTests.java
@@ -144,7 +144,7 @@ public class TableTests extends TestsInit {
     }
 
     @Test
-    public void virtualizedTable() {
+    public void virtualizedTableTest() {
         getTableCell(virtualizedTable, 1, 1).has().cssClass("ReactVirtualized__Table__rowColumn");
         assertThat(virtualizedTable.size(), equalTo(90));
     }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/BackdropTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/BackdropTests.java
@@ -1,13 +1,12 @@
 package io.github.epam.material.tests.feedback;
 
-import com.jdiai.tools.Timer;
-import io.github.epam.TestsInit;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import static io.github.com.StaticSite.backdropPage;
 import static io.github.com.pages.feedback.BackdropPage.backdrop;
 import static io.github.com.pages.feedback.BackdropPage.showBackdropButton;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * To see an example of Backdrop web element please visit
@@ -15,8 +14,6 @@ import static io.github.com.pages.feedback.BackdropPage.showBackdropButton;
  */
 
 public class BackdropTests extends TestsInit {
-
-    private static final Timer TIMER = new Timer(1000L);
 
     @BeforeMethod
     public void before() {
@@ -26,10 +23,9 @@ public class BackdropTests extends TestsInit {
 
     @Test
     public void defaultBackdropTest() {
-
         showBackdropButton.click();
-        TIMER.wait(() -> backdrop.is().visible());
+        backdrop.is().visible();
         backdrop.core().click();
-        TIMER.wait(() -> backdrop.is().hidden());
+        backdrop.is().hidden();
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
@@ -31,7 +31,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ProgressTests extends TestsInit {
-    private final Timer timer = new Timer(5000L);
+    private final Timer timer = new Timer(16000L);
 
     @BeforeMethod
     public void openPage() {
@@ -41,7 +41,7 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void circularIndeterminateTest() {
-        timer.wait(() -> circularIndeterminate.isDisplayed());
+        timer.wait(() -> circularIndeterminate.is().displayed());
         circularIndeterminate.is().indeterminate();
     }
 

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/AppBarTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/AppBarTests.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
  */
 
 public class AppBarTests extends TestsInit {
-    private final Timer timer = new Timer(2000L);
+    private final Timer timer = new Timer(16000L);
 
     @Test
     public void simpleAppBarTest() {
@@ -49,7 +49,7 @@ public class AppBarTests extends TestsInit {
         appBarMenuItems.get(1).has().text("Profile");
         appBarMenuItems.get(1).click();
         userIconSwitch.check();
-        timer.wait(() -> appBarMenu.getOverflowMenuButton().isNotDisplayed());
+        timer.wait(() -> appBarMenu.getOverflowMenuButton().is().notVisible());
 
         prominentMenu.getNavigationButton().is().displayed();
         prominentMenu.getNavigationButton().click();
@@ -84,7 +84,7 @@ public class AppBarTests extends TestsInit {
         hideAppBar.is().displayed();
         hideAppBar.getTitle().has().text("Scroll to Hide App Bar");
         scrollToBottom();
-        timer.wait(() -> hideAppBar.isHidden());
+        timer.wait(() -> hideAppBar.is().hidden());
     }
 
     @Test
@@ -105,8 +105,8 @@ public class AppBarTests extends TestsInit {
         backToTopAppBar.getTitle().has().text("Scroll to see button");
         backToTopButton.is().hidden();
         scrollToBottom();
-        timer.wait(() -> backToTopButton.isVisible());
+        timer.wait(() -> backToTopButton.is().visible());
         backToTopButton.click();
-        timer.wait(() -> backToTopButton.isHidden());
+        timer.wait(() -> backToTopButton.is().hidden());
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/CardTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/CardTests.java
@@ -20,7 +20,7 @@ import org.testng.annotations.Test;
 
 public class CardTests extends TestsInit {
 
-    private static final Timer TIMER = new Timer(100L);
+    private static final Timer TIMER = new Timer(16000L);
 
     @BeforeMethod
     public void beforeTest() {

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/utils/PopperTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/utils/PopperTests.java
@@ -1,11 +1,11 @@
 package io.github.epam.material.tests.utils;
 
-import com.epam.jdi.light.material.elements.utils.enums.Position;
-import com.jdiai.tools.Timer;
 import static io.github.com.StaticSite.popperPage;
 import static io.github.com.pages.utils.PopperPage.fakeReferenceObject;
 import static io.github.com.pages.utils.PopperPage.popper;
 import static io.github.com.pages.utils.PopperPage.popperButton;
+
+import com.epam.jdi.light.material.elements.utils.enums.Position;
 import io.github.epam.TestsInit;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
@@ -21,7 +21,6 @@ public class PopperTests extends TestsInit {
 
     @Test(dataProvider = "positionedPopperDataProvider")
     public void positionedPoppersTest(int number, String buttonText, Position position) {
-        Timer timer = new Timer(2000L);
 
         popperButton.get(number).has().text(buttonText);
         popperButton.get(number).click();
@@ -29,7 +28,7 @@ public class PopperTests extends TestsInit {
         popperButton.get(number).popper().assertThat().text("The content of the Popper.");
         popperButton.get(number).popper().assertThat().position(position);
         popperButton.get(number).click();
-        timer.wait(() -> popperButton.get(number).popper().assertThat().notVisible());
+        popperButton.get(number).popper().assertThat().notVisible();
     }
 
     @Test
@@ -41,7 +40,10 @@ public class PopperTests extends TestsInit {
     @DataProvider
     public Object[][] positionedPopperDataProvider() {
         return new Object[][]{
-                {1, "TOP", Position.TOP}, {2, "LEFT", Position.LEFT}, {3, "RIGHT", Position.RIGHT}, {4, "BOTTOM", Position.BOTTOM}
+                {1, "TOP", Position.TOP},
+                {2, "LEFT", Position.LEFT},
+                {3, "RIGHT", Position.RIGHT},
+                {4, "BOTTOM", Position.BOTTOM}
         };
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/utils/TransitionTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/utils/TransitionTests.java
@@ -1,10 +1,5 @@
 package io.github.epam.material.tests.utils;
 
-import com.jdiai.tools.Timer;
-import io.github.epam.TestsInit;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
 import static com.epam.jdi.light.material.elements.utils.enums.TransitionType.COLLAPSE;
 import static com.epam.jdi.light.material.elements.utils.enums.TransitionType.FADE;
 import static com.epam.jdi.light.material.elements.utils.enums.TransitionType.GROW;
@@ -15,6 +10,10 @@ import static io.github.com.pages.utils.TransitionPage.checkboxes;
 import static io.github.com.pages.utils.TransitionPage.collapseFadeTransitions;
 import static io.github.com.pages.utils.TransitionPage.growSlideTransitions;
 import static io.github.com.pages.utils.TransitionPage.zoomTransitions;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 /**
  * To see an example of Transitions web element please visit
@@ -31,86 +30,81 @@ public class TransitionTests extends TestsInit {
 
     @Test
     public void collapseDisplayTest() {
-        Timer timer = new Timer(2000L);
 
         collapseFadeTransitions.get(1).is().transitionExited(COLLAPSE);
         collapseFadeTransitions.get(2).is().transitionExited(COLLAPSE);
 
         checkboxes.get(1).check();
 
-        timer.wait(() -> collapseFadeTransitions.get(1).is().transitionEntered(COLLAPSE));
+        collapseFadeTransitions.get(1).is().transitionEntered(COLLAPSE);
         collapseFadeTransitions.get(2).is().transitionEntered(COLLAPSE);
 
         checkboxes.get(1).uncheck();
 
-        timer.wait(() -> collapseFadeTransitions.get(1).is().collapseTransitionHidden(COLLAPSE));
+        collapseFadeTransitions.get(1).is().collapseTransitionHidden(COLLAPSE);
         collapseFadeTransitions.get(1).is().transitionExited(COLLAPSE);
         collapseFadeTransitions.get(2).is().transitionExited(COLLAPSE);
     }
 
     @Test
     public void fadeDisplayTest() {
-        Timer timer = new Timer(2000L);
         collapseFadeTransitions.get(3).is().transitionExited(FADE);
         collapseFadeTransitions.get(4).is().transitionExited(FADE);
 
         checkboxes.get(2).check();
 
-        timer.wait(() -> collapseFadeTransitions.get(3).is().transitionEntered(FADE));
+        collapseFadeTransitions.get(3).is().transitionEntered(FADE);
         collapseFadeTransitions.get(4).is().transitionEntered(FADE);
 
         checkboxes.get(2).uncheck();
 
-        timer.wait(() -> collapseFadeTransitions.get(3).is().collapseTransitionHidden(FADE));
+        collapseFadeTransitions.get(3).is().collapseTransitionHidden(FADE);
         collapseFadeTransitions.get(3).is().transitionExited(FADE);
         collapseFadeTransitions.get(4).is().transitionExited(FADE);
     }
 
     @Test
     public void growDisplayTest() {
-        Timer timer = new Timer(2000L);
         growSlideTransitions.get(1).is().transitionExited(GROW);
         growSlideTransitions.get(2).is().transitionExited(GROW);
 
         checkboxes.get(3).check();
 
-        timer.wait(() -> growSlideTransitions.get(1).is().transitionEntered(GROW));
-        timer.wait(() -> growSlideTransitions.get(2).is().transitionEntered(GROW));
+        growSlideTransitions.get(1).is().transitionEntered(GROW);
+        growSlideTransitions.get(2).is().transitionEntered(GROW);
 
         checkboxes.get(3).uncheck();
 
-        timer.wait(() -> growSlideTransitions.get(1).is().transitionExited(GROW));
-        timer.wait(() -> growSlideTransitions.get(2).is().transitionExited(GROW));
+        growSlideTransitions.get(1).is().transitionExited(GROW);
+        growSlideTransitions.get(2).is().transitionExited(GROW);
     }
 
     @Test
     public void slideDisplayTest() {
-        Timer timer = new Timer(2000L);
         growSlideTransitions.get(3).is().transitionExited(SLIDE);
 
         checkboxes.get(4).check();
 
-        timer.wait(() -> growSlideTransitions.get(3).is().transitionEntered(SLIDE));
+        growSlideTransitions.get(3).is().transitionEntered(SLIDE);
 
         checkboxes.get(4).uncheck();
 
-        timer.wait(() -> growSlideTransitions.get(3).is().transitionExited(SLIDE));
+        growSlideTransitions.get(3).is().transitionExited(SLIDE);
     }
 
     @Test
     public void zoomDisplayTest() {
-        Timer timer = new Timer(2000L);
         zoomTransitions.get(1).is().transitionExited(ZOOM);
         zoomTransitions.get(2).is().transitionExited(ZOOM);
 
         checkboxes.get(5).check();
 
-        timer.wait(() -> zoomTransitions.get(1).is().transitionEntered(ZOOM));
-        timer.wait(() -> zoomTransitions.get(2).is().transitionEntered(ZOOM));
+        zoomTransitions.get(1).is().transitionEntered(ZOOM);
+        zoomTransitions.get(2).is().transitionEntered(ZOOM);
 
         checkboxes.get(5).uncheck();
 
-        timer.wait(() -> zoomTransitions.get(1).is().transitionExited(ZOOM));
-        timer.wait(() -> zoomTransitions.get(2).is().transitionExited(ZOOM));
+        zoomTransitions.get(1).is().transitionExited(ZOOM);
+        zoomTransitions.get(2).is().transitionExited(ZOOM);
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/utils/UseMediaQueryTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/utils/UseMediaQueryTests.java
@@ -1,15 +1,14 @@
 package io.github.epam.material.tests.utils;
 
-import com.jdiai.tools.Timer;
+import static io.github.com.StaticSite.useMediaQueryPage;
+import static io.github.com.pages.utils.UseMediaQueryPage.useMediaQueryText;
+import static org.hamcrest.Matchers.containsString;
+
 import io.github.epam.TestsInit;
 import org.openqa.selenium.Dimension;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-
-import static io.github.com.StaticSite.useMediaQueryPage;
-import static io.github.com.pages.utils.UseMediaQueryPage.useMediaQueryText;
-import static org.hamcrest.Matchers.containsString;
 
 public class UseMediaQueryTests extends TestsInit {
 
@@ -21,7 +20,7 @@ public class UseMediaQueryTests extends TestsInit {
 
     @Test
     public void useMediaQueryTestWithDifferentScreenWidth() {
-        new Timer(2000L).wait(() -> useMediaQueryText.has().value(containsString("true")));
+        useMediaQueryText.has().value(containsString("true"));
         useMediaQueryPage.driver().manage().window().setSize(new Dimension(500, 1000));
         useMediaQueryText.has().value(containsString("false"));
         useMediaQueryPage.driver().manage().window().setSize(new Dimension(700, 1000));


### PR DESCRIPTION
### Table refactoring
- `jdiAsserts` are replaced with `has().size(...)` when possible
- the type of *purchaseTables* is changed to Table
- `Timer` timeout is increased to 16 seconds
- added assert of "sizeSmall" in `denseTableTest()`
- in `virtualizedTableTest()` boolean method is replaced with the assert

### Timer refactoring:
- `UseMediaQueryTests`: timer is deleted
- `AppBarTests`: timeout is increased to 16 sec, boolean methods are replaced with asserts
- `CardTests`: timeout is increased to 16 sec
- `BackdropTests`: timer is deleted
- `ProgressTests`: timeout is increased to 16 sec, the boolean method is replaced with the assert
- `PopperTests`: timer is deleted
- `TransitionTests`: timer is deleted