### PR TITLE
3754 - Fix TreeViewTests

### DIFF
--- a/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/TreeViewTests.java
+++ b/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/TreeViewTests.java
@@ -5,6 +5,7 @@ import com.epam.jdi.light.elements.complex.WebList;
 import com.epam.jdi.light.vuetify.elements.complex.TreeView;
 import io.github.com.enums.Colors;
 import io.github.epam.TestsInit;
+import org.openqa.selenium.support.Color;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -74,9 +75,11 @@ public class TreeViewTests extends TestsInit {
         expectedBaseTreeStructure.put("/Documents :/vuetify :", asList("src :"));
         expectedBaseTreeStructure.put("/Documents :/vuetify :/src :", asList("index : ts", "bootstrap : ts"));
         expectedBaseTreeStructure.put("/Documents :/material2 :", asList("src :"));
-        expectedBaseTreeStructure.put("/Documents :/material2 :/src :", asList("v-btn : ts", "v-card : ts", "v-window : ts"));
+        expectedBaseTreeStructure.put("/Documents :/material2 :/src :",
+                asList("v-btn : ts", "v-card : ts", "v-window : ts"));
         expectedBaseTreeStructure.put("/Downloads :", asList("October : pdf", "November : pdf", "Tutorial : html"));
-        expectedBaseTreeStructure.put("/Videos :", asList("Tutorials :", "Intro : mov", "Conference introduction : avi"));
+        expectedBaseTreeStructure.put("/Videos :",
+                asList("Tutorials :", "Intro : mov", "Conference introduction : avi"));
         expectedBaseTreeStructure.put("/Videos :/Tutorials :",
                 asList("Basic layouts : mp4", "Advanced techniques : mp4", "All about app : dir"));
 
@@ -109,7 +112,6 @@ public class TreeViewTests extends TestsInit {
 
     @Test
     public void colorTreeViewTest() {
-        colorTreeView.has().structure(expectedBaseTreeStructure);
         colorTreeView.walk(treeView -> {
             if (!treeView.isLeaf() && !treeView.isPseudoCore()) {
                 TreeView child = treeView.first();
@@ -232,7 +234,8 @@ public class TreeViewTests extends TestsInit {
                 checkedTree.is().notMarked();
                 checkedTree.check();
                 checkedTree.is().fullyMarked();
-                checkedTree.checkbox().has().css("color", color.value());
+                assertThat(Color.fromString(checkedTree.checkbox().css("caret-color")).asRgba(),
+                        is(color.value()));
                 checkedTree.uncheck();
                 checkedTree.is().notMarked();
             }
@@ -341,6 +344,7 @@ public class TreeViewTests extends TestsInit {
                 treeView.is().notMarked();
                 treeView.check();
                 List<String> checked = new ArrayList<>();
+                chips.hover();
                 treeView.walk(childTree -> {
                     childTree.is().fullyMarked();
                     if (childTree.isLeaf()) {

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/TreeView.java
@@ -186,18 +186,23 @@ public class TreeView extends Dropdown
         return list().size();
     }
 
+    @JDIAction("Get check list from '{name}'")
+    public WebList checkList() {
+        if (isPseudoCore()) {
+            return core().finds(nodesInCoreLocator);
+        } else {
+            return new WebList();
+        }
+    }
+
     @Override
     @JDIAction("Get list from '{name}'")
     public WebList list() {
-        WebList result = core().finds(nodesInNodeLocator);
-        if (isPseudoCore()) {
-            result = core().finds(nodesInCoreLocator);
-        }
-        if (isLeaf()) {
-            result = new WebList();
+        if (isPseudoCore() | isLeaf()) {
+            return checkList();
         }
         expand();
-        return result;
+        return core().finds(nodesInNodeLocator);
     }
 
     @JDIAction("Get list of nodes from '{name}'")


### PR DESCRIPTION
TreeViewTests were fixed/updated:
- list() method in TreeView was corrected. Cause its incorrect functioning broke test run (it started to function incorrectly after last changes to satisfy Codacy criteria - see task 3705).
- Color check in selectableTreeViewTest was corrected to improve test stability.
- hover() method was added in selectableIconsTreeViewTest to improve test stability.
- One check was excluded from colorTreeViewTest cause the same check of the same structure is present in other tests (and it takes lots of time). It was done to save time. 