### PR TITLE
Item Groups are implemented

### DIFF
--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/itemGroups/PrimaryItemGroup.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/itemGroups/PrimaryItemGroup.java
@@ -1,0 +1,13 @@
+package io.github.com.custom.itemGroups;
+
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.vuetify.elements.complex.ItemGroup;
+
+public class PrimaryItemGroup extends ItemGroup {
+
+    @Override
+    @JDIAction("Is item '{0}' selected in {name}")
+    public boolean selected(int index) {
+        return get(index).hasClass("primary");
+    }
+}

--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/itemGroups/SelectionItemGroup.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/itemGroups/SelectionItemGroup.java
@@ -10,18 +10,4 @@ public class SelectionItemGroup extends ItemGroup {
     public Icon itemIcon(int index) {
         return new Icon().setCore(Icon.class, get(index).find(".v-icon"));
     }
-
-    @JDIAction("Check item {0} in {name}")
-    public void check(int index) {
-        if (notSelected(index)) {
-            select(index);
-        }
-    }
-
-    @JDIAction("Uncheck item {0} in {name}")
-    public void uncheck(int index) {
-        if (selected(index)) {
-            select(index);
-        }
-    }
 }

--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/itemGroups/SelectionItemGroup.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/custom/itemGroups/SelectionItemGroup.java
@@ -1,0 +1,27 @@
+package io.github.com.custom.itemGroups;
+
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.vuetify.elements.common.Icon;
+import com.epam.jdi.light.vuetify.elements.complex.ItemGroup;
+
+public class SelectionItemGroup extends ItemGroup {
+
+    @JDIAction("Get icon of item {0} in {name}")
+    public Icon itemIcon(int index) {
+        return new Icon().setCore(Icon.class, get(index).find(".v-icon"));
+    }
+
+    @JDIAction("Check item {0} in {name}")
+    public void check(int index) {
+        if (notSelected(index)) {
+            select(index);
+        }
+    }
+
+    @JDIAction("Uncheck item {0} in {name}")
+    public void uncheck(int index) {
+        if (selected(index)) {
+            select(index);
+        }
+    }
+}

--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ItemGroupsPage.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ItemGroupsPage.java
@@ -1,5 +1,18 @@
 package io.github.com.pages;
 
+import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
+import com.epam.jdi.light.vuetify.elements.complex.ItemGroup;
+import io.github.com.custom.itemGroups.PrimaryItemGroup;
+import io.github.com.custom.itemGroups.SelectionItemGroup;
+
 public class ItemGroupsPage extends VuetifyPage {
 
+    @UI("#ActiveClassItemGroup .v-card")
+    public static PrimaryItemGroup activeClassItemGroup;
+
+    @UI("#MandatoryItemGroup .v-card")
+    public static ItemGroup mandatoryItemGroup;
+
+    @UI("#SelectionItemGroup .v-image")
+    public static SelectionItemGroup selectionItemGroup;
 }

--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ItemGroupsPage.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/pages/ItemGroupsPage.java
@@ -1,7 +1,10 @@
 package io.github.com.pages;
 
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
+import com.epam.jdi.light.vuetify.elements.common.VuetifyButton;
 import com.epam.jdi.light.vuetify.elements.complex.ItemGroup;
+import com.epam.jdi.light.vuetify.elements.complex.TextArea;
+import com.epam.jdi.light.vuetify.elements.complex.TextField;
 import io.github.com.custom.itemGroups.PrimaryItemGroup;
 import io.github.com.custom.itemGroups.SelectionItemGroup;
 
@@ -12,6 +15,21 @@ public class ItemGroupsPage extends VuetifyPage {
 
     @UI("#MandatoryItemGroup .v-card")
     public static ItemGroup mandatoryItemGroup;
+
+    @UI("#MultipleItemGroup .v-card")
+    public static ItemGroup multipleItemGroup;
+
+    @UI("#ChipsItemGroup .v-text-field")
+    public static TextField textField;
+
+    @UI("#ChipsItemGroup .v-textarea")
+    public static TextArea textArea;
+
+    @UI("#ChipsItemGroup .v-chip")
+    public static ItemGroup chipsItemGroup;
+
+    @UI("#ChipsItemGroup button")
+    public static VuetifyButton button;
 
     @UI("#SelectionItemGroup .v-image")
     public static SelectionItemGroup selectionItemGroup;

--- a/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ItemGroupsTests.java
+++ b/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ItemGroupsTests.java
@@ -43,11 +43,11 @@ public class ItemGroupsTests extends TestsInit {
 
     @Test
     public void selectionItemGroupTest() {
+        selectionItemGroup.has().notSelected(1).and().notSelected(2);
         selectionItemGroup.itemIcon(1).has().type("mdi-heart-outline");
-        selectionItemGroup.check(1);
+        selectionItemGroup.list().check(1);
         selectionItemGroup.itemIcon(1).has().type("mdi-heart");
 
-        selectionItemGroup.uncheck(2);
         selectionItemGroup.itemIcon(2).has().type("mdi-heart-outline");
         selectionItemGroup.itemIcon(2).click();
         selectionItemGroup.itemIcon(2).has().type("mdi-heart");

--- a/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ItemGroupsTests.java
+++ b/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ItemGroupsTests.java
@@ -1,0 +1,57 @@
+package io.github.epam.vuetify.tests.complex;
+
+import static com.jdiai.tools.Timer.waitCondition;
+import static io.github.com.StaticSite.itemGroupsPage;
+import static io.github.com.pages.ItemGroupsPage.activeClassItemGroup;
+import static io.github.com.pages.ItemGroupsPage.mandatoryItemGroup;
+import static io.github.com.pages.ItemGroupsPage.selectionItemGroup;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class ItemGroupsTests extends TestsInit {
+
+    @BeforeClass
+    public static void setup() {
+        itemGroupsPage.open();
+        waitCondition(() -> itemGroupsPage.isOpened());
+        itemGroupsPage.checkOpened();
+
+    }
+
+    @Test
+    public void singleItemGroupTest() {
+        activeClassItemGroup.select(1);
+        activeClassItemGroup.has().selected(1);
+
+        activeClassItemGroup.select(2);
+        activeClassItemGroup.has().selected(2).and().notSelected(1);
+
+        activeClassItemGroup.select(2);
+        activeClassItemGroup.has().notSelected(2);
+    }
+
+    @Test
+    public void mandatoryItemGroupTest() {
+        mandatoryItemGroup.select(1);
+        mandatoryItemGroup.has().selected(1);
+
+        mandatoryItemGroup.select(1);
+        mandatoryItemGroup.has().selected(1);
+    }
+
+    @Test
+    public void selectionItemGroupTest() {
+        selectionItemGroup.itemIcon(1).has().type("mdi-heart-outline");
+        selectionItemGroup.check(1);
+        selectionItemGroup.itemIcon(1).has().type("mdi-heart");
+
+        selectionItemGroup.uncheck(2);
+        selectionItemGroup.itemIcon(2).has().type("mdi-heart-outline");
+        selectionItemGroup.itemIcon(2).click();
+        selectionItemGroup.itemIcon(2).has().type("mdi-heart");
+
+        selectionItemGroup.has().selected(1).and().selected(2);
+    }
+}

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/asserts/ItemGroupAssert.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/asserts/ItemGroupAssert.java
@@ -1,0 +1,26 @@
+package com.epam.jdi.light.vuetify.asserts;
+
+import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
+
+import com.epam.jdi.light.asserts.generic.UISelectAssert;
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.vuetify.elements.complex.ItemGroup;
+import org.hamcrest.Matchers;
+
+public class ItemGroupAssert extends UISelectAssert<ItemGroupAssert, ItemGroup> {
+
+    @Override
+    @JDIAction("Assert that {0} item is selected in {name}")
+    public ItemGroupAssert selected(int index) {
+        jdiAssert(element().selected(index) ? "is selected" : "is not selected",
+                Matchers.is("is selected"));
+        return this;
+    }
+
+    @JDIAction("Assert that {0} item is not selected in {name}")
+    public ItemGroupAssert notSelected(int index) {
+        jdiAssert(element().selected(index) ? "is selected" : "is not selected",
+                Matchers.is("is not selected"));
+        return this;
+    }
+}

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/asserts/ItemGroupAssert.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/asserts/ItemGroupAssert.java
@@ -19,7 +19,7 @@ public class ItemGroupAssert extends UISelectAssert<ItemGroupAssert, ItemGroup> 
 
     @JDIAction("Assert that {0} item is not selected in {name}")
     public ItemGroupAssert notSelected(int index) {
-        jdiAssert(element().selected(index) ? "is selected" : "is not selected",
+        jdiAssert(element().notSelected(index) ? "is not selected" : "is selected",
                 Matchers.is("is not selected"));
         return this;
     }

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/ItemGroup.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/ItemGroup.java
@@ -1,0 +1,24 @@
+package com.epam.jdi.light.vuetify.elements.complex;
+
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.elements.base.UIListBase;
+import com.epam.jdi.light.vuetify.asserts.ItemGroupAssert;
+
+public class ItemGroup extends UIListBase<ItemGroupAssert> {
+
+    @Override
+    @JDIAction("Is item '{0}' selected in {name}")
+    public boolean selected(int index) {
+        return get(index).hasClass("v-item--active");
+    }
+
+    @JDIAction("Is item '{0}' not selected in {name}")
+    public boolean notSelected(int index) {
+        return !selected(index);
+    }
+
+    @Override
+    public ItemGroupAssert is() {
+        return new ItemGroupAssert().set(this);
+    }
+}


### PR DESCRIPTION
[Item Groups Documentation](https://vuetifyjs.com/en/components/item-groups/)
- created class `ItemGroup`
  - `ItemGroup` extends `UIListBase` and has two boolean methods: `selected(index)`, `notSelected(index)` - and method `is()` that returns `ItemGroupAssert`
- `ItemGroupAssert` has two checks: `selected(index)`, `notSelected(index)`
- Three ItemGroup elements are tested: `ItemGroup` and his subclasses - `PrimaryItemGroup` and `SelectionItemGroup`
  - `PrimaryItemGroup` overrides method `selected(index)` checking class "primary"
  - `SelectionItemGroup` has three additional methods: 
    - `itemIcon(index)` returns icon of specified item
    - `check(index)` checks specified item
    - `uncheck(index)` unchecks specified item