### PR TITLE
3859 Material UI snackbars tests refactoring

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/SnackbarPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/feedback/SnackbarPage.java
@@ -38,6 +38,9 @@ public class SnackbarPage extends WebPage {
     @UI("//h2[text() = 'Consecutive Snackbars']/following::div[1]//div[@role='alert']")
     public static Snackbar consecutiveSnackbar;
 
+    @UI("//h2[text() = 'Consecutive Snackbars']/following::div[1]//div[@role='alert']")
+    public static List<Snackbar> consecutiveSnackbarList;
+
     @UI("//h2[text()='Change Transition']/following::div[1]/button")
     public static List<Button> transitionButtons;
 
@@ -55,5 +58,8 @@ public class SnackbarPage extends WebPage {
 
     @UI("//div[@id='notistack-snackbar']")
     public static Snackbar complementaryProjectsSnackbar;
+
+    @UI("//div[@id='notistack-snackbar']")
+    public static List<Snackbar> complementaryProjectsSnackbarList;
 
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/SnackbarTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/feedback/SnackbarTests.java
@@ -3,7 +3,9 @@ package io.github.epam.material.tests.feedback;
 import static io.github.com.StaticSite.snackbarPage;
 import static io.github.com.pages.feedback.SnackbarPage.changeTransitionSnackbar;
 import static io.github.com.pages.feedback.SnackbarPage.complementaryProjectsSnackbar;
+import static io.github.com.pages.feedback.SnackbarPage.complementaryProjectsSnackbarList;
 import static io.github.com.pages.feedback.SnackbarPage.consecutiveSnackbar;
+import static io.github.com.pages.feedback.SnackbarPage.consecutiveSnackbarList;
 import static io.github.com.pages.feedback.SnackbarPage.controlSlideDirectionSnackbar;
 import static io.github.com.pages.feedback.SnackbarPage.customizedSnackbar;
 import static io.github.com.pages.feedback.SnackbarPage.directionButtons;
@@ -22,20 +24,17 @@ import io.github.epam.test.data.SnackbarsDataProvider;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+
 public class SnackbarTests extends TestsInit {
 
-    private static final String[] MESSAGE = {"SHOW MESSAGE A", "SHOW MESSAGE B", "Message A", "Message B"};
     private static final String LOVE_SNACKS = "I love snacks";
-    private static final String LOREM = "lorem ipsum dolorem";
-    private static final String LOVE_CANDY = "I love candy. I love cookies. I love cupcakes.";
-    private static final String LOVE_CHEESECAKE = "I love cheesecake. I love chocolate.";
+    private static final String SUCCESS_MESSAGE = "This is a success message!";
     private static final String UNDO = "UNDO";
 
     @BeforeMethod
     public void before() {
         snackbarPage.open();
         snackbarPage.isOpened();
-
     }
 
     @Test
@@ -78,37 +77,32 @@ public class SnackbarTests extends TestsInit {
         positionedSnackbar.waitFor().hidden();
     }
 
-    @Test
-    public void messageLengthTest() {
-        // TODO: Get items only once
-        messageLength.get(1).has().text(LOVE_SNACKS + ".");
-        messageLength.get(1).snackbarButton(LOREM).click();
-
-        messageLength.get(2).has().text(LOVE_CANDY + " " + LOVE_CHEESECAKE);
-
-        messageLength.get(3).has().text(LOVE_CANDY);
-        messageLength.get(3).snackbarButton(LOREM).click();
-
-        messageLength.get(4).has().text(LOVE_CANDY + " " + LOVE_CHEESECAKE);
-        messageLength.get(4).snackbarButton(LOREM).click();
+    @Test(dataProviderClass = SnackbarsDataProvider.class, dataProvider = "messageLengthSnackbarDataProvider")
+    public void messageLengthTest(int number, String message) {
+        messageLength.get(number).has().text(message);
     }
 
-    @Test
-    public void consecutiveSnackbarsTest() {
-        for (int i = 1; i <= 2; i++) {
-            showMessageButtons.get(i).is().displayed().and().has().text(MESSAGE[i - 1]);
-            showMessageButtons.get(i).click();
-            consecutiveSnackbar.waitFor().displayed();
-            consecutiveSnackbar.has().text(MESSAGE[i + 1]);
-            consecutiveSnackbar.close();
-            consecutiveSnackbar.waitFor().notVisible();
+    @Test(dataProviderClass = SnackbarsDataProvider.class, dataProvider = "consecutiveSnackbarsDataProvider")
+    public void consecutiveSnackbarsTest(int number, String message, String buttonMessage) {
+        showMessageButtons.get(number).is().displayed().and().has().text(buttonMessage);
+        showMessageButtons.get(number).click();
+        consecutiveSnackbar.waitFor().displayed();
+        consecutiveSnackbar.has().text(message);
+        consecutiveSnackbar.close();
+        consecutiveSnackbar.waitFor().notVisible();
 
-            showMessageButtons.get(i).click();
-            consecutiveSnackbar.waitFor().displayed();
-            consecutiveSnackbar.snackbarButton(UNDO).click();
-            consecutiveSnackbar.waitFor().notVisible();
-        }
-        //TODO: Add check that second is displayed on click event the first is displayed (we can see only one)
+        showMessageButtons.get(number).click();
+        consecutiveSnackbar.waitFor().displayed();
+        consecutiveSnackbar.snackbarButton(UNDO).click();
+        consecutiveSnackbar.waitFor().notVisible();
+
+        showMessageButtons.get(1).click();
+        consecutiveSnackbar.waitFor().displayed();
+
+        showMessageButtons.get(2).click();
+        consecutiveSnackbar.waitFor().displayed();
+        consecutiveSnackbarList.get(2).isDisplayed();
+        consecutiveSnackbarList.get(1).isHidden();
     }
 
     @Test
@@ -130,15 +124,16 @@ public class SnackbarTests extends TestsInit {
         });
     }
 
-    @Test(dataProviderClass = SnackbarsDataProvider.class, dataProvider = "complementaryProjectsSnackbarDataProvider")
-    public void complementaryProjectsSnackbarTest(int number, String message) {
-        showSnackbarButtons.get(number).click();
+    @Test()
+    public void complementaryProjectsSnackbarTest() {
+        showSnackbarButtons.get(1).click();
         complementaryProjectsSnackbar.waitFor().displayed();
-        complementaryProjectsSnackbar.has().text(message);
+        complementaryProjectsSnackbar.has().text(LOVE_SNACKS + ".");
+
+        showSnackbarButtons.get(2).click();
+        complementaryProjectsSnackbarList.get(1).has().text(LOVE_SNACKS + ".");
+        complementaryProjectsSnackbarList.get(2).has().text(SUCCESS_MESSAGE);
         complementaryProjectsSnackbar.waitFor().disappear();
         complementaryProjectsSnackbar.is().notVisible();
-        //TODO: Add check that second is displayed on click event the first is displayed (we can see both)
     }
 }
-
-

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/SnackbarsDataProvider.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/test/data/SnackbarsDataProvider.java
@@ -21,10 +21,21 @@ public class SnackbarsDataProvider {
         };
     }
 
-    @DataProvider(name = "complementaryProjectsSnackbarDataProvider")
-    public Object[][] complementaryProjectsSnackbarTestData() {
-        return new Object[][]{
-                {1, "I love snacks."}, {2, "This is a success message!"}
+    @DataProvider(name = "messageLengthSnackbarDataProvider")
+    public static Object[][] messageLengthSnackbarTestData() {
+        return new Object[][] {
+                {1, "I love snacks."},
+                {2, "I love candy. I love cookies. I love cupcakes. I love cheesecake. I love chocolate."},
+                {3, "I love candy. I love cookies. I love cupcakes."},
+                {4, "I love candy. I love cookies. I love cupcakes. I love cheesecake. I love chocolate."},
+        };
+    }
+
+    @DataProvider(name = "consecutiveSnackbarsDataProvider")
+    public static Object[][] consecutiveSnackbarsTestData() {
+        return new Object[][] {
+                {1, "Message A", "SHOW MESSAGE A"},
+                {2, "Message B", "SHOW MESSAGE B"},
         };
     }
 }


### PR DESCRIPTION
1) SnackbarTests - complementaryProjectsSnackbarTest - Added check that second Snackbar is displayed while the first is displayed. (We can see both snackbars)
2) SnackbarTests - consecutiveSnackbarsTest - Added check that second Snackbar is displayed while the first is hidden. (We can see only one snackbar)
3) SnackbarTests - messageLengthTest - Get items only once. Added DataProvider to get items only once. Also delete unuseful method click() - after the method nothing happened and nothing checked.