### PR TITLE
Task 3937: Add whitespaces to fix issue found by checkstyle

### DIFF
--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -10,7 +10,7 @@ public class StringUtils {
 
         Random r = new Random();
         char[] randomString = new char[r.nextBoolean() ? 12 : 13];
-        for (int i=0; i<randomString.length; i++) {
+        for (int i =0; i<randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;
         }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -9,7 +9,7 @@ public class StringUtils {
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789$&@?<>~!%#";
 
         Random r = new Random();
-        char[] randomString = new char[r.nextBoolean() ?12:13];
+        char[] randomString = new char[r.nextBoolean() ? 12:13];
         for(int i=0; i<randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -10,7 +10,7 @@ public class StringUtils {
 
         Random r = new Random();
         char[] randomString = new char[r.nextBoolean() ? 12 : 13];
-        for (int i = 0; i<randomString.length; i++) {
+        for (int i = 0; i <randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;
         }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -9,7 +9,7 @@ public class StringUtils {
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789$&@?<>~!%#";
 
         Random r = new Random();
-        char[] randomString = new char[r.nextBoolean() ? 12 :13];
+        char[] randomString = new char[r.nextBoolean() ? 12 : 13];
         for(int i=0; i<randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -9,7 +9,7 @@ public class StringUtils {
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789$&@?<>~!%#";
 
         Random r = new Random();
-        char[] randomString = new char[r.nextBoolean() ? 12:13];
+        char[] randomString = new char[r.nextBoolean() ? 12 :13];
         for(int i=0; i<randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -10,7 +10,7 @@ public class StringUtils {
 
         Random r = new Random();
         char[] randomString = new char[r.nextBoolean() ? 12 : 13];
-        for (int i = 0; i <randomString.length; i++) {
+        for (int i = 0; i < randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;
         }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -10,7 +10,7 @@ public class StringUtils {
 
         Random r = new Random();
         char[] randomString = new char[r.nextBoolean() ? 12 : 13];
-        for (int i =0; i<randomString.length; i++) {
+        for (int i = 0; i<randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;
         }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -9,7 +9,7 @@ public class StringUtils {
                 "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789$&@?<>~!%#";
 
         Random r = new Random();
-        char[] randomString = new char[r.nextBoolean()?12:13];
+        char[] randomString = new char[r.nextBoolean() ?12:13];
         for(int i=0; i<randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/utils/StringUtils.java
@@ -10,7 +10,7 @@ public class StringUtils {
 
         Random r = new Random();
         char[] randomString = new char[r.nextBoolean() ? 12 : 13];
-        for(int i=0; i<randomString.length; i++) {
+        for (int i=0; i<randomString.length; i++) {
             char ch = symbols.charAt(r.nextInt(symbols.length()));
             randomString[i] = ch;
         }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/AppBar.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/surfaces/AppBar.java
@@ -66,16 +66,16 @@ public class AppBar extends Section implements ISetup {
 
     @Override
     public void setup(Field field) {
-        if(!fieldHasAnnotation(field, JAppBar.class, AppBar.class)) {
+        if (!fieldHasAnnotation(field, JAppBar.class, AppBar.class)) {
             return;
         }
         JAppBar jAppBar = field.getAnnotation(JAppBar.class);
-        if(isNotBlank(jAppBar.root())) {
+        if (isNotBlank(jAppBar.root())) {
             core().setLocator(NAME_TO_LOCATOR.execute(jAppBar.root()));
             this.navigationButtonLocator = NAME_TO_LOCATOR.execute(jAppBar.navigationButton());
             this.titleLocator = NAME_TO_LOCATOR.execute(jAppBar.title());
             this.overflowMenuButtonLocator = NAME_TO_LOCATOR.execute(jAppBar.overflowMenuButton());
-            if(jAppBar.actionItems().length != 0) {
+            if (jAppBar.actionItems().length != 0) {
                 actionItemsLocators = new ArrayList<>();
                 Arrays.stream(jAppBar.actionItems())
                         .forEach(actionItem -> actionItemsLocators.add(NAME_TO_LOCATOR.execute(actionItem)));

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
@@ -14,7 +14,7 @@ public interface HasHelperText extends ICoreElement, IsText {
 
     @JDIAction("Get helper text")
     default String getHelperText() {
-        if(helperText().isDisplayed()) {
+        if (helperText().isDisplayed()) {
             return helperText().getText();
         } else {
             return null;


### PR DESCRIPTION
Added whitespaces to fix issues: 
 'if' is not followed by whitespace.
 '?' is not preceded with whitespace.
 '?' is not followed by whitespace.
 ':' is not preceded with whitespace.
 ':' is not followed by whitespace.
 'for' is not followed by whitespace.
 '=' is not preceded with whitespace.
 '=' is not followed by whitespace.
 '<' is not preceded with whitespace.
 '<' is not followed by whitespace.