### PR TITLE
3841 - Progress refactoring

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/ProgressPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/ProgressPage.java
@@ -39,7 +39,7 @@ public class ProgressPage extends WebPage {
     @UI(".MuiButton-containedPrimary")
     public static Button acceptTermsButton;
 
-    @JProgress(root = "//button[@aria-label='save']/following-sibling::div")
+    @JProgress(root = "//button[contains(@class, 'MuiButton-containedPrimary')]/following-sibling::div")
     public static CircularProgress acceptTermsCircularProgress;
 
     @JProgress(root = "(//h2[text()='Circular with label']/following::div[@role='progressbar'])[1]",

--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/ProgressPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/ProgressPage.java
@@ -10,68 +10,74 @@ import com.epam.jdi.light.ui.html.elements.common.Text;
 
 public class ProgressPage extends WebPage {
     @JProgress(root = "#circularIndeterminateProgress")
-    public static CircularProgress circularIndeterminate;
+    public static CircularProgress circularProgressIndeterminate;
 
     @JProgress(root = "(//div[@aria-valuenow='25'])[1]")
-    public static CircularProgress circularDeterminateWithValue25;
+    public static CircularProgress circularProgressDeterminateWithValue25;
 
     @JProgress(root = "(//div[@aria-valuenow='50'])[1]")
-    public static CircularProgress circularDeterminateWithValue50;
+    public static CircularProgress circularProgressDeterminateWithValue50;
 
     @JProgress(root = "(//div[@aria-valuenow='75'])[1]")
-    public static CircularProgress circularDeterminateWithValue75;
+    public static CircularProgress circularProgressDeterminateWithValue75;
 
     @JProgress(root = "(//div[@aria-valuenow='100'])[1]")
-    public static CircularProgress circularDeterminateWithValue100;
+    public static CircularProgress circularProgressDeterminateWithValue100;
 
     @JProgress(root = "(//div[@aria-valuenow='100']/following-sibling::div)[1]")
-    public static CircularProgress circularDeterminateProgress;
+    public static CircularProgress circularProgressDeterminate;
 
     @JProgress(root = "(//h2[text()='Circular determinate']/following::div[@role='progressbar'])[6]")
-    public static CircularProgress circularDeterminateIndeterminateProgress;
+    public static CircularProgress circularProgressDeterminateIndeterminate;
 
     @UI("//button[@aria-label='save']")
-    public static Button interactiveIntegrationCircularButton;
+    public static Button saveButton;
 
     @JProgress(root = "//button[@aria-label='save']/following-sibling::div")
-    public static CircularProgress interactiveIntegrationCircularIndeterminate;
+    public static CircularProgress saveCircularProgress;
+
+    @UI(".MuiButton-containedPrimary")
+    public static Button acceptTermsButton;
+
+    @JProgress(root = "//button[@aria-label='save']/following-sibling::div")
+    public static CircularProgress acceptTermsCircularProgress;
 
     @JProgress(root = "(//h2[text()='Circular with label']/following::div[@role='progressbar'])[1]",
             label = "div.MuiTypography-caption")
-    public static CircularProgress circularDeterminateProgressWithLabel;
+    public static CircularProgress circularProgressWithLabel;
 
     @JProgress(root = "(//h2[text()='Linear indeterminate']/following::div)[2]",
             bar1 = ".MuiLinearProgress-bar1Indeterminate",
             bar2 = ".MuiLinearProgress-bar2Indeterminate")
-    public static LinearProgress linearIndeterminate;
+    public static LinearProgress linearProgressIndeterminate;
 
     @JProgress(root = "(//h2[text()='Linear determinate']/following::div)[2]")
-    public static LinearProgress linearDeterminate;
+    public static LinearProgress linearProgressDeterminate;
 
     @JProgress(root = "(//h2[text()='Linear buffer']/following::div)[2]")
-    public static LinearProgress linearBuffer;
+    public static LinearProgress linearProgressBuffer;
 
     @JProgress(root = "//h2[text()='Linear with label']/following::*[contains(@class, 'MuiLinearProgress-root')]",
             label = "p.MuiTypography-root")
-    public static LinearProgress linearWithLabel;
+    public static LinearProgress linearProgressWithLabel;
 
     @JProgress(root = "(//h2[text()='Customized progress']/following::div[@role='progressbar'])[2]")
-    public static CircularProgress circularIndeterminateCustomized;
+    public static CircularProgress customizedCircularProgress;
 
     @JProgress(root = "(//h2[text()='Customized progress']/following::div[@role='progressbar'])[3]")
-    public static LinearProgress linearDeterminateCustomized;
+    public static LinearProgress customizedLinearProgress;
 
     @UI("//*[text()='Loading']/..")
     public static Button startLoadingButton;
 
     @JProgress(root = "//*[text()='Stop loading']/../../div/div")
-    public static CircularProgress loadingCircularIndeterminate;
+    public static CircularProgress loadingCircularProgress;
 
     @UI("//*[text()='Simulate a load']")
     public static Button simulateLoadButton;
 
     @JProgress(root = "//*[text()='Reset']/../preceding-sibling::div[1]/div")
-    public static CircularProgress simulateLoadCircularIndeterminate;
+    public static CircularProgress simulateLoadCircularProgress;
 
     @UI("//p[text()='Success!']")
     public static Text successMessage;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
@@ -1,6 +1,8 @@
 package io.github.epam.material.tests.feedback;
 
 import static io.github.com.StaticSite.progressPage;
+import static io.github.com.pages.feedback.ProgressPage.acceptTermsButton;
+import static io.github.com.pages.feedback.ProgressPage.acceptTermsCircularProgress;
 import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminate;
 import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminateIndeterminate;
 import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminateWithValue100;
@@ -72,6 +74,10 @@ public class ProgressTests extends TestsInit {
         saveButton.click();
         saveCircularProgress.is().indeterminate();
         timer.wait(() -> saveCircularProgress.is().hidden());
+
+        acceptTermsButton.click();
+        acceptTermsCircularProgress.is().indeterminate();
+        timer.wait(() -> acceptTermsCircularProgress.is().hidden());
     }
 
     @Test

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
@@ -44,11 +44,13 @@ public class ProgressTests extends TestsInit {
     @Test
     public void circularIndeterminateTest() {
         timer.wait(() -> circularProgressIndeterminate.is().displayed());
+        circularProgressIndeterminate.core().show();
         circularProgressIndeterminate.is().indeterminate();
     }
 
     @Test
     public void circularDeterminateTest() {
+        circularProgressDeterminateWithValue25.core().show();
         circularProgressDeterminateWithValue25.is().displayed().and().determinate()
             .and().has().value(25).and().primaryColor();
         circularProgressDeterminateWithValue50.is().displayed().and().determinate()
@@ -71,6 +73,7 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void interactiveIntegrationTest() {
+        saveButton.core().show();
         saveButton.click();
         saveCircularProgress.is().indeterminate();
         timer.wait(() -> saveCircularProgress.is().hidden());
@@ -91,6 +94,7 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void linearIndeterminateTest() {
+        linearProgressIndeterminate.core().show();
         linearProgressIndeterminate.is().displayed().and().indeterminate();
         linearProgressIndeterminate.has().firstBarColor(Colors.PRIMARY.rgba());
 
@@ -102,6 +106,7 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void linearDeterminateTest() {
+        linearProgressDeterminate.core().show();
         linearProgressDeterminate.is().displayed().and().determinate();
 
         linearProgressDeterminate.has().min(0).and().max(100);
@@ -114,6 +119,7 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void linearBufferTest() {
+        linearProgressBuffer.core().show();
         linearProgressBuffer.is().displayed().and().determinate().and().buffer();
 
         linearProgressBuffer.has().min(0).and().max(100);
@@ -123,6 +129,7 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void linearWithLabelTest() {
+        linearProgressWithLabel.core().show();
         linearProgressWithLabel.is().determinate().and().has().firstBarColor(Colors.PRIMARY.rgba());
 
         linearProgressWithLabel.has().min(0).and().max(100);
@@ -138,6 +145,7 @@ public class ProgressTests extends TestsInit {
     @Test
     public void customizedProgressTest() {
         String lightBlueColor = "rgba(26, 144, 255, 1)";
+        customizedCircularProgress.core().show();
         customizedCircularProgress.isDisplayed();
         customizedCircularProgress.has().color(lightBlueColor);
 
@@ -147,8 +155,11 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void delayingAppearanceTest() {
+        startLoadingButton.core().show();
         startLoadingButton.click();
         loadingCircularProgress.is().indeterminate();
+
+        simulateLoadButton.core().show();
         simulateLoadButton.click();
         simulateLoadCircularProgress.is().indeterminate();
         timer.wait(() -> successMessage.is().displayed());

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/ProgressTests.java
@@ -1,25 +1,25 @@
 package io.github.epam.material.tests.feedback;
 
 import static io.github.com.StaticSite.progressPage;
-import static io.github.com.pages.feedback.ProgressPage.circularDeterminateIndeterminateProgress;
-import static io.github.com.pages.feedback.ProgressPage.circularDeterminateProgress;
-import static io.github.com.pages.feedback.ProgressPage.circularDeterminateProgressWithLabel;
-import static io.github.com.pages.feedback.ProgressPage.circularDeterminateWithValue100;
-import static io.github.com.pages.feedback.ProgressPage.circularDeterminateWithValue25;
-import static io.github.com.pages.feedback.ProgressPage.circularDeterminateWithValue50;
-import static io.github.com.pages.feedback.ProgressPage.circularDeterminateWithValue75;
-import static io.github.com.pages.feedback.ProgressPage.circularIndeterminate;
-import static io.github.com.pages.feedback.ProgressPage.circularIndeterminateCustomized;
-import static io.github.com.pages.feedback.ProgressPage.interactiveIntegrationCircularButton;
-import static io.github.com.pages.feedback.ProgressPage.interactiveIntegrationCircularIndeterminate;
-import static io.github.com.pages.feedback.ProgressPage.linearBuffer;
-import static io.github.com.pages.feedback.ProgressPage.linearDeterminate;
-import static io.github.com.pages.feedback.ProgressPage.linearDeterminateCustomized;
-import static io.github.com.pages.feedback.ProgressPage.linearIndeterminate;
-import static io.github.com.pages.feedback.ProgressPage.linearWithLabel;
-import static io.github.com.pages.feedback.ProgressPage.loadingCircularIndeterminate;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminate;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminateIndeterminate;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminateWithValue100;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminateWithValue25;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminateWithValue50;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressDeterminateWithValue75;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressIndeterminate;
+import static io.github.com.pages.feedback.ProgressPage.circularProgressWithLabel;
+import static io.github.com.pages.feedback.ProgressPage.customizedCircularProgress;
+import static io.github.com.pages.feedback.ProgressPage.customizedLinearProgress;
+import static io.github.com.pages.feedback.ProgressPage.linearProgressBuffer;
+import static io.github.com.pages.feedback.ProgressPage.linearProgressDeterminate;
+import static io.github.com.pages.feedback.ProgressPage.linearProgressIndeterminate;
+import static io.github.com.pages.feedback.ProgressPage.linearProgressWithLabel;
+import static io.github.com.pages.feedback.ProgressPage.loadingCircularProgress;
+import static io.github.com.pages.feedback.ProgressPage.saveButton;
+import static io.github.com.pages.feedback.ProgressPage.saveCircularProgress;
 import static io.github.com.pages.feedback.ProgressPage.simulateLoadButton;
-import static io.github.com.pages.feedback.ProgressPage.simulateLoadCircularIndeterminate;
+import static io.github.com.pages.feedback.ProgressPage.simulateLoadCircularProgress;
 import static io.github.com.pages.feedback.ProgressPage.startLoadingButton;
 import static io.github.com.pages.feedback.ProgressPage.successMessage;
 
@@ -41,111 +41,110 @@ public class ProgressTests extends TestsInit {
 
     @Test
     public void circularIndeterminateTest() {
-        timer.wait(() -> circularIndeterminate.is().displayed());
-        circularIndeterminate.is().indeterminate();
+        timer.wait(() -> circularProgressIndeterminate.is().displayed());
+        circularProgressIndeterminate.is().indeterminate();
     }
 
     @Test
     public void circularDeterminateTest() {
-        circularDeterminateWithValue25.is().displayed().and().determinate()
-                .and().has().value(25).and().primaryColor();
-        circularDeterminateWithValue50.is().displayed().and().determinate()
-                .and().has().value(50).and().primaryColor();
-        circularDeterminateWithValue75.is().displayed().and().determinate()
-                .and().has().value(75).and().primaryColor();
-        circularDeterminateWithValue100.is().displayed().and().determinate()
-                .and().has().value(100).and().primaryColor();
+        circularProgressDeterminateWithValue25.is().displayed().and().determinate()
+            .and().has().value(25).and().primaryColor();
+        circularProgressDeterminateWithValue50.is().displayed().and().determinate()
+            .and().has().value(50).and().primaryColor();
+        circularProgressDeterminateWithValue75.is().displayed().and().determinate()
+            .and().has().value(75).and().primaryColor();
+        circularProgressDeterminateWithValue100.is().displayed().and().determinate()
+            .and().has().value(100).and().primaryColor();
 
-        circularDeterminateProgress.is().displayed().and().determinate()
-                .and().has().primaryColor();
-        int valueNow = circularDeterminateProgress.getValueNow();
-        timer.wait(() -> circularDeterminateProgress.has().value(valueNow + 10));
+        circularProgressDeterminate.is().displayed().and().determinate()
+            .and().has().primaryColor();
+        int valueNow = circularProgressDeterminate.getValueNow();
+        timer.wait(() -> circularProgressDeterminate.has().value(valueNow + 10));
 
-        circularDeterminateIndeterminateProgress.is().displayed().and().indeterminate()
-                .and().has().primaryColor();
-        circularDeterminateIndeterminateProgress.circle()
-                .has().cssClass("MuiCircularProgress-circleDisableShrink");
+        circularProgressDeterminateIndeterminate.is().displayed().and().indeterminate()
+            .and().has().primaryColor();
+        circularProgressDeterminateIndeterminate.circle()
+            .has().cssClass("MuiCircularProgress-circleDisableShrink");
     }
 
     @Test
     public void interactiveIntegrationTest() {
-        interactiveIntegrationCircularButton.click();
-        interactiveIntegrationCircularIndeterminate.is().indeterminate();
-        timer.wait(() -> interactiveIntegrationCircularIndeterminate.is().hidden());
-        // TODO: Add check for Accept terms button
+        saveButton.click();
+        saveCircularProgress.is().indeterminate();
+        timer.wait(() -> saveCircularProgress.is().hidden());
     }
 
     @Test
     public void circularWithLabelTest() {
-        circularDeterminateProgressWithLabel.show();
-        circularDeterminateProgressWithLabel.is().displayed().and().determinate();
-        circularDeterminateProgressWithLabel.label().is().displayed();
-        timer.wait(() -> circularDeterminateProgressWithLabel.label().has().text("60%"));
-        timer.wait(() -> circularDeterminateProgressWithLabel.has().value(60));
+        circularProgressWithLabel.show();
+        circularProgressWithLabel.is().displayed().and().determinate();
+        circularProgressWithLabel.label().is().displayed();
+        timer.wait(() -> circularProgressWithLabel.label().has().text("60%"));
+        timer.wait(() -> circularProgressWithLabel.has().value(60));
     }
 
     @Test
     public void linearIndeterminateTest() {
-        linearIndeterminate.is().displayed().and().indeterminate();
-        linearIndeterminate.has().firstBarColor(Colors.PRIMARY.rgba());
+        linearProgressIndeterminate.is().displayed().and().indeterminate();
+        linearProgressIndeterminate.has().firstBarColor(Colors.PRIMARY.rgba());
 
-        linearIndeterminate.bar1().is().displayed();
-        linearIndeterminate.bar2().is().displayed();
-        linearIndeterminate.has().firstBarColor(Colors.PRIMARY.rgba())
-                .and().secondBarColor(Colors.PRIMARY.rgba());
+        linearProgressIndeterminate.bar1().is().displayed();
+        linearProgressIndeterminate.bar2().is().displayed();
+        linearProgressIndeterminate.has().firstBarColor(Colors.PRIMARY.rgba())
+            .and().secondBarColor(Colors.PRIMARY.rgba());
     }
 
     @Test
     public void linearDeterminateTest() {
-        linearDeterminate.is().displayed().and().determinate();
+        linearProgressDeterminate.is().displayed().and().determinate();
 
-        linearDeterminate.has().min(0).and().max(100);
-        timer.wait(() -> linearDeterminate.has().value(Matchers.greaterThanOrEqualTo(5)));
-        timer.wait(() -> linearDeterminate.has().value(Matchers.greaterThanOrEqualTo(10)));
+        linearProgressDeterminate.has().min(0).and().max(100);
+        timer.wait(() -> linearProgressDeterminate.has().value(Matchers.greaterThanOrEqualTo(5)));
+        timer.wait(() -> linearProgressDeterminate.has().value(Matchers.greaterThanOrEqualTo(10)));
 
-        linearDeterminate.bar1().is().displayed();
-        linearDeterminate.has().firstBarColor(Colors.PRIMARY.rgba());
+        linearProgressDeterminate.bar1().is().displayed();
+        linearProgressDeterminate.has().firstBarColor(Colors.PRIMARY.rgba());
     }
 
     @Test
     public void linearBufferTest() {
-        linearBuffer.is().displayed().and().determinate().and().buffer();
+        linearProgressBuffer.is().displayed().and().determinate().and().buffer();
 
-        linearBuffer.has().min(0).and().max(100);
-        timer.wait(() -> linearBuffer.has().value(Matchers.greaterThanOrEqualTo(5)));
-        timer.wait(() -> linearBuffer.has().value(Matchers.greaterThanOrEqualTo(10)));
+        linearProgressBuffer.has().min(0).and().max(100);
+        timer.wait(() -> linearProgressBuffer.has().value(Matchers.greaterThanOrEqualTo(5)));
+        timer.wait(() -> linearProgressBuffer.has().value(Matchers.greaterThanOrEqualTo(10)));
     }
 
     @Test
     public void linearWithLabelTest() {
-        linearWithLabel.is().determinate().and().has().firstBarColor(Colors.PRIMARY.rgba());
+        linearProgressWithLabel.is().determinate().and().has().firstBarColor(Colors.PRIMARY.rgba());
 
-        linearWithLabel.has().min(0).and().max(100);
-        int valueNow = linearWithLabel.getValueNow();
-        linearWithLabel.label().has().text(valueNow + "%");
+        linearProgressWithLabel.has().min(0).and().max(100);
+        int valueNow = linearProgressWithLabel.getValueNow();
+        linearProgressWithLabel.label().has().text(valueNow + "%");
 
         int finalValueNow = valueNow;
-        timer.wait(() -> linearWithLabel.is().value(Matchers.greaterThan(finalValueNow + 10)));
-        valueNow = linearWithLabel.getValueNow();
-        linearWithLabel.label().has().text(valueNow + "%");
+        timer.wait(() -> linearProgressWithLabel.is().value(Matchers.greaterThan(finalValueNow + 10)));
+        valueNow = linearProgressWithLabel.getValueNow();
+        linearProgressWithLabel.label().has().text(valueNow + "%");
     }
 
     @Test
     public void customizedProgressTest() {
         String lightBlueColor = "rgba(26, 144, 255, 1)";
-        circularIndeterminateCustomized.isDisplayed();
-        circularIndeterminateCustomized.has().color(lightBlueColor);
+        customizedCircularProgress.isDisplayed();
+        customizedCircularProgress.has().color(lightBlueColor);
 
-        linearDeterminateCustomized.isDisplayed();
-        linearDeterminateCustomized.has().firstBarColor(lightBlueColor);
+        customizedLinearProgress.isDisplayed();
+        customizedLinearProgress.has().firstBarColor(lightBlueColor);
     }
 
     @Test
     public void delayingAppearanceTest() {
         startLoadingButton.click();
-        loadingCircularIndeterminate.is().indeterminate();
+        loadingCircularProgress.is().indeterminate();
         simulateLoadButton.click();
-        simulateLoadCircularIndeterminate.is().indeterminate();
+        simulateLoadCircularProgress.is().indeterminate();
         timer.wait(() -> successMessage.is().displayed());
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/ProgressAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/ProgressAssert.java
@@ -10,32 +10,32 @@ import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 public class ProgressAssert<A extends ProgressAssert<?, ?>, E extends Progress<?>>
-        extends UIAssert<A, E> {
-
-    @JDIAction("Assert that '{name}' is indeterminate")
-    public A indeterminate() {
-        boolean isIndeterminate = new Timer(base().getTimeout() * 1000L)
-                .wait(() -> element().isIndeterminate());
-        jdiAssert(isIndeterminate, Matchers.is(true));
-        return (A) this;
-    }
+    extends UIAssert<A, E> {
 
     @Override
     public E element() {
         return super.element();
     }
 
+    @JDIAction("Assert that '{name}' is indeterminate")
+    public A indeterminate() {
+        boolean isIndeterminate = new Timer(base().getTimeout() * 1000L)
+            .wait(() -> element().isIndeterminate());
+        jdiAssert(isIndeterminate, Matchers.is(true));
+        return (A) this;
+    }
+
     @JDIAction("Assert that '{name}' is determinate")
     public A determinate() {
         boolean isDeterminate = new Timer(base().getTimeout() * 1000L)
-                .wait(() -> element().isDeterminate());
+            .wait(() -> element().isDeterminate());
         jdiAssert(isDeterminate, Matchers.is(true));
         return (A) this;
     }
 
+    @JDIAction("Assert that '{name}' value {0}")
     public A value(int value) {
-        jdiAssert(element().getValueNow(), Matchers.is(value));
-        return (A) this;
+        return value(Matchers.is(value));
     }
 
     @JDIAction("Assert that '{name}' value {0}")
@@ -46,26 +46,42 @@ public class ProgressAssert<A extends ProgressAssert<?, ?>, E extends Progress<?
 
     @JDIAction("Assert that '{name}' min value is {0}")
     public A min(int minValue) {
-        jdiAssert(element().minValue(), Matchers.is(minValue));
+        return min(Matchers.is(minValue));
+    }
+
+    @JDIAction("Assert that '{name}' min value is {0}")
+    public A min(Matcher<Integer> condition) {
+        jdiAssert(element().minValue(), condition);
         return (A) this;
     }
 
     @JDIAction("Assert that '{name}' max value is {0}")
     public A max(int maxValue) {
-        jdiAssert(element().maxValue(), Matchers.is(maxValue));
+        return max(Matchers.is(maxValue));
+    }
+
+    @JDIAction("Assert that '{name}' max value is {0}")
+    public A max(Matcher<Integer> condition) {
+        jdiAssert(element().maxValue(), condition);
         return (A) this;
     }
 
     @JDIAction("Assert that '{name}' has primary color")
     public A primaryColor() {
         jdiAssert(element().hasPrimaryColor() ? "has primary color" : "does not have primary color",
-                Matchers.is("has primary color"));
+            Matchers.is("has primary color"));
         return (A) this;
     }
 
     @JDIAction("Assert that '{name}' has color {0}")
     public A color(String color) {
         jdiAssert(element().color(), Matchers.is(color));
+        return (A) this;
+    }
+
+    @JDIAction("Assert that '{name}' has color {0}")
+    public A color(Matcher<String> condition) {
+        jdiAssert(element().color(), condition);
         return (A) this;
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/progress/LinearProgress.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/progress/LinearProgress.java
@@ -1,10 +1,17 @@
 package com.epam.jdi.light.material.elements.feedback.progress;
 
+import static com.epam.jdi.light.elements.pageobjects.annotations.objects.FillFromAnnotationRules.fieldHasAnnotation;
+
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.common.UIElement;
+import com.epam.jdi.light.material.annotations.JProgress;
 import com.epam.jdi.light.material.asserts.feedback.LinearProgressAssert;
+import java.lang.reflect.Field;
 
 public class LinearProgress extends Progress<LinearProgressAssert> {
+
+    protected String bar1;
+    protected String bar2;
 
     @JDIAction("Is '{name}' buffer")
     public boolean isBuffer() {
@@ -52,5 +59,17 @@ public class LinearProgress extends Progress<LinearProgressAssert> {
     @Override
     public LinearProgressAssert is() {
         return new LinearProgressAssert().set(this);
+    }
+
+    @Override
+    public void setup(Field field) {
+        if (!fieldHasAnnotation(field, JProgress.class, Progress.class)) {
+            return;
+        }
+        JProgress j = field.getAnnotation(JProgress.class);
+        root = j.root();
+        bar1 = j.bar1();
+        bar2 = j.bar2();
+        labelLocator = j.label();
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/progress/Progress.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/feedback/progress/Progress.java
@@ -11,7 +11,6 @@ import com.epam.jdi.light.elements.interfaces.base.HasLabel;
 import com.epam.jdi.light.material.annotations.JProgress;
 import com.epam.jdi.light.material.asserts.feedback.ProgressAssert;
 import com.epam.jdi.light.material.interfaces.base.HasColor;
-
 import java.lang.reflect.Field;
 import java.util.NoSuchElementException;
 
@@ -21,12 +20,9 @@ import java.util.NoSuchElementException;
  */
 
 public abstract class Progress<A extends ProgressAssert<?, ?>> extends UIBaseElement<A>
-        implements ISetup, HasLabel, HasColor {
+    implements ISetup, HasLabel, HasColor {
 
     protected String root;
-    // TODO: bar1 and bar2 are a part of LinearProgress only, should be moved
-    protected String bar1;
-    protected String bar2;
     protected String labelLocator;
 
     @JDIAction("Get '{name}' value now")
@@ -101,9 +97,6 @@ public abstract class Progress<A extends ProgressAssert<?, ?>> extends UIBaseEle
         }
         JProgress j = field.getAnnotation(JProgress.class);
         root = j.root();
-        bar1 = j.bar1();
-        bar2 = j.bar2();
         labelLocator = j.label();
     }
 }
-


### PR DESCRIPTION
- renamed elements on the page
- added test for accept terms button and progress
- moved `bar1` and `bar2` fields from Progress to LinearProgress
- overridden `setup` method in LinearProgress