### PR TITLE
Task 3906: Implement IColorAssert interface

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/cards/ComplexInteractionCard.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/cards/ComplexInteractionCard.java
@@ -2,9 +2,9 @@ package io.github.com.custom.elements.cards;
 
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
+import com.epam.jdi.light.material.elements.displaydata.Icon;
 import com.epam.jdi.light.material.elements.surfaces.Card;
 import com.epam.jdi.light.ui.html.elements.common.Button;
-import com.epam.jdi.light.ui.html.elements.common.Icon;
 import com.epam.jdi.light.ui.html.elements.common.Text;
 
 public class ComplexInteractionCard extends Card {

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/CardTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/surfaces/CardTests.java
@@ -56,7 +56,7 @@ public class CardTests extends TestsInit {
         complexCard.textUnderImage().has().text(containsString("paella is a perfect party dish"));
 
         complexCard.addToFavoritesButton().click();
-        complexCard.addToFavoritesSvgIcon().has().css("color","rgba(244, 67, 54, 1)");
+        complexCard.addToFavoritesSvgIcon().has().color("rgba(244, 67, 54, 1)");
 
         complexCardDropdownText.is().hidden();
         complexCard.expandButton().click();

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/IconAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/IconAssert.java
@@ -1,14 +1,15 @@
 package com.epam.jdi.light.material.asserts.displaydata;
 
-import com.epam.jdi.light.asserts.generic.UIAssert;
-import com.epam.jdi.light.common.JDIAction;
-import com.epam.jdi.light.material.elements.displaydata.Icon;
-import org.hamcrest.Matchers;
-
 import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
+import com.epam.jdi.light.asserts.generic.UIAssert;
+import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.material.asserts.generic.IColorAssert;
+import com.epam.jdi.light.material.elements.displaydata.Icon;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
 
-public class IconAssert extends UIAssert<IconAssert, Icon> {
+public class IconAssert extends UIAssert<IconAssert, Icon> implements IColorAssert<IconAssert> {
     @JDIAction("Assert that {name} is colored")
     public IconAssert colored() {
         jdiAssert(element().colored() ? "colored" : "not colored", Matchers.is("colored"));
@@ -21,12 +22,9 @@ public class IconAssert extends UIAssert<IconAssert, Icon> {
         return this;
     }
 
-    /**
-     * String color example: "rgba(0, 0, 0, 0.54)"
-     */
-    @JDIAction("Assert that {name} color is {0}")
-    public IconAssert color(String color) {
-        jdiAssert(element().getColor(), Matchers.is(color));
+    @JDIAction("Assert that {name} color {0}")
+    public IconAssert color(Matcher<String> condition) {
+        jdiAssert(element().color(), condition);
         return this;
     }
 

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/ProgressAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/feedback/ProgressAssert.java
@@ -4,13 +4,14 @@ import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
 import com.epam.jdi.light.asserts.generic.UIAssert;
 import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.material.asserts.generic.IColorAssert;
 import com.epam.jdi.light.material.elements.feedback.progress.Progress;
 import com.jdiai.tools.Timer;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 public class ProgressAssert<A extends ProgressAssert<?, ?>, E extends Progress<?>>
-    extends UIAssert<A, E> {
+    extends UIAssert<A, E> implements IColorAssert<A> {
 
     @Override
     public E element() {
@@ -66,13 +67,8 @@ public class ProgressAssert<A extends ProgressAssert<?, ?>, E extends Progress<?
         return (A) this;
     }
 
-    @JDIAction("Assert that '{name}' has color {0}")
-    public A color(String color) {
-        jdiAssert(element().color(), Matchers.is(color));
-        return (A) this;
-    }
-
-    @JDIAction("Assert that '{name}' has color {0}")
+    @Override
+    @JDIAction("Assert that '{name}' color {0}")
     public A color(Matcher<String> condition) {
         jdiAssert(element().color(), condition);
         return (A) this;

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/generic/IColorAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/generic/IColorAssert.java
@@ -1,0 +1,17 @@
+package com.epam.jdi.light.material.asserts.generic;
+
+import com.epam.jdi.light.asserts.generic.UIAssert;
+import com.epam.jdi.light.common.JDIAction;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+
+public interface IColorAssert<A extends UIAssert<?, ?>> {
+
+    @JDIAction("Assert that '{name}' color is '{0}'")
+    default A color(String color) {
+        return color(Matchers.is(color));
+    }
+
+    @JDIAction("Assert that '{name}' color {0}")
+    A color(Matcher<String> condition);
+}

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/CheckboxAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/CheckboxAssert.java
@@ -2,13 +2,15 @@ package com.epam.jdi.light.material.asserts.inputs;
 
 import com.epam.jdi.light.asserts.generic.UIAssert;
 import com.epam.jdi.light.common.JDIAction;
+import com.epam.jdi.light.material.asserts.generic.IColorAssert;
 import com.epam.jdi.light.material.elements.inputs.Checkbox;
 import com.epam.jdi.light.material.elements.utils.enums.Position;
+import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
-public class CheckboxAssert extends UIAssert<CheckboxAssert, Checkbox> {
+public class CheckboxAssert extends UIAssert<CheckboxAssert, Checkbox> implements IColorAssert<CheckboxAssert> {
 
     @JDIAction("Assert that '{name}' is checked")
     public CheckboxAssert checked() {
@@ -22,9 +24,9 @@ public class CheckboxAssert extends UIAssert<CheckboxAssert, Checkbox> {
         return this;
     }
 
-    @JDIAction("Assert that '{name}' has color '{0}'")
-    public CheckboxAssert color(String color) {
-        jdiAssert(element().color(), Matchers.is(color));
+    @JDIAction("Assert that '{name}' color '{0}'")
+    public CheckboxAssert color(Matcher<String> condition) {
+        jdiAssert(element().color(), condition);
         return this;
     }
 
@@ -33,5 +35,4 @@ public class CheckboxAssert extends UIAssert<CheckboxAssert, Checkbox> {
         jdiAssert(element().labelPosition(), Matchers.is(position));
         return this;
     }
-
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/LinkAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/LinkAssert.java
@@ -4,11 +4,12 @@ import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.material.asserts.displaydata.TypographyAssert;
+import com.epam.jdi.light.material.asserts.generic.IColorAssert;
 import com.epam.jdi.light.material.elements.navigation.Link;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
-public class LinkAssert extends TypographyAssert {
+public class LinkAssert extends TypographyAssert implements IColorAssert<LinkAssert> {
 
     @Override
     public Link element() {
@@ -29,9 +30,9 @@ public class LinkAssert extends TypographyAssert {
         return this;
     }
 
-    @JDIAction("Assert that '{name}' is color {0}")
-    public LinkAssert color(String rgbaColor) {
-        jdiAssert(element().color(), Matchers.is(rgbaColor));
+    @JDIAction("Assert that '{name}' color {0}")
+    public LinkAssert color(Matcher<String> condition) {
+        jdiAssert(element().color(), condition);
         return this;
     }
 

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/Icon.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/Icon.java
@@ -5,23 +5,18 @@ import com.epam.jdi.light.elements.base.UIBaseElement;
 import com.epam.jdi.light.elements.interfaces.base.HasClick;
 import com.epam.jdi.light.material.asserts.displaydata.IconAssert;
 import com.epam.jdi.light.material.interfaces.base.CanBeDisabled;
-
+import com.epam.jdi.light.material.interfaces.base.HasColor;
 
 /**
  * To see examples of Icon web element please visit https://mui.com/components/icons/
  */
 
-public class Icon extends UIBaseElement<IconAssert> implements HasClick, CanBeDisabled {
+public class Icon extends UIBaseElement<IconAssert> implements HasClick, CanBeDisabled, HasColor {
 
     @JDIAction("Check if {name} is colored")
     public boolean colored() {
         return String.join("", classes()).contains("color") ||
                 attr("style").contains("color");
-    }
-
-    @JDIAction("Get color of {name}")
-    public String getColor() {
-        return css("color");
     }
 
     @Override


### PR DESCRIPTION
Created interface IColorAssert with methods:
- color(Matcher<String>)
- color(String) - with default implementation

With this solution you have to implement `color(Matcher<String>)` in your asserts.