### PR TITLE
3875: Menu refactoring

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/navigation/ContextMenuPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/navigation/ContextMenuPage.java
@@ -1,8 +1,8 @@
 package io.github.com.pages.navigation;
 
+import com.epam.jdi.light.elements.complex.Menu;
 import com.epam.jdi.light.elements.composite.WebPage;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
-import com.epam.jdi.light.material.elements.displaydata.List;
 import com.epam.jdi.light.ui.html.elements.common.Text;
 
 public class ContextMenuPage extends WebPage {
@@ -10,6 +10,6 @@ public class ContextMenuPage extends WebPage {
     @UI("p.MuiTypography-root")
     public static Text pageText;
 
-    @UI(".MuiMenu-list")
-    public static List contextMenuList;
+    @UI(".MuiMenuItem-root")
+    public static Menu contextMenuList;
 }

--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/navigation/SimpleMenuPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/navigation/SimpleMenuPage.java
@@ -2,38 +2,35 @@ package io.github.com.pages.navigation;
 
 import com.epam.jdi.light.elements.composite.WebPage;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
-import com.epam.jdi.light.material.elements.displaydata.List;
 import com.epam.jdi.light.material.elements.navigation.Menu;
 import com.epam.jdi.light.ui.html.elements.common.Button;
 import com.epam.jdi.light.ui.html.elements.common.Text;
 
 public class SimpleMenuPage extends WebPage {
+
+    @UI(".MuiMenuItem-root")
+    public static Menu menu;
+
     @UI(".MuiButton-text")
-    public static Button menuButton;
-
-    @UI(".MuiMenu-list")
-    public static Menu items;
-
-    @UI(".MuiMenu-list")
-    public static List menuItems;
-
-    @UI(".MuiListItemText-multiline")
-    public static Button selectedMenuButton;
-
-    @UI("[aria-controls=long-menu]")
-    public static Button scrollMenuButton;
-
-    @UI(".MuiIconButton-root")
-    public static Button iconMenuButton;
+    public static Button simpleMenuButton;
 
     @UI("#selectedItem")
     public static Text selectedSimpleMenuItem;
 
+    @UI(".MuiIconButton-root")
+    public static Button iconMenuButton;
+
     @UI("#selectedIconMenu")
     public static Text selectedMenuIconItem;
 
+    @UI(".MuiListItemText-multiline")
+    public static Button selectedSelectedMenuButton;
+
     @UI(".MuiTypography-colorTextSecondary")
-    public static Text selectedMenuItem;
+    public static Text selectedSelectedMenuItem;
+
+    @UI("[aria-controls=long-menu]")
+    public static Button scrollMenuButton;
 
     @UI("#selectedLongMenu")
     public static Text selectedScrollMenuItem;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/navigation/MenuTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/navigation/MenuTests.java
@@ -1,38 +1,30 @@
 package io.github.epam.material.tests.navigation;
 
-import io.github.epam.TestsInit;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
-
-import java.util.Arrays;
-import java.util.List;
-
 import static io.github.com.StaticSite.contextMenuPage;
 import static io.github.com.StaticSite.simpleMenuPage;
-import static io.github.com.pages.navigation.ContextMenuPage.pageText;
 import static io.github.com.pages.navigation.ContextMenuPage.contextMenuList;
-import static io.github.com.pages.navigation.SimpleMenuPage.menuItems;
-import static io.github.com.pages.navigation.SimpleMenuPage.menuButton;
-import static io.github.com.pages.navigation.SimpleMenuPage.selectedSimpleMenuItem;
-import static io.github.com.pages.navigation.SimpleMenuPage.items;
-import static io.github.com.pages.navigation.SimpleMenuPage.scrollMenuButton;
-import static io.github.com.pages.navigation.SimpleMenuPage.selectedMenuButton;
-import static io.github.com.pages.navigation.SimpleMenuPage.selectedScrollMenuItem;
-import static io.github.com.pages.navigation.SimpleMenuPage.selectedMenuItem;
+import static io.github.com.pages.navigation.ContextMenuPage.pageText;
 import static io.github.com.pages.navigation.SimpleMenuPage.iconMenuButton;
+import static io.github.com.pages.navigation.SimpleMenuPage.menu;
+import static io.github.com.pages.navigation.SimpleMenuPage.scrollMenuButton;
 import static io.github.com.pages.navigation.SimpleMenuPage.selectedMenuIconItem;
+import static io.github.com.pages.navigation.SimpleMenuPage.selectedScrollMenuItem;
+import static io.github.com.pages.navigation.SimpleMenuPage.selectedSelectedMenuButton;
+import static io.github.com.pages.navigation.SimpleMenuPage.selectedSelectedMenuItem;
+import static io.github.com.pages.navigation.SimpleMenuPage.selectedSimpleMenuItem;
+import static io.github.com.pages.navigation.SimpleMenuPage.simpleMenuButton;
+
+import com.epam.jdi.light.ui.html.elements.common.Button;
+import io.github.epam.TestsInit;
+import io.github.epam.test.data.MenuDataProvider;
+import java.util.Arrays;
+import java.util.List;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 public class MenuTests extends TestsInit {
 
     private static final List<String> CONTEXT_MENU_ITEMS = Arrays.asList("Copy", "Print", "Highlight", "Email");
-    private static final List<String> SIMPLE_AND_SELECTED_MENU_ITEMS = Arrays.asList("Profile", "My account", "Logout");
-    private static final List<String> ICON_MENU_ITEMS = Arrays.asList("Text with send icon",
-            "Text with priority icon", "Text with drafts icon");
-    private static final List<String> SCROLL_MENU_ITEMS = Arrays.asList("None", "Atria", "Callisto",
-            "Dione", "Ganymede", "Hangouts Call", "Luna", "Oberon", "Phobos", "Pyxis", "Sedna",
-            "Titania", "Triton", "Umbriel");
-
-    private static final String EXPECTED_MENU_TEXT_PART = "Selected menu: ";
 
     @BeforeMethod
     public void before() {
@@ -40,66 +32,73 @@ public class MenuTests extends TestsInit {
         simpleMenuPage.isOpened();
     }
 
-    @Test
-    public void simpleMenuTest() {
-        String expectedPart = "Profile";
-        menuButton.show();
-        menuButton.has().text("OPEN MENU");
-        menuButton.click();
-        items.is().displayed()
-                .has().properMenuItems(menuItems, SIMPLE_AND_SELECTED_MENU_ITEMS);
-        menuItems.selectItemByText(expectedPart);
+    @Test(dataProvider = "simpleMenuItemsTestData", dataProviderClass = MenuDataProvider.class)
+    public void simpleMenusItemsTest(Button menuButton, List<String> menuOptions) {
         menuButton.is().displayed();
-        selectedSimpleMenuItem.has().text(EXPECTED_MENU_TEXT_PART + expectedPart);
+
+        menuButton.click();
+        menu.is().displayed().and().has().itemsTexts(menuOptions);
     }
 
     @Test
-    public void scrollMenuTest() {
-        String expectedPart = "Callisto";
-        scrollMenuButton.show();
-        scrollMenuButton.click();
-        items.is().displayed()
-                .has().properMenuItems(menuItems, SCROLL_MENU_ITEMS);
-        items.scrollToMenuItem(menuItems, expectedPart);
-        items.has().displayedMenuItem(menuItems, expectedPart);
-        menuItems.selectItemByText(expectedPart);
-        scrollMenuButton.is().displayed();
-        selectedScrollMenuItem.has().text(EXPECTED_MENU_TEXT_PART + expectedPart);
+    public void simpleMenuTest() {
+        simpleMenuButton.show();
+        simpleMenuButton.has().text("OPEN MENU");
+        simpleMenuButton.click();
+
+        String option = "Profile";
+        menu.select(option);
+        selectedSimpleMenuItem.has().text("Selected menu: " + option);
+    }
+
+    @Test
+    public void menuWithIconsTest() {
+        iconMenuButton.show();
+
+        iconMenuButton.click();
+        String option = "Text with send icon";
+        menu.itemIcon(option).is().displayed();
+
+        menu.select(option);
+        selectedMenuIconItem.has().text("Selected menu: " + option);
     }
 
     @Test
     public void selectedVerticalPositioningTest() {
+        selectedSelectedMenuButton.show();
+
         String defaultSelectedItem = "My account";
-        String expectedPart = "Logout";
-        selectedMenuButton.show();
-        selectedMenuItem.has().text(defaultSelectedItem);
-        selectedMenuButton.click();
-        menuItems.getItemByText(defaultSelectedItem).isSelected();
-        items.is().displayed()
-                .has().properMenuItems(menuItems, SIMPLE_AND_SELECTED_MENU_ITEMS);
-        menuItems.selectItemByText(expectedPart);
-        selectedMenuButton.is().displayed();
-        selectedMenuItem.has().text(expectedPart);
+        selectedSelectedMenuItem.has().text(defaultSelectedItem);
+
+        selectedSelectedMenuButton.click();
+        menu.has().selected(defaultSelectedItem);
+
+        String option = "Logout";
+        menu.select(option);
+        selectedSelectedMenuItem.has().text(option);
+    }
+
+    @Test
+    public void scrollMenuTest() {
+        scrollMenuButton.show();
+        scrollMenuButton.click();
+
+        String option = "Callisto";
+        menu.scrollToItem(option);
+        menu.get(option).is().displayed();
+        menu.select(option);
+        selectedScrollMenuItem.has().text("Selected menu: " + option);
     }
 
     @Test
     public void contextMenuTest() {
         contextMenuPage.open();
-        pageText.rightClick();
-        items.has().properMenuItems(menuItems, CONTEXT_MENU_ITEMS);
-        contextMenuList.selectItemByText("Print");
+        contextMenuPage.isOpened();
         pageText.is().displayed();
-    }
 
-    @Test
-    public void menuWithIconsTest() {
-        String expectedPart = "Text with send icon";
-        iconMenuButton.show();
-        iconMenuButton.click();
-        items.has().properMenuItems(menuItems, ICON_MENU_ITEMS)
-                .has().displayedSvg();
-        menuItems.selectItemByText(expectedPart);
-        iconMenuButton.is().displayed();
-        selectedMenuIconItem.has().text(EXPECTED_MENU_TEXT_PART + expectedPart);
+        pageText.rightClick();
+        menu.is().displayed().and().has().itemsTexts(CONTEXT_MENU_ITEMS);
+        contextMenuList.select("Print");
+        menu.is().hidden();
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/MenuDataProvider.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/MenuDataProvider.java
@@ -12,7 +12,7 @@ public class MenuDataProvider {
 
     @DataProvider
     public Object[][] simpleMenuItemsTestData() {
-        return new Object[][]{
+        return new Object[][] {
             {simpleMenuButton, Arrays.asList("Profile", "My account", "Logout")},
             {iconMenuButton, Arrays.asList("Text with send icon", "Text with priority icon", "Text with drafts icon")},
             {selectedSelectedMenuButton, Arrays.asList("Profile", "My account", "Logout")},

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/MenuDataProvider.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/MenuDataProvider.java
@@ -1,0 +1,23 @@
+package io.github.epam.test.data;
+
+import static io.github.com.pages.navigation.SimpleMenuPage.iconMenuButton;
+import static io.github.com.pages.navigation.SimpleMenuPage.scrollMenuButton;
+import static io.github.com.pages.navigation.SimpleMenuPage.selectedSelectedMenuButton;
+import static io.github.com.pages.navigation.SimpleMenuPage.simpleMenuButton;
+
+import java.util.Arrays;
+import org.testng.annotations.DataProvider;
+
+public class MenuDataProvider {
+
+    @DataProvider
+    public Object[][] simpleMenuItemsTestData() {
+        return new Object[][]{
+            {simpleMenuButton, Arrays.asList("Profile", "My account", "Logout")},
+            {iconMenuButton, Arrays.asList("Text with send icon", "Text with priority icon", "Text with drafts icon")},
+            {selectedSelectedMenuButton, Arrays.asList("Profile", "My account", "Logout")},
+            {scrollMenuButton, Arrays.asList("None", "Atria", "Callisto", "Dione", "Ganymede", "Hangouts Call", "Luna",
+                "Oberon", "Phobos", "Pyxis", "Sedna", "Titania", "Triton", "Umbriel")},
+        };
+    }
+}

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/MenuAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/MenuAssert.java
@@ -1,57 +1,24 @@
 package com.epam.jdi.light.material.asserts.navigation;
 
-import com.epam.jdi.light.asserts.generic.UIAssert;
+import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
+
+import com.epam.jdi.light.asserts.generic.UISelectAssert;
 import com.epam.jdi.light.common.JDIAction;
-import com.epam.jdi.light.material.elements.displaydata.List;
 import com.epam.jdi.light.material.elements.navigation.Menu;
-import com.jdiai.tools.Timer;
+import java.util.List;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
-import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
+public class MenuAssert extends UISelectAssert<MenuAssert, Menu> {
 
-public class MenuAssert extends UIAssert<MenuAssert, Menu> {
-    @JDIAction("Assert that {name} is displayed")
-    @Override
-    public MenuAssert displayed() {
-        boolean isDisplayed = new Timer(base().getTimeout() * 1000L)
-                .wait(() -> element().isDisplayed());
-        jdiAssert(isDisplayed, Matchers.is(true));
-        return this;
+    @JDIAction("Assert that '{name}' has items: {0}")
+    public MenuAssert itemsTexts(List<String> expectedItems) {
+        return itemsTexts(Matchers.contains(expectedItems.toArray()));
     }
 
-    @JDIAction("Assert that menu item is displayed")
-    public MenuAssert displayedMenuItem(List listLocator, String menuItem) {
-        jdiAssert(listLocator.getItemByText(menuItem).core().isDisplayed(), Matchers.is(true));
-        return this;
-    }
-
-    @JDIAction("Assert that {name}'s child svg is visible")
-    public MenuAssert displayedSvg() {
-        try {
-            boolean isDisplayed = new Timer(base().getTimeout() * 1000L)
-                    .wait(() -> element().find(".MuiSvgIcon-root").isDisplayed());
-            jdiAssert(isDisplayed, Matchers.is(true));
-        } catch (AssertionError e) {
-            throw new AssertionError("Svg not found");
-        }
-        return this;
-    }
-
-    @JDIAction("Assert that '{name}' text is '{0}'")
-    public MenuAssert text(String text) {
-        return text(Matchers.is(text));
-    }
-
-    @JDIAction("Assert that '{name}' text '{0}'")
-    public MenuAssert text(Matcher<String> condition) {
-        jdiAssert(element().getText(), condition);
-        return this;
-    }
-
-    @JDIAction("Assert that all menu items are correct")
-    public MenuAssert properMenuItems(List listLocator, java.util.List<String> expectedItems) {
-        jdiAssert(element().getMenuItems(listLocator), Matchers.containsInAnyOrder(expectedItems.toArray()));
+    @JDIAction("Assert that '{name}' has items {0}")
+    public MenuAssert itemsTexts(Matcher<? super List<String>> condition) {
+        jdiAssert(element().itemsTexts(), condition);
         return this;
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Menu.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Menu.java
@@ -1,12 +1,10 @@
 package com.epam.jdi.light.material.elements.navigation;
 
 import com.epam.jdi.light.common.JDIAction;
-import com.epam.jdi.light.elements.base.UIBaseElement;
-import com.epam.jdi.light.elements.interfaces.base.HasClick;
+import com.epam.jdi.light.elements.base.UIListBase;
+import com.epam.jdi.light.elements.common.UIElement;
 import com.epam.jdi.light.material.asserts.navigation.MenuAssert;
-import com.epam.jdi.light.material.elements.displaydata.List;
-import com.epam.jdi.light.material.elements.displaydata.ListItem;
-
+import com.epam.jdi.light.material.elements.displaydata.Icon;
 import java.util.stream.Collectors;
 
 /**
@@ -14,31 +12,31 @@ import java.util.stream.Collectors;
  * https://mui.com/components/menus/
  */
 
-public class Menu extends UIBaseElement<MenuAssert> implements HasClick {
+public class Menu extends UIListBase<MenuAssert> {
 
-    @JDIAction("Scroll to menu item")
-    public void scrollToMenuItem(List listLocator, String menuItem) {
-        listLocator.getItemByText(menuItem).core().jsExecute("scrollIntoView()");
+    @JDIAction("Get icon of '{name}' item {0}")
+    public Icon itemIcon(String menuItem) {
+        return new Icon().setCore(Icon.class, get(menuItem).core().find(".MuiListItemIcon-root"));
+    }
+
+    @JDIAction("Get list of '{name}' items")
+    public java.util.List<String> itemsTexts() {
+        return list().stream().map(UIElement::getText).collect(Collectors.toList());
+    }
+
+    @Override
+    @JDIAction("Get selected '{name}' item")
+    public String selected() {
+        return list().filter(e -> e.core().hasClass("Mui-selected")).get(0).text();
+    }
+
+    @JDIAction("Scroll to '{name}' item {0}")
+    public void scrollToItem(String menuItem) {
+        get(menuItem).core().jsExecute("scrollIntoView()");
     }
 
     @Override
     public MenuAssert is() {
         return new MenuAssert().set(this);
-    }
-
-    @JDIAction("Check if '{name}' is displayed")
-    @Override
-    public boolean isDisplayed() {
-        return core().isDisplayed();
-    }
-
-    @JDIAction("Get text in '{name}'")
-    public String getText() {
-        return core().getText();
-    }
-
-    @JDIAction("Get list of menu items")
-    public java.util.List<String> getMenuItems(List listLocator) {
-        return listLocator.items().stream().map(ListItem::getText).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
- The Menu component:
  - extends UIListBase
  - methods are refactored
  - method for getting an item icon is added
  - selected() method is overridden for correct asserts work
- MenuAssert: only check of items texts are left
- Menu Pages: changed menu locators, page objects names and order
- Tests:
  - added test of menu items of simple menus
  - deleted unnecessary checks
  - changed check methods