### PR TITLE
Task 3955: Write Javadoc for TextField

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/MultilineTextField.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/MultilineTextField.java
@@ -4,8 +4,18 @@ import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 import com.epam.jdi.light.material.elements.inputs.TextField;
 import com.epam.jdi.light.ui.html.elements.common.TextArea;
 
+/**
+ * Represents multiline text field MUI component on GUI.
+ * This text field has textarea component that represents the input field.
+ *
+ * @see <a href="https://mui.com/components/text-fields/#multiline">Multiline Text Field MUI documentation</a>
+ * @see <a href="https://jdi-testing.github.io/jdi-light/material">MUI test page</a>
+ */
 public class MultilineTextField extends TextField {
 
+    /**
+     * Textarea that represents the input field of the text field.
+     */
     @UI("//textarea[1]")
     public TextArea textArea;
 

--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/SelectTextField.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/SelectTextField.java
@@ -24,7 +24,7 @@ public class SelectTextField extends TextField {
      */
     @JDIAction("Get '{name}' select")
     public Select select() {
-        return new Select().setCore(Select.class, find(".MuiInputBase-root"));
+        return new Select().setCore(Select.class, core().find(".MuiInputBase-root"));
     }
 
     /**
@@ -36,6 +36,6 @@ public class SelectTextField extends TextField {
      */
     @JDIAction("Get '{name}' dropdown")
     public Dropdown nativeSelect() {
-        return new Dropdown().setCore(Dropdown.class, find(".MuiInputBase-root"));
+        return new Dropdown().setCore(Dropdown.class, core().find(".MuiInputBase-root"));
     }
 }

--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/SelectTextField.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/SelectTextField.java
@@ -6,8 +6,10 @@ import com.epam.jdi.light.material.elements.inputs.Select;
 import com.epam.jdi.light.material.elements.inputs.TextField;
 
 /**
- * Represents select text field MUI component on GUI.
- * This text field uses the Select component internally.
+ * Represents select text field MUI component on GUI. This text field uses the Select component internally.
+ * Select text field might be of two types: select and native select.
+ * Whereas native select text field uses HTML tags &lt;select&gt; and &lt;option&gt;,
+ * default select text field uses &lt;ul&gt; and &lt;li&gt;.
  *
  * @see <a href="https://mui.com/components/text-fields/#select">Select Text Field MUI documentation</a>
  * @see <a href="https://jdi-testing.github.io/jdi-light/material">MUI test page</a>
@@ -15,8 +17,8 @@ import com.epam.jdi.light.material.elements.inputs.TextField;
 public class SelectTextField extends TextField {
 
     /**
-     * Gets the inner Select component. It doesn't work for the native Select.
-     * For native select you should use {@link SelectTextField#nativeSelect()}
+     * Gets the inner Select component that uses HTML tags &lt;ul&gt; and &lt;li&gt;.
+     * For native select use {@link SelectTextField#nativeSelect()}
      *
      * @return select component as {@link Select}
      */
@@ -26,7 +28,9 @@ public class SelectTextField extends TextField {
     }
 
     /**
-     * Gets the inner Native Select component. You should use it for the native Select.
+     * Gets the inner native Select component as {@link Dropdown} since native select looks like default
+     * {@link Dropdown} element and uses HTML tags &lt;select&gt; and &lt;option&gt;.
+     * It should be used for the native Select.
      *
      * @return native select component as {@link Dropdown}
      */

--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/SelectTextField.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/custom/elements/textfields/SelectTextField.java
@@ -5,15 +5,33 @@ import com.epam.jdi.light.elements.complex.dropdown.Dropdown;
 import com.epam.jdi.light.material.elements.inputs.Select;
 import com.epam.jdi.light.material.elements.inputs.TextField;
 
+/**
+ * Represents select text field MUI component on GUI.
+ * This text field uses the Select component internally.
+ *
+ * @see <a href="https://mui.com/components/text-fields/#select">Select Text Field MUI documentation</a>
+ * @see <a href="https://jdi-testing.github.io/jdi-light/material">MUI test page</a>
+ */
 public class SelectTextField extends TextField {
 
+    /**
+     * Gets the inner Select component. It doesn't work for the native Select.
+     * For native select you should use {@link SelectTextField#nativeSelect()}
+     *
+     * @return select component as {@link Select}
+     */
     @JDIAction("Get '{name}' select")
     public Select select() {
         return new Select().setCore(Select.class, find(".MuiInputBase-root"));
     }
 
+    /**
+     * Gets the inner Native Select component. You should use it for the native Select.
+     *
+     * @return native select component as {@link Dropdown}
+     */
     @JDIAction("Get '{name}' dropdown")
-    public Dropdown dropdown() {
+    public Dropdown nativeSelect() {
         return new Dropdown().setCore(Dropdown.class, find(".MuiInputBase-root"));
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
@@ -1,14 +1,23 @@
 package io.github.epam.enums;
 
+/**
+ * Contains named constants representing currencies (i.e. USD, EUR, BTC, JPY).
+ * Each constant includes information about its symbol.
+ */
 public enum Currency {
   USD("$"),
   EUR("€"),
   BTC("฿"),
   JPY("¥");
 
-  public final String value;
+  private final String value;
 
   Currency(String currencyItemText) {
     this.value = currencyItemText;
+  }
+
+  @Override
+  public String toString() {
+    return value;
   }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
@@ -16,6 +16,11 @@ public enum Currency {
     this.value = currencyItemText;
   }
 
+  /**
+   * Gets currency symbol (e.g. "$", "€").
+   *
+   * @return currency symbol as {@link String}
+   */
   @Override
   public String toString() {
     return value;

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
@@ -10,12 +10,19 @@ public enum Currency {
   BTC("฿"),
   JPY("¥");
 
-  /**
-   * Currency symbol (e.g. "$", "€").
-   */
-  public final String value;
+  private final String value;
 
   Currency(String currencyItemSymbol) {
     this.value = currencyItemSymbol;
+  }
+
+  /**
+   * Gets currency symbol (e.g. "$", "€").
+   *
+   * @return currency symbol as {@link String}
+   */
+  @Override
+  public String toString() {
+    return value;
   }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/enums/Currency.java
@@ -10,19 +10,12 @@ public enum Currency {
   BTC("฿"),
   JPY("¥");
 
-  private final String value;
-
-  Currency(String currencyItemText) {
-    this.value = currencyItemText;
-  }
-
   /**
-   * Gets currency symbol (e.g. "$", "€").
-   *
-   * @return currency symbol as {@link String}
+   * Currency symbol (e.g. "$", "€").
    */
-  @Override
-  public String toString() {
-    return value;
+  public final String value;
+
+  Currency(String currencyItemSymbol) {
+    this.value = currencyItemSymbol;
   }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
@@ -106,7 +106,7 @@ public class TextFieldTests extends TestsInit {
         searchTextField.show();
 
         searchTextField.has().type("search")
-            .and().placeholder().and().placeholderText("Search field");
+            .and().placeholderText("Search field");
 
         searchTextField.click();
         searchTextField.is().focused();
@@ -139,7 +139,8 @@ public class TextFieldTests extends TestsInit {
         TextField validationTextField = validationTextFields.get(1);
         validationTextField.show();
 
-        validationTextField.has().text(HELLO_WORLD).and().is().validationError();
+        validationTextField.has().text(HELLO_WORLD);
+        validationTextField.label().has().cssClass("Mui-error");
 
         validationTextField.click();
         validationTextField.is().focused();
@@ -148,7 +149,7 @@ public class TextFieldTests extends TestsInit {
         validationTextField.is().empty();
 
         validationTextFields.get(2).click();
-        validationTextField.has().placeholder().and().placeholderText("Error");
+        validationTextField.has().placeholderText("Error");
 
         validationTextField.sendKeys(randomString);
         validationTextField.has().text(randomString);
@@ -169,7 +170,7 @@ public class TextFieldTests extends TestsInit {
         validationTextFieldWithHelper.is().empty();
 
         validationTextFields.get(1).click();
-        validationTextFieldWithHelper.has().placeholder().and().placeholderText("Error");
+        validationTextFieldWithHelper.has().placeholderText("Error");
 
         validationTextFieldWithHelper.sendKeys(randomString);
         validationTextFieldWithHelper.has().text(randomString).and().helperText("Incorrect entry.");
@@ -200,7 +201,7 @@ public class TextFieldTests extends TestsInit {
         MultilineTextField textareaTextField = multilineTextFields.get(2);
         textareaTextField.show();
 
-        textareaTextField.has().placeholder().and().placeholderText("Multiline Placeholder");
+        textareaTextField.has().placeholderText("Multiline Placeholder");
 
         textareaTextField.click();
         textareaTextField.has().placeholderText("Placeholder")
@@ -262,7 +263,7 @@ public class TextFieldTests extends TestsInit {
         passwordAdornmentTextField.show();
 
         passwordAdornmentTextField.adornment().has().position(Position.END);
-        passwordAdornmentTextField.has().placeholder().and().type("password");
+        passwordAdornmentTextField.has().type("password").and().placeholderText("Password");
 
         passwordAdornmentTextField.click();
         passwordAdornmentTextField.is().focused();

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
@@ -283,7 +283,7 @@ public class TextFieldTests extends TestsInit {
         TextField amountAdornmentTextField = inputAdornmentsTextFields.get(4);
         amountAdornmentTextField.show();
 
-        amountAdornmentTextField.adornment().has().position(Position.START).and().text(Currency.USD.value);
+        amountAdornmentTextField.adornment().has().position(Position.START).and().text(Currency.USD.toString());
         amountAdornmentTextField.label().has().text("Amount");
         amountAdornmentTextField.has().type("text");
 

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
@@ -282,7 +282,7 @@ public class TextFieldTests extends TestsInit {
         TextField amountAdornmentTextField = inputAdornmentsTextFields.get(4);
         amountAdornmentTextField.show();
 
-        amountAdornmentTextField.adornment().has().position(Position.START).and().text(Currency.USD.value);
+        amountAdornmentTextField.adornment().has().position(Position.START).and().text(Currency.USD.toString());
         amountAdornmentTextField.label().has().text("Amount");
         amountAdornmentTextField.has().type("text");
 
@@ -316,8 +316,8 @@ public class TextFieldTests extends TestsInit {
         selectNativeTextField.has().helperText("Please select your currency");
         for (Currency currency : Currency.values()) {
             selectNativeTextField.click();
-            selectNativeTextField.dropdown().select(currency.ordinal() + 1);
-            selectNativeTextField.dropdown().has().selected(currency);
+            selectNativeTextField.nativeSelect().select(currency.ordinal() + 1);
+            selectNativeTextField.nativeSelect().has().selected(currency);
         }
     }
 }

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/inputs/TextFieldTests.java
@@ -283,7 +283,7 @@ public class TextFieldTests extends TestsInit {
         TextField amountAdornmentTextField = inputAdornmentsTextFields.get(4);
         amountAdornmentTextField.show();
 
-        amountAdornmentTextField.adornment().has().position(Position.START).and().text(Currency.USD.toString());
+        amountAdornmentTextField.adornment().has().position(Position.START).and().text(Currency.USD.value);
         amountAdornmentTextField.label().has().text("Amount");
         amountAdornmentTextField.has().type("text");
 

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/AdornmentAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/AdornmentAssert.java
@@ -10,6 +10,9 @@ import org.hamcrest.Matchers;
 
 import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
+/**
+ * Assertions for {@link Adornment}
+ */
 public class AdornmentAssert extends UIAssert<AdornmentAssert, Adornment> implements ITextAssert<AdornmentAssert> {
 
     @Override
@@ -19,6 +22,12 @@ public class AdornmentAssert extends UIAssert<AdornmentAssert, Adornment> implem
         return this;
     }
 
+    /**
+     * Checks that the adornment has given position.
+     *
+     * @param position expected adornment position
+     * @return this {@link AdornmentAssert} instance
+     */
     @JDIAction("Assert that '{name}' adornment has position '{0}'")
     public AdornmentAssert position(Position position) {
         jdiAssert(element().position(), Matchers.is(position));

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/TextFieldAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/TextFieldAssert.java
@@ -21,13 +21,6 @@ public class TextFieldAssert extends UIAssert<TextFieldAssert, TextField> implem
         return this;
     }
 
-    @Override
-    @JDIAction("Assert that '{name}' is empty")
-    public TextFieldAssert empty() {
-        jdiAssert(element().isEmpty() ? "is empty" : "is not empty", Matchers.is("is empty"));
-        return this;
-    }
-
     /**
      * Checks that text field is readonly.
      *

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/TextFieldAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/TextFieldAssert.java
@@ -51,26 +51,14 @@ public class TextFieldAssert extends UIAssert<TextFieldAssert, TextField> implem
      */
     @JDIAction("Assert that '{name}' helper text {0}")
     public TextFieldAssert helperText(Matcher<String> condition) {
-        jdiAssert(element().getHelperText(), condition);
-        return this;
-    }
-
-    /**
-     * Checks that text field has placeholder.
-     *
-     * @return this {@link TextFieldAssert} instance
-     */
-    @JDIAction("Assert that '{name}' has placeholder")
-    public TextFieldAssert placeholder() {
-        jdiAssert(element().hasPlaceholder() ? "has placeholder" : "does not have placeholder",
-            Matchers.is("has placeholder"));
+        jdiAssert(element().helperText().text(), condition);
         return this;
     }
 
     /**
      * Checks that text field has given placeholder text.
      *
-     * @param text expected helper text
+     * @param text expected placeholder text
      * @return this {@link TextFieldAssert} instance
      */
     @JDIAction("Assert that '{name}' placeholder text is '{0}'")
@@ -86,12 +74,12 @@ public class TextFieldAssert extends UIAssert<TextFieldAssert, TextField> implem
      */
     @JDIAction("Assert that '{name}' placeholder text {0}")
     public TextFieldAssert placeholderText(Matcher<String> condition) {
-        jdiAssert(element().getPlaceHolderText(), condition);
+        jdiAssert(element().placeHolderText(), condition);
         return this;
     }
 
     /**
-     * Checks that text field his focused.
+     * Checks that text field is focused.
      *
      * @return this {@link TextFieldAssert} instance
      */
@@ -131,7 +119,7 @@ public class TextFieldAssert extends UIAssert<TextFieldAssert, TextField> implem
      */
     @JDIAction("Assert that '{name}' has error notification")
     public TextFieldAssert validationError() {
-        jdiAssert(element().hasValidationError() ? "has validation error" : "does not have validation error",
+        jdiAssert(element().isValidationErrorPresent() ? "has validation error" : "does not have validation error",
             Matchers.is("has validation error"));
         return this;
     }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/TextFieldAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/inputs/TextFieldAssert.java
@@ -9,7 +9,11 @@ import com.epam.jdi.light.material.elements.inputs.TextField;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
+/**
+ * Assertions for {@link TextField}
+ */
 public class TextFieldAssert extends UIAssert<TextFieldAssert, TextField> implements ITextAssert<TextFieldAssert> {
+
     @Override
     @JDIAction("Assert that '{name}' label text {0}")
     public TextFieldAssert text(Matcher<String> condition) {
@@ -24,23 +28,45 @@ public class TextFieldAssert extends UIAssert<TextFieldAssert, TextField> implem
         return this;
     }
 
+    /**
+     * Checks that text field is readonly.
+     *
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' is readonly")
     public TextFieldAssert readonly() {
         jdiAssert(element().isReadonly() ? "is readonly" : "is not readonly", Matchers.is("is readonly"));
         return this;
     }
 
+    /**
+     * Checks that text field has given helper text.
+     *
+     * @param text expected helper text
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' helper text is '{0}'")
     public TextFieldAssert helperText(String text) {
         return helperText(Matchers.is(text));
     }
 
+    /**
+     * Checks that text field helper text meets the given condition.
+     *
+     * @param condition expected condition
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' helper text {0}")
     public TextFieldAssert helperText(Matcher<String> condition) {
         jdiAssert(element().getHelperText(), condition);
         return this;
     }
 
+    /**
+     * Checks that text field has placeholder.
+     *
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' has placeholder")
     public TextFieldAssert placeholder() {
         jdiAssert(element().hasPlaceholder() ? "has placeholder" : "does not have placeholder",
@@ -48,34 +74,68 @@ public class TextFieldAssert extends UIAssert<TextFieldAssert, TextField> implem
         return this;
     }
 
+    /**
+     * Checks that text field has given placeholder text.
+     *
+     * @param text expected helper text
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' placeholder text is '{0}'")
     public TextFieldAssert placeholderText(String text) {
         return placeholderText(Matchers.is(text));
     }
 
+    /**
+     * Checks that text field placeholder text meets the given condition.
+     *
+     * @param condition expected condition
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' placeholder text {0}")
     public TextFieldAssert placeholderText(Matcher<String> condition) {
         jdiAssert(element().getPlaceHolderText(), condition);
         return this;
     }
 
+    /**
+     * Checks that text field his focused.
+     *
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' is focused")
     public TextFieldAssert focused() {
         jdiAssert(element().isFocused() ? "is focused" : "is not focused", Matchers.is("is focused"));
         return this;
     }
 
+    /**
+     * Checks that text field has given type.
+     *
+     * @param type expected text field type
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' type is '{0}'")
     public TextFieldAssert type(String type) {
         return type(Matchers.is(type));
     }
 
+    /**
+     * Checks that text field type meets the given condition.
+     *
+     * @param condition expected condition
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' type {0}")
     public TextFieldAssert type(Matcher<String> condition) {
         jdiAssert(element().type(), condition);
         return this;
     }
 
+    /**
+     * Checks that text field has validation error.
+     *
+     * @return this {@link TextFieldAssert} instance
+     */
     @JDIAction("Assert that '{name}' has error notification")
     public TextFieldAssert validationError() {
         jdiAssert(element().hasValidationError() ? "has validation error" : "does not have validation error",

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
@@ -14,7 +14,7 @@ import static com.epam.jdi.light.common.Exceptions.runtimeException;
 /**
  * Represents an adornment.
  * Adornment can be used to add a prefix, a suffix, or an action to an input.
- * For instance, you can use an icon button to hide or reveal the password.
+ * For example, it can be an icon button that hides or reveals the password.
  *
  * @see <a href="https://mui.com/api/input-adornment/">InputAdornment API MUI documentation</a>
  */
@@ -46,6 +46,11 @@ public class Adornment extends UIBaseElement<AdornmentAssert> implements IsButto
         return new Button().setCore(Button.class, find("button"));
     }
 
+    /**
+     * Clicks the button in the adornment.
+     *
+     * @throws RuntimeException if the adornment doesn't contain button
+     */
     @Override
     @JDIAction("Click on '{name}'")
     public void click() {

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
@@ -11,19 +11,27 @@ import java.util.Arrays;
 
 import static com.epam.jdi.light.common.Exceptions.runtimeException;
 
-public class Adornment extends UIBaseElement<AdornmentAssert>
-        implements IsButton {
+/**
+ * Represents an adornment.
+ * Adornment can be used to add a prefix, a suffix, or an action to an input.
+ * For instance, you can use an icon button to hide or reveal the password.
+ *
+ * @see <a href="https://mui.com/api/input-adornment/">InputAdornment API MUI documentation</a>
+ */
+public class Adornment extends UIBaseElement<AdornmentAssert> implements IsButton {
 
     @Override
-    @JDIAction("Get '{name}'s text")
+    @JDIAction("Get '{name}' text")
     public String getText() {
         return find("p").getText();
     }
 
     /**
-     * Method 'position' will return one of two possible positions of the adornment: 'start' or 'end'.
+     * Gets one of two possible positions of the adornment: 'start' or 'end'.
+     *
+     * @return adornment position as {@link Position}
      */
-    @JDIAction("Get '{name}'s position")
+    @JDIAction("Get '{name}' position")
     public Position position() {
         String position =  Arrays.stream(attr("class")
                         .split("[^a-zA-Z0-9]"))
@@ -39,7 +47,7 @@ public class Adornment extends UIBaseElement<AdornmentAssert>
     }
 
     @Override
-    @JDIAction("Click on adornment")
+    @JDIAction("Click on '{name}'")
     public void click() {
         if (getButton().isDisplayed()) {
             getButton().click();
@@ -57,5 +65,4 @@ public class Adornment extends UIBaseElement<AdornmentAssert>
     public AdornmentAssert has() {
         return is();
     }
-
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
@@ -5,11 +5,8 @@ import com.epam.jdi.light.elements.base.UIBaseElement;
 import com.epam.jdi.light.elements.interfaces.common.IsButton;
 import com.epam.jdi.light.material.asserts.inputs.AdornmentAssert;
 import com.epam.jdi.light.material.elements.utils.enums.Position;
-import com.epam.jdi.light.ui.html.elements.common.Button;
 
 import java.util.Arrays;
-
-import static com.epam.jdi.light.common.Exceptions.runtimeException;
 
 /**
  * Represents an adornment.
@@ -40,25 +37,6 @@ public class Adornment extends UIBaseElement<AdornmentAssert> implements IsButto
                 .replace("position", "")
                 .toLowerCase();
         return Position.fromString(position);
-    }
-
-    private Button getButton() {
-        return new Button().setCore(Button.class, find("button"));
-    }
-
-    /**
-     * Clicks the button in the adornment.
-     *
-     * @throws RuntimeException if the adornment doesn't contain button
-     */
-    @Override
-    @JDIAction("Click on '{name}'")
-    public void click() {
-        if (getButton().isDisplayed()) {
-            getButton().click();
-        } else {
-            throw runtimeException("Adornment does not contain button");
-        }
     }
 
     @Override

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
@@ -20,7 +20,7 @@ public class Adornment extends UIBaseElement<AdornmentAssert> implements IsButto
     @Override
     @JDIAction("Get '{name}' text")
     public String getText() {
-        return find("p").getText();
+        return core().find("p").getText();
     }
 
     /**

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/Adornment.java
@@ -60,9 +60,4 @@ public class Adornment extends UIBaseElement<AdornmentAssert> implements IsButto
     public AdornmentAssert is() {
         return new AdornmentAssert().set(this);
     }
-
-    @Override
-    public AdornmentAssert has() {
-        return is();
-    }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
@@ -29,21 +29,14 @@ public class TextField extends UIBaseElement<TextFieldAssert>
         HasHelperText, HasValidationError, HasPlaceholder, HasLabel, CanBeDisabled {
 
     /**
-     * Gets the input field of the text field by searching by the tag "input".
+     * Gets the input field of the text field.
      *
      * @return input field as {@link IsInput}
-     * @see IsInput
      */
     protected IsInput inputField() {
         return find("input");
     }
 
-    /**
-     * Gets the label of the text field by searching by the tag "label".
-     *
-     * @return input field as {@link Label}
-     * @see Label
-     */
     @Override
     @JDIAction("Get '{name}' label")
     public Label label() {
@@ -98,7 +91,7 @@ public class TextField extends UIBaseElement<TextFieldAssert>
     }
 
     /**
-     * Checks if the input field is readonly or not (e.g. can be edited or not).
+     * Checks if the input field is readonly or not (i.e. can be edited or not).
      *
      * @return {@code true} if the input field is readonly, otherwise {@code false}
      */
@@ -124,7 +117,7 @@ public class TextField extends UIBaseElement<TextFieldAssert>
     }
 
     /**
-     * Gets the type of the input field (e.g. password, text, number, search)
+     * Gets the type of the input field (e.g. password, text, number, search).
      *
      * @return the type of the input field as {@link String}
      */

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
@@ -19,18 +19,31 @@ import com.epam.jdi.light.material.interfaces.inputs.HasValidationError;
 import org.openqa.selenium.Keys;
 
 /**
- * To see examples of Text Field web elements please visit
- * https://mui.com/components/text-fields/
+ * Represents text field MUI component on GUI.
+ *
+ * @see <a href="https://mui.com/components/text-fields/">Text Field MUI documentation</a>
+ * @see <a href="https://jdi-testing.github.io/jdi-light/material">MUI test page</a>
  */
-
 public class TextField extends UIBaseElement<TextFieldAssert>
         implements IsInput, HasClick, HasAdornment, CanBeFocused,
         HasHelperText, HasValidationError, HasPlaceholder, HasLabel, CanBeDisabled {
 
+    /**
+     * Gets the input field of the text field by searching by the tag "input".
+     *
+     * @return input field as {@link IsInput}
+     * @see IsInput
+     */
     protected IsInput inputField() {
         return find("input");
     }
 
+    /**
+     * Gets the label of the text field by searching by the tag "label".
+     *
+     * @return input field as {@link Label}
+     * @see Label
+     */
     @Override
     @JDIAction("Get '{name}' label")
     public Label label() {
@@ -49,6 +62,13 @@ public class TextField extends UIBaseElement<TextFieldAssert>
         inputField().setText(value);
     }
 
+    /**
+     * Clears the input field of the text field by selecting all text and removing it.
+     * For macOS the keys that are used for it are 'COMMAND + A + BACK_SPACE'.
+     * For Windows it is 'CONTROL + A + DELETE'.
+     *
+     * @see IsInput
+     */
     @Override
     @JDIAction("Clear '{name}' text field")
     public void clear() {
@@ -77,6 +97,11 @@ public class TextField extends UIBaseElement<TextFieldAssert>
         return !isDisabled();
     }
 
+    /**
+     * Checks if the input field is readonly or not (e.g. can be edited or not).
+     *
+     * @return {@code true} if the input field is readonly, otherwise {@code false}
+     */
     @JDIAction("Check that '{name}' is readonly")
     public boolean isReadonly() {
         return inputField().hasAttribute("readonly");
@@ -98,6 +123,11 @@ public class TextField extends UIBaseElement<TextFieldAssert>
         return inputField().getText();
     }
 
+    /**
+     * Gets the type of the input field (e.g. password, text, number, search)
+     *
+     * @return the type of the input field as {@link String}
+     */
     @JDIAction("Get '{name}' type")
     public String type() {
         return inputField().attr("type");

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
@@ -36,13 +36,13 @@ public class TextField extends UIBaseElement<TextFieldAssert>
      * @return input field as {@link IsInput}
      */
     protected IsInput inputField() {
-        return find("input");
+        return core().find("input");
     }
 
     @Override
     @JDIAction("Get '{name}' label")
     public Label label() {
-        return new Label().setCore(Label.class, find("label"));
+        return new Label().setCore(Label.class, core().find("label"));
     }
 
     @Override
@@ -76,7 +76,7 @@ public class TextField extends UIBaseElement<TextFieldAssert>
     @Override
     @JDIAction("Check that '{name}' is disabled")
     public boolean isDisabled() {
-        return label().hasClass("Mui-disabled");
+        return label().core().hasClass("Mui-disabled");
     }
 
     @Override
@@ -92,7 +92,7 @@ public class TextField extends UIBaseElement<TextFieldAssert>
      */
     @JDIAction("Check that '{name}' is readonly")
     public boolean isReadonly() {
-        return inputField().hasAttribute("readonly");
+        return inputField().core().hasAttribute("readonly");
     }
 
     @Override
@@ -108,17 +108,17 @@ public class TextField extends UIBaseElement<TextFieldAssert>
      */
     @JDIAction("Get '{name}' type")
     public String type() {
-        return inputField().attr("type");
+        return inputField().core().attr("type");
     }
 
     @Override
     @JDIAction("Get '{name}' placeholder text")
     public String placeHolderText() {
         String res = null;
-        if (label().attr("data-shrink").equals("false")) {
+        if (label().core().attr("data-shrink").equals("false")) {
             res = label().getText();
-        } else if (inputField().hasAttribute("placeholder")) {
-            res = inputField().attr("placeholder");
+        } else if (inputField().core().hasAttribute("placeholder")) {
+            res = inputField().core().attr("placeholder");
         }
         return res;
     }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/inputs/TextField.java
@@ -20,6 +20,8 @@ import org.openqa.selenium.Keys;
 
 /**
  * Represents text field MUI component on GUI.
+ * The TextField wrapper component is a complete form control that can contain
+ * a label, input, helper text, placeholder and adornment.
  *
  * @see <a href="https://mui.com/components/text-fields/">Text Field MUI documentation</a>
  * @see <a href="https://jdi-testing.github.io/jdi-light/material">MUI test page</a>
@@ -55,13 +57,6 @@ public class TextField extends UIBaseElement<TextFieldAssert>
         inputField().setText(value);
     }
 
-    /**
-     * Clears the input field of the text field by selecting all text and removing it.
-     * For macOS the keys that are used for it are 'COMMAND + A + BACK_SPACE'.
-     * For Windows it is 'CONTROL + A + DELETE'.
-     *
-     * @see IsInput
-     */
     @Override
     @JDIAction("Clear '{name}' text field")
     public void clear() {
@@ -101,16 +96,6 @@ public class TextField extends UIBaseElement<TextFieldAssert>
     }
 
     @Override
-    @JDIAction("Check that '{name}' has placeholder")
-    public boolean hasPlaceholder() {
-        if (label().attr("data-shrink").equals("false")) {
-            return true;
-        } else {
-            return inputField().hasAttribute("placeholder");
-        }
-    }
-
-    @Override
     @JDIAction("Get '{name}' text area text")
     public String getText() {
         return inputField().getText();
@@ -128,14 +113,12 @@ public class TextField extends UIBaseElement<TextFieldAssert>
 
     @Override
     @JDIAction("Get '{name}' placeholder text")
-    public String getPlaceHolderText() {
+    public String placeHolderText() {
         String res = null;
-        if (hasPlaceholder()) {
-            if (label().attr("data-shrink").equals("false")) {
-                res = label().getText();
-            } else {
-                res = inputField().attr("placeholder");
-            }
+        if (label().attr("data-shrink").equals("false")) {
+            res = label().getText();
+        } else if (inputField().hasAttribute("placeholder")) {
+            res = inputField().attr("placeholder");
         }
         return res;
     }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/utils/enums/Position.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/utils/enums/Position.java
@@ -2,37 +2,46 @@ package com.epam.jdi.light.material.elements.utils.enums;
 
 import static com.epam.jdi.light.common.Exceptions.runtimeException;
 
+/**
+ * Contains named constants representing element positions.
+ * Each constant includes information about its string representation.
+ */
 public enum Position {
-  TOP("top"),
-  BOTTOM("bottom"),
-  LEFT("left"),
-  RIGHT("right"),
-  END("end"),
-  START("start"),
-  TOP_RIGHT("TopRight"),
-  TOP_LEFT("TopLeft"),
-  TOP_CENTER("TopCenter"),
-  BOTTOM_CENTER("BottomCenter"),
-  BOTTOM_RIGHT("BottomRight"),
-  BOTTOM_LEFT("BottomLeft");
+    TOP("top"),
+    BOTTOM("bottom"),
+    LEFT("left"),
+    RIGHT("right"),
+    END("end"),
+    START("start"),
+    TOP_RIGHT("TopRight"),
+    TOP_LEFT("TopLeft"),
+    TOP_CENTER("TopCenter"),
+    BOTTOM_CENTER("BottomCenter"),
+    BOTTOM_RIGHT("BottomRight"),
+    BOTTOM_LEFT("BottomLeft");
 
-  private final String value;
+    private final String value;
 
-  @Override
-  public String toString() {
-    return value;
-  }
-
-  Position(String value) {
-    this.value = value.toLowerCase();
-  }
-
-  public static Position fromString(String text) {
-    for (Position b : Position.values()) {
-      if (b.value.equalsIgnoreCase(text)) {
-        return b;
-      }
+    Position(String value) {
+        this.value = value.toLowerCase();
     }
-    throw runtimeException(String.format("No appropriate %s constant found for value '%s'", Position.class.getName(), text));
-  }
+
+    /**
+     * Gets {@link Position} named constant from the given string.
+     *
+     * @return position as {@link Position}
+     */
+    public static Position fromString(String text) {
+        for (Position b : Position.values()) {
+            if (b.value.equalsIgnoreCase(text)) {
+                return b;
+            }
+        }
+        throw runtimeException(String.format("No appropriate %s constant found for value '%s'", Position.class.getName(), text));
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/utils/enums/Position.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/utils/enums/Position.java
@@ -13,12 +13,12 @@ public enum Position {
     RIGHT("right"),
     END("end"),
     START("start"),
-    TOP_RIGHT("TopRight"),
-    TOP_LEFT("TopLeft"),
-    TOP_CENTER("TopCenter"),
-    BOTTOM_CENTER("BottomCenter"),
-    BOTTOM_RIGHT("BottomRight"),
-    BOTTOM_LEFT("BottomLeft");
+    TOP_RIGHT("topRight"),
+    TOP_LEFT("topLeft"),
+    TOP_CENTER("topCenter"),
+    BOTTOM_CENTER("bottomCenter"),
+    BOTTOM_RIGHT("bottomRight"),
+    BOTTOM_LEFT("bottomLeft");
 
     private final String value;
 
@@ -30,6 +30,7 @@ public enum Position {
      * Gets {@link Position} named constant from the given string.
      *
      * @return position as {@link Position}
+     * @throws RuntimeException if no appropriate constant found for given value
      */
     public static Position fromString(String text) {
         for (Position b : Position.values()) {
@@ -40,6 +41,11 @@ public enum Position {
         throw runtimeException(String.format("No appropriate %s constant found for value '%s'", Position.class.getName(), text));
     }
 
+    /**
+     * Gets string representation of element position in CamelCase (e.g. "bottom", "bottomLeft").
+     *
+     * @return element position as {@link String}
+     */
     @Override
     public String toString() {
         return value;

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/CanBeFocused.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/CanBeFocused.java
@@ -3,6 +3,13 @@ package com.epam.jdi.light.material.interfaces.inputs;
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
+/**
+ * Represents an element that can be checked to see if it's focused.
+ *
+ * @see <a href="https://mui.com/customization/how-to-customize/#state-classes">
+ *     State classes MUI Documentation
+ *     </a>
+ */
 public interface CanBeFocused extends ICoreElement {
 
     /**

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/CanBeFocused.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/CanBeFocused.java
@@ -5,9 +5,13 @@ import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
 public interface CanBeFocused extends ICoreElement {
 
-    @JDIAction("Is '{name}' focused")
+    /**
+     * Checks if the element is focused or not.
+     *
+     * @return {@code true} if the element is focused, otherwise {@code false}
+     */
+    @JDIAction("Check that '{name}' is focused")
     default boolean isFocused() {
-        return find(".Mui-focused").isDisplayed();
+        return core().find(".Mui-focused").isDisplayed();
     }
-
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasAdornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasAdornment.java
@@ -6,10 +6,17 @@ import com.epam.jdi.light.material.elements.inputs.Adornment;
 import java.util.List;
 import java.util.stream.Collectors;
 
+/**
+ * Represents an element that has an {@link Adornment}.
+ *
+ * @see <a href="https://mui.com/customization/how-to-customize/#state-classes">
+ *     State classes MUI Documentation
+ *     </a>
+ */
 public interface HasAdornment extends ICoreElement {
 
     /**
-     * Gets adornment of the element by searching by the class "MuiInputAdornment-root".
+     * Gets adornment of the element.
      *
      * @return adornment as {@link Adornment}
      * @see Adornment
@@ -19,7 +26,7 @@ public interface HasAdornment extends ICoreElement {
     }
 
     /**
-     * Gets the list of adornments of the element by searching by the class "MuiInputAdornment-root".
+     * Gets the list of adornments of the element.
      * If there are no adornments, an empty list is returned.
      *
      * @return list of adornments as {@link List}

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasAdornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasAdornment.java
@@ -8,10 +8,23 @@ import java.util.stream.Collectors;
 
 public interface HasAdornment extends ICoreElement {
 
+    /**
+     * Gets adornment of the element by searching by the class "MuiInputAdornment-root".
+     *
+     * @return adornment as {@link Adornment}
+     * @see Adornment
+     */
     default Adornment adornment() {
         return new Adornment().setCore(Adornment.class, find(".MuiInputAdornment-root"));
     }
 
+    /**
+     * Gets the list of adornments of the element by searching by the class "MuiInputAdornment-root".
+     * If there are no adornments, an empty list is returned.
+     *
+     * @return list of adornments as {@link List}
+     * @see Adornment
+     */
     default List<Adornment> adornments() {
         return finds(".MuiInputAdornment-root").stream()
                 .map(element -> element.setCore(Adornment.class, element))

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasAdornment.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasAdornment.java
@@ -22,7 +22,7 @@ public interface HasAdornment extends ICoreElement {
      * @see Adornment
      */
     default Adornment adornment() {
-        return new Adornment().setCore(Adornment.class, find(".MuiInputAdornment-root"));
+        return new Adornment().setCore(Adornment.class, core().find(".MuiInputAdornment-root"));
     }
 
     /**
@@ -33,7 +33,7 @@ public interface HasAdornment extends ICoreElement {
      * @see Adornment
      */
     default List<Adornment> adornments() {
-        return finds(".MuiInputAdornment-root").stream()
+        return core().finds(".MuiInputAdornment-root").stream()
                 .map(element -> element.setCore(Adornment.class, element))
                 .collect(Collectors.toList());
     }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
@@ -5,13 +5,18 @@ import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 import com.epam.jdi.light.elements.interfaces.common.IsText;
 import com.epam.jdi.light.ui.html.elements.common.Text;
 
+/**
+ * Represents an element with a helper text.
+ * Helper text gives context about an input, such as hint or error message.
+ *
+ * @see <a href="https://mui.com/api/form-helper-text/"> FormHelperText API MUI Documentation </a>
+ */
 public interface HasHelperText extends ICoreElement, IsText {
 
     /**
      * Gets the helper text of the element as an element.
      *
      * @return helper text as {@link Text}
-     * @see Text
      */
     @JDIAction("Get helper text element")
     default Text helperText() {

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
@@ -7,11 +7,22 @@ import com.epam.jdi.light.ui.html.elements.common.Text;
 
 public interface HasHelperText extends ICoreElement, IsText {
 
+    /**
+     * Gets the helper text of the element as an element.
+     *
+     * @return helper text as {@link Text}
+     * @see Text
+     */
     @JDIAction("Get helper text element")
     default Text helperText() {
         return new Text().setCore(Text.class, find("p.MuiFormHelperText-root"));
     }
 
+    /**
+     * Gets the helper text of the element as a string.
+     *
+     * @return helper text as {@link String}
+     */
     @JDIAction("Get helper text")
     default String getHelperText() {
         if (helperText().isDisplayed()) {

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
@@ -20,6 +20,6 @@ public interface HasHelperText extends ICoreElement, IsText {
      */
     @JDIAction("Get helper text")
     default Text helperText() {
-        return new Text().setCore(Text.class, find("p.MuiFormHelperText-root"));
+        return new Text().setCore(Text.class, core().find("p.MuiFormHelperText-root"));
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasHelperText.java
@@ -14,26 +14,12 @@ import com.epam.jdi.light.ui.html.elements.common.Text;
 public interface HasHelperText extends ICoreElement, IsText {
 
     /**
-     * Gets the helper text of the element as an element.
+     * Gets the helper text of the element.
      *
      * @return helper text as {@link Text}
      */
-    @JDIAction("Get helper text element")
+    @JDIAction("Get helper text")
     default Text helperText() {
         return new Text().setCore(Text.class, find("p.MuiFormHelperText-root"));
-    }
-
-    /**
-     * Gets the helper text of the element as a string.
-     *
-     * @return helper text as {@link String}
-     */
-    @JDIAction("Get helper text")
-    default String getHelperText() {
-        if (helperText().isDisplayed()) {
-            return helperText().getText();
-        } else {
-            return null;
-        }
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasPlaceholder.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasPlaceholder.java
@@ -5,7 +5,7 @@ import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 /**
  * Represents an element with a placeholder.
  * The placeholder attribute specifies a short hint that describes the expected value of an input field / textarea.
- * The short hint is displayed in the field before the user enters a value.
+ * The short hint is displayed within the field before the user enters a value.
  *
  * @see <a href="https://www.w3schools.com/tags/att_placeholder.asp#:~:text=The%20placeholder%20attribute%20specifies%20a,the%20user%20enters%20a%20value.">
  *     W3Schools - HTML placeholder Attribute
@@ -14,16 +14,9 @@ import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 public interface HasPlaceholder extends ICoreElement {
 
     /**
-     * Checks if the element has the placeholder or not.
-     *
-     * @return {@code true} if the element has the placeholder, otherwise {@code false}
-     */
-    boolean hasPlaceholder();
-
-    /**
-     * Gets the placeholder text of the element as a string.
+     * Gets the placeholder text of the element.
      *
      * @return placeholder text as {@link String}
      */
-    String getPlaceHolderText();
+    String placeHolderText();
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasPlaceholder.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasPlaceholder.java
@@ -2,6 +2,15 @@ package com.epam.jdi.light.material.interfaces.inputs;
 
 import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
+/**
+ * Represents an element with a placeholder.
+ * The placeholder attribute specifies a short hint that describes the expected value of an input field / textarea.
+ * The short hint is displayed in the field before the user enters a value.
+ *
+ * @see <a href="https://www.w3schools.com/tags/att_placeholder.asp#:~:text=The%20placeholder%20attribute%20specifies%20a,the%20user%20enters%20a%20value.">
+ *     W3Schools - HTML placeholder Attribute
+ *     </a>
+ */
 public interface HasPlaceholder extends ICoreElement {
 
     /**

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasPlaceholder.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasPlaceholder.java
@@ -4,7 +4,17 @@ import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
 public interface HasPlaceholder extends ICoreElement {
 
+    /**
+     * Checks if the element has the placeholder or not.
+     *
+     * @return {@code true} if the element has the placeholder, otherwise {@code false}
+     */
     boolean hasPlaceholder();
 
+    /**
+     * Gets the placeholder text of the element as a string.
+     *
+     * @return placeholder text as {@link String}
+     */
     String getPlaceHolderText();
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
@@ -5,9 +5,14 @@ import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
 public interface HasValidationError extends ICoreElement {
 
-    @JDIAction("Does '{name}' have error notification")
+    /**
+     * Checks if the element has the error notification or not.
+     * The error notification is searched by the class "Mui-error".
+     *
+     * @return {@code true} if the element has the error notification, otherwise {@code false}
+     */
+    @JDIAction("Check that '{name}' has the error notification")
     default boolean hasValidationError() {
         return find(".Mui-error").isDisplayed();
     }
-
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
@@ -19,6 +19,6 @@ public interface HasValidationError extends ICoreElement {
      */
     @JDIAction("Check that '{name}' has the error notification")
     default boolean isValidationErrorPresent() {
-        return find(".Mui-error").isDisplayed();
+        return core().find(".Mui-error").isDisplayed();
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
@@ -3,11 +3,17 @@ package com.epam.jdi.light.material.interfaces.inputs;
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
+/**
+ * Represents an element that can have error state.
+ *
+ * @see <a href="https://mui.com/customization/how-to-customize/#state-classes">
+ *     State classes MUI Documentation
+ *     </a>
+ */
 public interface HasValidationError extends ICoreElement {
 
     /**
      * Checks if the element has the error notification or not.
-     * The error notification is searched by the class "Mui-error".
      *
      * @return {@code true} if the element has the error notification, otherwise {@code false}
      */

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/inputs/HasValidationError.java
@@ -13,12 +13,12 @@ import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 public interface HasValidationError extends ICoreElement {
 
     /**
-     * Checks if the element has the error notification or not.
+     * Checks if the element has the present validation error notification or not.
      *
-     * @return {@code true} if the element has the error notification, otherwise {@code false}
+     * @return {@code true} if the validation error notification is present, otherwise {@code false}
      */
     @JDIAction("Check that '{name}' has the error notification")
-    default boolean hasValidationError() {
+    default boolean isValidationErrorPresent() {
         return find(".Mui-error").isDisplayed();
     }
 }


### PR DESCRIPTION
### Javadoc is written for:
- TextField
- Interfaces:
  - HasAdornment
    Connected classes:
    - Adornment
    - AdornmentAssert
  - CanBeFocused
  - HasHelperText
  - HasValidationError
  - HasPlaceholder
- TextFieldAssert
- MultilineTextField
- SelectTextField
- Enums (using in tests)
  - Currency
  - Position

### Changes in TextField:
- deleted `hasPlaceholder()`

### Changes in Adornment:
- deleted overriding of method `click()` 
- deleted private method `getButton()`
- deleted overriding of method `has()`

### Other changes:
- added usages of method `core()`
- HasPlaceholder: deleted `hasPlaceholder()`
- HasHelperText: deleted `getHelperText()`
- HasValidationError: renamed method to `isValidationErrorPresent()`