### PR TITLE
3816 - Fix LazyTests

### DIFF
--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/LazyPage.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/LazyPage.java
@@ -9,6 +9,9 @@ public class LazyPage extends VuetifyPage {
     @UI(".v-lazy")
     public static Lazy lazy;
 
+    @UI("div.mx-auto.v-card.v-sheet.theme--light")
+    public static Lazy lazyContent;
+
     public static final String ITEM_TITLE = ".v-card__title";
 
     public static final String ITEM_TEXT = ".v-card__text";

--- a/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/LazyTests.java
+++ b/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/LazyTests.java
@@ -10,6 +10,7 @@ import static io.github.com.StaticSite.lazyPage;
 import static io.github.com.pages.LazyPage.ITEM_TEXT;
 import static io.github.com.pages.LazyPage.ITEM_TITLE;
 import static io.github.com.pages.LazyPage.lazy;
+import static io.github.com.pages.LazyPage.lazyContent;
 
 
 public class LazyTests extends TestsInit {
@@ -23,8 +24,7 @@ public class LazyTests extends TestsInit {
 
     @Test
     public void itemIsHiddenTest() {
-        waitCondition(() -> lazy.isExist());
-        lazy.is().notVisible();
+        lazyContent.is().hidden();
     }
 
     @Test


### PR DESCRIPTION
LazyTests: itemIsHiddenTest was fixed:
- Additional element locator was implemented to improve test stability (lazyContent).
- itemIsHiddenTest was refactored (now it is similar to first version of this test).