### PR TITLE
3807 - Fix ColorPickerTests

### DIFF
--- a/jdi-light-vuetify-tests/src/main/java/io/github/com/dataproviders/ColorPickersDataProviders.java
+++ b/jdi-light-vuetify-tests/src/main/java/io/github/com/dataproviders/ColorPickersDataProviders.java
@@ -3,17 +3,14 @@ package io.github.com.dataproviders;
 import io.github.com.enums.Colors;
 import org.testng.annotations.DataProvider;
 
-import static com.epam.jdi.light.vuetify.elements.complex.ColorPicker.INITIAL_RGBA_STRING_COLOR;
-
 public class ColorPickersDataProviders {
 
     @DataProvider
     public static Object[][] colorsDataProvider() {
         return new Object[][]{
-                {INITIAL_RGBA_STRING_COLOR, Colors.RED_ACCENT_1.value(), Colors.TRANSPARENT.value()},
-                {INITIAL_RGBA_STRING_COLOR, Colors.GREEN_LIGHTEN_3.value(), Colors.BLACK_TRANSPARENT_087.value()},
-                {INITIAL_RGBA_STRING_COLOR, Colors.BLUE_GREY.value(), Colors.BLACK_TRANSPARENT_02.value()}
+                {Colors.RED_ACCENT_1.value(), Colors.TRANSPARENT.value()},
+                {Colors.GREEN_LIGHTEN_3.value(), Colors.BLACK_TRANSPARENT_087.value()},
+                {Colors.BLUE_GREY.value(), Colors.BLACK_TRANSPARENT_02.value()}
         };
     }
-
 }

--- a/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ColorPickerTests.java
+++ b/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/ColorPickerTests.java
@@ -49,17 +49,15 @@ public class ColorPickerTests extends TestsInit {
     }
 
     @Test(dataProviderClass = ColorPickersDataProviders.class, dataProvider = "colorsDataProvider")
-    public void fullCanvasColorPickerTest(String initialRGBAStringColor,
-                                          String stringColorValue,
-                                          String stringTransparentColorValue) {
-        fullCanvasColorPicker.has().color(initialRGBAStringColor);
+    public void fullCanvasColorPickerTest(String colorValue,
+                                          String transparentColorValue) {
         String initialHueSliderStyle = fullCanvasColorPicker.hueSlider().getValue();
         String initialAlphaSliderStyle = fullCanvasColorPicker.alphaSlider().getValue();
-        fullCanvasColorPicker.setColor(stringColorValue);
-        fullCanvasColorPicker.has().color(stringColorValue);
+        fullCanvasColorPicker.setColor(colorValue);
+        fullCanvasColorPicker.has().color(colorValue);
         fullCanvasColorPicker.assertThat().hueSliderValueHaveChanged(initialHueSliderStyle);
-        fullCanvasColorPicker.setColor(stringTransparentColorValue);
-        fullCanvasColorPicker.has().color(stringTransparentColorValue);
+        fullCanvasColorPicker.setColor(transparentColorValue);
+        fullCanvasColorPicker.has().color(transparentColorValue);
         fullCanvasColorPicker.assertThat().alphaSliderValueHaveChanged(initialAlphaSliderStyle);
     }
 
@@ -172,5 +170,4 @@ public class ColorPickerTests extends TestsInit {
             bigSwatchesColorPicker.has().color(color.asRgba());
         }
     }
-
 }


### PR DESCRIPTION
Two ways to change fullCanvasColorPickerTest were considered:
1. Change DataProvider to use correct color for initial check (first member of each 1D-array). Cause firstly this member was correct only for the first run with DataProvider, while for other two runs is was incorrect. But in this case we have unnecessary double check of the same color result in fullCanvasColorPickerTest.
2. Exclude fullCanvasColorPicker.has().color(initialRGBAStringColor) check from the test. Because it is not too important which color is present before any color changes are done. It is also recommended to cut DataProvider to exclude first member of each 1D-array as unused.

Variant #2 was chosen to save test time.

Other correction: parameter names (stringColorValue and stringTransparentColorValue) in fullCanvasColorPickerTest were optimized.