### PR TITLE
Task 3946: Write javadoc for drawer, list, box

### DIFF
--- a/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/layout/BoxPage.java
+++ b/jdi-light-material-ui-tests/src/main/java/io/github/com/pages/layout/BoxPage.java
@@ -6,6 +6,7 @@ import com.epam.jdi.light.ui.html.elements.common.Button;
 import com.epam.jdi.light.ui.html.elements.common.Text;
 
 public class BoxPage extends WebPage {
+
     @UI(".MuiButton-contained")
     public static Button buttonContainedBox;
 

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/MUIListTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/MUIListTests.java
@@ -7,6 +7,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -78,17 +79,22 @@ public class MUIListTests extends TestsInit {
     @Test
     public void checkboxListTests() {
         checkboxList.show();
-        java.util.List<MUIListItem> listItems = checkboxList.items();
+        List<MUIListItem> listItems = checkboxList.items();
+
         listItems.get(0).is().checked();
         listItems.get(0).checkbox().uncheck();
         listItems.get(0).is().unchecked();
-        listItems.get(0).button().click(); // should not affect primary checkbox
+
+        // should not affect primary checkbox
+        listItems.get(0).button().click();
         listItems.get(0).is().unchecked();
 
-        listItems.get(1).checkbox().check(); // checking item by interacting with checkbox
+        // checking item by interacting with checkbox
+        listItems.get(1).checkbox().check();
         listItems.get(1).is().checked();
 
-        listItems.get(2).click(); // checking item by clicking its primary area
+        // checking item by clicking its primary area
+        listItems.get(2).click();
         listItems.get(2).is().checked();
     }
 

--- a/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/MUIListTests.java
+++ b/jdi-light-material-ui-tests/src/test/java/io/github/epam/material/tests/displaydata/MUIListTests.java
@@ -82,7 +82,7 @@ public class MUIListTests extends TestsInit {
         listItems.get(0).is().checked();
         listItems.get(0).checkbox().uncheck();
         listItems.get(0).is().unchecked();
-        listItems.get(0).secondaryActionButton().click(); // should not affect primary checkbox
+        listItems.get(0).button().click(); // should not affect primary checkbox
         listItems.get(0).is().unchecked();
 
         listItems.get(1).checkbox().check(); // checking item by interacting with checkbox
@@ -99,9 +99,9 @@ public class MUIListTests extends TestsInit {
                 .collect(Collectors.toCollection(HashSet::new));
         listWithSwitch.has().itemsWithTexts(expectedItems);
         java.util.List<MUIListItem> listItems = listWithSwitch.items();
-        listItems.get(0).secondaryActionSwitch().is().checked();
-        listItems.get(0).secondaryActionSwitch().uncheck();
-        listItems.get(0).secondaryActionSwitch().is().unchecked();
+        listItems.get(0).getSwitch().is().checked();
+        listItems.get(0).getSwitch().uncheck();
+        listItems.get(0).getSwitch().is().unchecked();
     }
 
     @Test

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListAssert.java
@@ -57,7 +57,7 @@ public class MUIListAssert extends UIAssert<MUIListAssert, MUIList> {
      * @param itemTexts expected item texts to be contained in list
      * @return this {@link MUIListAssert} instance
      */
-    @JDIAction("Assert that '{name}' contains all items with texts specified in '{0}'")
+    @JDIAction("Assert that '{name}' contains all items with texts '{0}'")
     public MUIListAssert itemsWithTexts(Set<String> itemTexts) {
         if (itemTexts.isEmpty()) {
             throw new IllegalArgumentException("Set containing expected item names should not be empty");

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListAssert.java
@@ -12,34 +12,59 @@ import java.util.stream.Collectors;
 
 import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
+/**
+ * Assertions for {@link MUIList}.
+ */
 public class MUIListAssert extends UIAssert<MUIListAssert, MUIList> {
 
+    /**
+     * Checks that list has given size.
+     *
+     * @param size expected size
+     * @return this {@link MUIListAssert} instance
+     */
     @JDIAction("Assert that '{name}' has size {0}")
-    public MUIListAssert size(int expectedSize) {
-        jdiAssert(element().size(), Matchers.is(expectedSize));
+    public MUIListAssert size(int size) {
+        jdiAssert(element().size(), Matchers.is(size));
         return this;
     }
 
+    /**
+     * Checks that list is empty.
+     *
+     * @return this {@link MUIListAssert} instance
+     */
     @JDIAction("Assert that '{name}' is empty")
     public MUIListAssert empty() {
         jdiAssert(element().isEmpty() ? "is empty" : "is not empty", Matchers.is("is empty"));
         return this;
     }
 
+    /**
+     * Checks that list is not empty.
+     *
+     * @return this {@link MUIListAssert} instance
+     */
     @JDIAction("Assert that '{name}' is not empty")
     public MUIListAssert notEmpty() {
         jdiAssert(!element().isEmpty() ? "is not empty" : "is empty", Matchers.is("is not empty"));
         return this;
     }
 
+    /**
+     * Checks that list contains all items with given texts.
+     *
+     * @param itemTexts expected item texts to be contained in list
+     * @return this {@link MUIListAssert} instance
+     */
     @JDIAction("Assert that '{name}' contains all items with texts specified in '{0}'")
-    public MUIListAssert itemsWithTexts(Set<String> expectedItemTexts) {
-        if (expectedItemTexts.isEmpty()) {
+    public MUIListAssert itemsWithTexts(Set<String> itemTexts) {
+        if (itemTexts.isEmpty()) {
             throw new IllegalArgumentException("Set containing expected item names should not be empty");
         } else {
             Set<String> actualItemTexts = element().items().stream().map(MUIListItem::getText)
                     .collect(Collectors.toCollection(HashSet::new));
-            jdiAssert(actualItemTexts.containsAll(expectedItemTexts)
+            jdiAssert(actualItemTexts.containsAll(itemTexts)
                             ? "List contains all items with given texts"
                             : "List does not contain all items with given texts",
                     Matchers.is("List contains all items with given texts"));

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListItemAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListItemAssert.java
@@ -23,9 +23,9 @@ public class MUIListItemAssert extends UIAssert<MUIListItemAssert, MUIListItem> 
     }
 
     /**
-     * Checks that primary text of list item matches given value.
+     * Checks that list item has given primary text.
      *
-     * @param text expected text
+     * @param text expected primary text
      * @return this {@link MUIListItemAssert} instance
      */
     @JDIAction("Assert that '{name}' has primary text '{0}'")
@@ -35,9 +35,9 @@ public class MUIListItemAssert extends UIAssert<MUIListItemAssert, MUIListItem> 
     }
 
     /**
-     * Checks that secondary text of list item matches given value.
+     * Checks that list item has given secondary text.
      *
-     * @param text expected text
+     * @param text expected secondary text
      * @return this {@link MUIListItemAssert} instance
      */
     @JDIAction("Assert that '{name}' has secondary text '{0}'")

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListItemAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/displaydata/MUIListItemAssert.java
@@ -4,14 +4,17 @@ import com.epam.jdi.light.asserts.generic.ITextAssert;
 import com.epam.jdi.light.asserts.generic.UIAssert;
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.material.elements.displaydata.MUIListItem;
+import com.epam.jdi.light.material.elements.inputs.Checkbox;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
 
 import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 
+/**
+ * Assertion for {@link MUIListItem}.
+ */
 public class MUIListItemAssert extends UIAssert<MUIListItemAssert, MUIListItem> implements ITextAssert<MUIListItemAssert> {
 
-    // Gets text using a regular primary text sub-element location or, failing that, text of list item element root.
     @Override
     @JDIAction("Assert that '{name}' text {0}")
     public MUIListItemAssert text(Matcher<String> condition) {
@@ -19,37 +22,68 @@ public class MUIListItemAssert extends UIAssert<MUIListItemAssert, MUIListItem> 
         return this;
     }
 
-    // Gets text from the sub-element with '.MuiListItemText-primary' class
+    /**
+     * Checks that primary text of list item matches given value.
+     *
+     * @param text expected text
+     * @return this {@link MUIListItemAssert} instance
+     */
     @JDIAction("Assert that '{name}' has primary text '{0}'")
     public MUIListItemAssert primaryText(String text) {
         jdiAssert(element().getPrimaryText().text(), Matchers.is(text));
         return this;
     }
 
+    /**
+     * Checks that secondary text of list item matches given value.
+     *
+     * @param text expected text
+     * @return this {@link MUIListItemAssert} instance
+     */
     @JDIAction("Assert that '{name}' has secondary text '{0}'")
     public MUIListItemAssert secondaryText(String text) {
         jdiAssert(element().getSecondaryText().text(), Matchers.is(text));
         return this;
     }
 
+    /**
+     * Checks that list item is selected.
+     *
+     * @return this {@link MUIListItemAssert} instance
+     */
     @JDIAction("Assert that '{name}' is selected")
     public MUIListItemAssert selected() {
         jdiAssert(element().isSelected() ? "is selected" : "is not selected", Matchers.is("is selected"));
         return this;
     }
 
+    /**
+     * Checks that list item is not selected.
+     *
+     * @return this {@link MUIListItemAssert} instance
+     */
     @JDIAction("Assert that '{name}' is not selected")
     public MUIListItemAssert notSelected() {
         jdiAssert(!element().isSelected() ? "is not selected" : "is selected", Matchers.is("is not selected"));
         return this;
     }
 
+    /**
+     * Checks that list item is checked. Relevant only for list items with {@link Checkbox}.
+     *
+     * @return this {@link MUIListItemAssert} instance
+     */
     @JDIAction("Assert that '{name}' is checked")
     public MUIListItemAssert checked() {
         jdiAssert(element().checkbox().isChecked() ? "is checked" : "is unchecked", Matchers.is("is checked"));
         return this;
     }
 
+    /**
+     * Checks that list item is unchecked. Relevant only for list items with {@link Checkbox}.
+     *
+     * @return this {@link MUIListItemAssert} instance
+     */
     @JDIAction("Assert that '{name}' is unchecked")
     public MUIListItemAssert unchecked() {
         jdiAssert(!element().checkbox().isChecked() ? "is unchecked" : "is checked", Matchers.is("is unchecked"));

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
@@ -38,7 +38,7 @@ public class DrawerAssert extends UIAssert<DrawerAssert, Drawer> {
     }
 
     /**
-     * Checks that number of all list items matches given number.
+     * Checks that drawer has given number of list items.
      *
      * @param numberOfMUIListItems expected number of list items
      * @return this {@link DrawerAssert} instance

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
@@ -64,9 +64,9 @@ public class DrawerAssert extends UIAssert<DrawerAssert, Drawer> {
      *
      * @return this {@link DrawerAssert} instance
      */
-    @JDIAction("Assert that '{name}' does not exist")
+    @JDIAction("Assert that '{name}' is not exist")
     public DrawerAssert notExist() {
-        jdiAssert(waitCondition(() -> element().core().isNotExist()) ? "does not exist" : "exists", Matchers.is("does not exist"));
+        jdiAssert(waitCondition(() -> element().core().isNotExist()) ? "is not exist" : "is exist", Matchers.is("is not exist"));
         return this;
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
@@ -64,9 +64,9 @@ public class DrawerAssert extends UIAssert<DrawerAssert, Drawer> {
      *
      * @return this {@link DrawerAssert} instance
      */
-    @JDIAction("Assert that '{name}' is not exist")
+    @JDIAction("Assert that '{name}' does not exist")
     public DrawerAssert notExist() {
-        jdiAssert(waitCondition(() -> element().core().isNotExist()) ? "is not exist" : "is exist", Matchers.is("is not exist"));
+        jdiAssert(waitCondition(() -> element().core().isNotExist()) ? "does not exist" : "exists", Matchers.is("does not exist"));
         return this;
     }
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/asserts/navigation/DrawerAssert.java
@@ -13,6 +13,9 @@ import java.util.stream.Collectors;
 import static com.epam.jdi.light.asserts.core.SoftAssert.jdiAssert;
 import static com.jdiai.tools.Timer.waitCondition;
 
+/**
+ * Assertions for {@link Drawer}.
+ */
 public class DrawerAssert extends UIAssert<DrawerAssert, Drawer> {
 
     @Override
@@ -22,17 +25,29 @@ public class DrawerAssert extends UIAssert<DrawerAssert, Drawer> {
         return this;
     }
 
+    /**
+     * Checks that drawer has given position.
+     *
+     * @param position expected position
+     * @return this {@link DrawerAssert} instance
+     */
     @JDIAction("Assert that '{name}' has position '{0}'")
     public DrawerAssert position(Position position) {
         jdiAssert(element().position(), Matchers.is(position));
         return this;
     }
 
+    /**
+     * Checks that number of all list items matches given number.
+     *
+     * @param numberOfMUIListItems expected number of list items
+     * @return this {@link DrawerAssert} instance
+     */
     @JDIAction("Assert that '{name}' has {0} list items")
     public DrawerAssert numberOfListItems(int numberOfMUIListItems) {
         List<MUIListItem> listItems = element().lists().stream()
-                        .flatMap(list -> list.items().stream())
-                        .collect(Collectors.toList());
+                .flatMap(list -> list.items().stream())
+                .collect(Collectors.toList());
         jdiAssert(listItems.size(), Matchers.is(numberOfMUIListItems));
         return this;
     }
@@ -44,6 +59,11 @@ public class DrawerAssert extends UIAssert<DrawerAssert, Drawer> {
         return this;
     }
 
+    /**
+     * Checks that drawer does not exist on page.
+     *
+     * @return this {@link DrawerAssert} instance
+     */
     @JDIAction("Assert that '{name}' is not exist")
     public DrawerAssert notExist() {
         jdiAssert(waitCondition(() -> element().core().isNotExist()) ? "is not exist" : "is exist", Matchers.is("is not exist"));

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIList.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIList.java
@@ -16,7 +16,7 @@ import static java.lang.String.format;
  * Represents list MUI component on GUI.
  * <p>Each list consists of list items, i.e. entries like menu items or table rows, containing all content like icons,
  * checkboxes, text etc. The list by itself does not operate its content directly, but gives access to it through its
- * items. There can be complex lists containing other (nested) lists, which could be (not always) separated through
+ * items. There can be complex lists containing other (nested) lists, which could be (not always) separated by
  * subheaders.</p>
  *
  * @see MUIListItem

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIList.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIList.java
@@ -47,10 +47,10 @@ public class MUIList extends UIBaseElement<MUIListAssert> {
      */
     @JDIAction("Get list of '{name}' items")
     public List<MUIListItem> items() {
-        Function<String, List<MUIListItem>> function = locator -> finds(locator).stream()
+        Function<String, List<MUIListItem>> function = locator -> core().finds(locator).stream()
                 .map(listItem -> new MUIListItem().setCore(MUIListItem.class, listItem))
                 .collect(Collectors.toList());
-        if (!finds(LIST_ITEM_CONTAINER_LOCATOR).isEmpty()) {
+        if (!core().finds(LIST_ITEM_CONTAINER_LOCATOR).isEmpty()) {
             return function.apply(LIST_ITEM_CONTAINER_LOCATOR);
         } else {
             return function.apply(LIST_ITEM_LOCATOR);
@@ -82,7 +82,7 @@ public class MUIList extends UIBaseElement<MUIListAssert> {
      */
     @JDIAction("Get list of Material UI lists nested directly within '{name}'")
     public List<MUIList> nestedLists() {
-        return finds(".//ul[not(parent::ul)]").stream() // targets only the first layer of nested lists
+        return core().finds(".//ul[not(parent::ul)]").stream() // targets only the first layer of nested lists
                 .map(nestedList -> new MUIList().setCore(MUIList.class, nestedList))
                 .collect(Collectors.toList());
     }
@@ -114,7 +114,7 @@ public class MUIList extends UIBaseElement<MUIListAssert> {
      */
     @JDIAction("Get list of '{name}' subheaders")
     public List<UIElement> subheaders() {
-        return finds(SUBHEADER_LOCATOR).stream()
+        return core().finds(SUBHEADER_LOCATOR).stream()
                 .map(subheader -> new UIElement().setCore(UIElement.class, subheader)).collect(Collectors.toList());
     }
 

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIList.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIList.java
@@ -14,7 +14,12 @@ import static java.lang.String.format;
 
 /**
  * Represents list MUI component on GUI.
+ * <p>Each list consists of list items, i.e. entries like menu items or table rows, containing all content like icons,
+ * checkboxes, text etc. The list by itself does not operate its content directly, but gives access to it through its
+ * items. There can be complex lists containing other (nested) lists, which could be (not always) separated through
+ * subheaders.</p>
  *
+ * @see MUIListItem
  * @see <a href="https://mui.com/components/lists/">List MUI documentation</a>
  * @see <a href="https://jdi-testing.github.io/jdi-light/material">MUI test page</a>
  */

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
@@ -39,8 +39,8 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     @Override
     @JDIAction("Get '{name}' text")
     public String getText() {
-        if (finds(TEXT_LOCATOR).size() > 0) {
-            return find(TEXT_LOCATOR).getText(); // normally this will get the primary text
+        if (core().finds(TEXT_LOCATOR).size() > 0) {
+            return core().find(TEXT_LOCATOR).getText(); // normally this will get the primary text
         } else {
             return core().text(); // fallback for less complex list items
         }
@@ -54,7 +54,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      */
     @JDIAction("Get '{name}' primary text")
     public Text getPrimaryText() {
-        return new Text().setCore(Text.class, find(PRIMARY_TEXT_LOCATOR));
+        return new Text().setCore(Text.class, core().find(PRIMARY_TEXT_LOCATOR));
     }
 
     /**
@@ -64,7 +64,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      */
     @JDIAction("Get '{name}' secondary text")
     public Text getSecondaryText() {
-        return new Text().setCore(Text.class, find(SECONDARY_TEXT_LOCATOR));
+        return new Text().setCore(Text.class, core().find(SECONDARY_TEXT_LOCATOR));
     }
 
     /**
@@ -74,7 +74,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      */
     @JDIAction("Get '{name}' icon")
     public Icon icon() {
-        return new Icon().setCore(Icon.class, find(ICON_LOCATOR));
+        return new Icon().setCore(Icon.class, core().find(ICON_LOCATOR));
     }
 
     /**
@@ -84,7 +84,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      */
     @JDIAction("Get '{name}' avatar")
     public Avatar avatar() {
-        return new Avatar().setCore(Avatar.class, find(AVATAR_LOCATOR));
+        return new Avatar().setCore(Avatar.class, core().find(AVATAR_LOCATOR));
     }
 
     /**
@@ -94,7 +94,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      */
     @JDIAction("Get '{name}' checkbox")
     public Checkbox checkbox() {
-        return new Checkbox().setCore(Checkbox.class, find(PRIMARY_CHECKBOX_LOCATOR));
+        return new Checkbox().setCore(Checkbox.class, core().find(PRIMARY_CHECKBOX_LOCATOR));
     }
 
     /**
@@ -114,7 +114,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      */
     @JDIAction("Get '{name}' button")
     public Button button() {
-        return new Button().setCore(Button.class, find(SECONDARY_BUTTON_LOCATOR));
+        return new Button().setCore(Button.class, core().find(SECONDARY_BUTTON_LOCATOR));
     }
 
     /**
@@ -124,7 +124,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      */
     @JDIAction("Get '{name}' switch")
     public Switch getSwitch() {
-        return new Switch().setCore(Switch.class, find(SECONDARY_SWITCH_LOCATOR));
+        return new Switch().setCore(Switch.class, core().find(SECONDARY_SWITCH_LOCATOR));
     }
 
     @Override

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
@@ -37,7 +37,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     private static final String TEXT_LOCATOR = ".MuiTypography-root";
 
     @Override
-    @JDIAction("Get '{name}'s text")
+    @JDIAction("Get '{name}' text")
     public String getText() {
         if (finds(TEXT_LOCATOR).size() > 0) {
             return find(TEXT_LOCATOR).getText(); // normally this will get the primary text
@@ -52,7 +52,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      *
      * @return primary text ot this list item as {@link Text}
      */
-    @JDIAction("Get '{name}'s primary text")
+    @JDIAction("Get '{name}' primary text")
     public Text getPrimaryText() {
         return new Text().setCore(Text.class, find(PRIMARY_TEXT_LOCATOR));
     }
@@ -60,9 +60,9 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     /**
      * Gets the secondary text of this list item.
      *
-     * @return primary text ot this list item as {@link Text}
+     * @return secondary text ot this list item as {@link Text}
      */
-    @JDIAction("Get '{name}'s secondary text")
+    @JDIAction("Get '{name}' secondary text")
     public Text getSecondaryText() {
         return new Text().setCore(Text.class, find(SECONDARY_TEXT_LOCATOR));
     }
@@ -72,7 +72,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      *
      * @return icon of this list item as {@link Icon}
      */
-    @JDIAction("Get '{name}'s icon")
+    @JDIAction("Get '{name}' icon")
     public Icon icon() {
         return new Icon().setCore(Icon.class, find(ICON_LOCATOR));
     }
@@ -80,9 +80,9 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     /**
      * Gets the avatar of this list item.
      *
-     * @return icon of this list item as {@link Avatar}
+     * @return avatar of this list item as {@link Avatar}
      */
-    @JDIAction("Get '{name}'s avatar")
+    @JDIAction("Get '{name}' avatar")
     public Avatar avatar() {
         return new Avatar().setCore(Avatar.class, find(AVATAR_LOCATOR));
     }
@@ -90,9 +90,9 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     /**
      * Gets the checkbox of this list item.
      *
-     * @return icon of this list item as {@link Checkbox}
+     * @return checkbox of this list item as {@link Checkbox}
      */
-    @JDIAction("Get '{name}'s checkbox")
+    @JDIAction("Get '{name}' checkbox")
     public Checkbox checkbox() {
         return new Checkbox().setCore(Checkbox.class, find(PRIMARY_CHECKBOX_LOCATOR));
     }
@@ -102,7 +102,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
      *
      * @return {@code true} if this list item is selected, otherwise {@code false}
      */
-    @JDIAction("Check if '{name}' is selected")
+    @JDIAction("Check that '{name}' is selected")
     public boolean isSelected() {
         return core().hasClass(SELECTED_CLASS);
     }
@@ -110,9 +110,9 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     /**
      * Gets the button of this list item.
      *
-     * @return icon of this list item as {@link Button}
+     * @return button of this list item as {@link Button}
      */
-    @JDIAction("Get '{name}'s secondary action button")
+    @JDIAction("Get '{name}' button")
     public Button button() {
         return new Button().setCore(Button.class, find(SECONDARY_BUTTON_LOCATOR));
     }
@@ -120,9 +120,9 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     /**
      * Gets the switch of this list item.
      *
-     * @return icon of this list item as {@link Switch}
+     * @return switch of this list item as {@link Switch}
      */
-    @JDIAction("Get '{name}'s switch")
+    @JDIAction("Get '{name}' switch")
     public Switch getSwitch() {
         return new Switch().setCore(Switch.class, find(SECONDARY_SWITCH_LOCATOR));
     }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
@@ -12,27 +12,29 @@ import com.epam.jdi.light.ui.html.elements.common.Button;
 import com.epam.jdi.light.ui.html.elements.common.Text;
 
 /**
- * Material UI List Items are flexible elements collected in a List.
+ * Represents Material UI list item.
  *
- * List item has a 'primary area' which may contain an icon/avatar/checkbox,
+ * <p>List items are essential parts of the list.
+ * Each list item has a 'primary area' which may contain an icon/avatar/checkbox,
  * primary and secondary text. It can also support a primary action
- * invoked by clicking on this area, like selecting the item.
+ * invoked by clicking on this area, like selecting the item.</p>
  *
- * List item also might have a 'secondary area' containing a switch
- * or button used to invoke a distinct secondary action.
+ * <p>List item also might have a 'secondary area' containing a switch
+ * or button used to invoke a distinct secondary action.</p>
+ *
+ * @see MUIList
  */
-
 // TODO: ListItem can contain a lot of another elements, and this should be described by user
 public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsText, HasClick, CanBeDisabled {
-    protected static final String SELECTED_CLASS = "Mui-selected";
-    protected static final String SECONDARY_BUTTON_LOCATOR = ".MuiListItemSecondaryAction-root button";
-    protected static final String SECONDARY_SWITCH_LOCATOR = ".MuiListItemSecondaryAction-root .MuiSwitch-root";
-    protected static final String PRIMARY_TEXT_LOCATOR = ".MuiListItemText-primary";
-    protected static final String SECONDARY_TEXT_LOCATOR = ".MuiListItemText-secondary";
-    protected static final String PRIMARY_CHECKBOX_LOCATOR = ".MuiCheckbox-root";
-    protected static final String AVATAR_LOCATOR = ".MuiAvatar-root";
-    protected static final String ICON_LOCATOR = ".MuiListItemIcon-root > .MuiSvgIcon-root";
-    protected static final String TEXT_LOCATOR = ".MuiTypography-root";
+    private static final String SELECTED_CLASS = "Mui-selected";
+    private static final String SECONDARY_BUTTON_LOCATOR = ".MuiListItemSecondaryAction-root button";
+    private static final String SECONDARY_SWITCH_LOCATOR = ".MuiListItemSecondaryAction-root .MuiSwitch-root";
+    private static final String PRIMARY_TEXT_LOCATOR = ".MuiListItemText-primary";
+    private static final String SECONDARY_TEXT_LOCATOR = ".MuiListItemText-secondary";
+    private static final String PRIMARY_CHECKBOX_LOCATOR = ".MuiCheckbox-root";
+    private static final String AVATAR_LOCATOR = ".MuiAvatar-root";
+    private static final String ICON_LOCATOR = ".MuiListItemIcon-root > .MuiSvgIcon-root";
+    private static final String TEXT_LOCATOR = ".MuiTypography-root";
 
     @Override
     @JDIAction("Get '{name}'s text")
@@ -44,44 +46,76 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
         }
     }
 
-    // Works when the primary text sub-element is marked with a proper Material UI class, which is not always the case.
+    /**
+     * Gets the primary text of this list item. Works when the primary text sub-element is marked with a proper
+     * Material UI class, which is not always the case.
+     * @return primary text ot this list item as {@link Text}
+     */
     @JDIAction("Get '{name}'s primary text")
     public Text getPrimaryText() {
         return new Text().setCore(Text.class, find(PRIMARY_TEXT_LOCATOR));
     }
 
+    /**
+     * Gets the secondary text of this list item.
+     * @return primary text ot this list item as {@link Text}
+     */
     @JDIAction("Get '{name}'s secondary text")
     public Text getSecondaryText() {
         return new Text().setCore(Text.class, find(SECONDARY_TEXT_LOCATOR));
     }
 
+    /**
+     * Gets the icon of this list item.
+     * @return icon of this list item as {@link Icon}
+     */
     @JDIAction("Get '{name}'s icon")
     public Icon icon() {
         return new Icon().setCore(Icon.class, find(ICON_LOCATOR));
     }
 
+    /**
+     * Gets the avatar of this list item.
+     * @return icon of this list item as {@link Avatar}
+     */
     @JDIAction("Get '{name}'s avatar")
     public Avatar avatar() {
         return new Avatar().setCore(Avatar.class, find(AVATAR_LOCATOR));
     }
 
+    /**
+     * Gets the checkbox of this list item.
+     * @return icon of this list item as {@link Checkbox}
+     */
     @JDIAction("Get '{name}'s checkbox")
     public Checkbox checkbox() {
         return new Checkbox().setCore(Checkbox.class, find(PRIMARY_CHECKBOX_LOCATOR));
     }
 
+    /**
+     * Checks that this list item is selected or not. Relevant for selectable lists.
+     * @return {@code true} if this list item is selected, otherwise {@code false}
+     */
     @JDIAction("Check if '{name}' is selected")
     public boolean isSelected() {
         return core().hasClass(SELECTED_CLASS);
     }
 
+    /**
+     * Gets the button of this list item.
+     * @return icon of this list item as {@link Button}
+     */
     @JDIAction("Get '{name}'s secondary action button")
-    public Button secondaryActionButton() {
+    public Button button() {
         return new Button().setCore(Button.class, find(SECONDARY_BUTTON_LOCATOR));
     }
 
+    /**
+     * Gets the switch of this list item.
+     * @return icon of this list item as {@link Switch}
+     */
     @JDIAction("Get '{name}'s switch")
-    public Switch secondaryActionSwitch() {
+    public Switch getSwitch() {
         return new Switch().setCore(Switch.class, find(SECONDARY_SWITCH_LOCATOR));
     }
 

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/displaydata/MUIListItem.java
@@ -49,6 +49,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
     /**
      * Gets the primary text of this list item. Works when the primary text sub-element is marked with a proper
      * Material UI class, which is not always the case.
+     *
      * @return primary text ot this list item as {@link Text}
      */
     @JDIAction("Get '{name}'s primary text")
@@ -58,6 +59,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
 
     /**
      * Gets the secondary text of this list item.
+     *
      * @return primary text ot this list item as {@link Text}
      */
     @JDIAction("Get '{name}'s secondary text")
@@ -67,6 +69,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
 
     /**
      * Gets the icon of this list item.
+     *
      * @return icon of this list item as {@link Icon}
      */
     @JDIAction("Get '{name}'s icon")
@@ -76,6 +79,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
 
     /**
      * Gets the avatar of this list item.
+     *
      * @return icon of this list item as {@link Avatar}
      */
     @JDIAction("Get '{name}'s avatar")
@@ -85,6 +89,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
 
     /**
      * Gets the checkbox of this list item.
+     *
      * @return icon of this list item as {@link Checkbox}
      */
     @JDIAction("Get '{name}'s checkbox")
@@ -94,6 +99,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
 
     /**
      * Checks that this list item is selected or not. Relevant for selectable lists.
+     *
      * @return {@code true} if this list item is selected, otherwise {@code false}
      */
     @JDIAction("Check if '{name}' is selected")
@@ -103,6 +109,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
 
     /**
      * Gets the button of this list item.
+     *
      * @return icon of this list item as {@link Button}
      */
     @JDIAction("Get '{name}'s secondary action button")
@@ -112,6 +119,7 @@ public class MUIListItem extends UIBaseElement<MUIListItemAssert> implements IsT
 
     /**
      * Gets the switch of this list item.
+     *
      * @return icon of this list item as {@link Switch}
      */
     @JDIAction("Get '{name}'s switch")

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Drawer.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Drawer.java
@@ -85,7 +85,7 @@ public class Drawer extends UIBaseElement<DrawerAssert> {
      */
     @JDIAction("Get '{name}'s position")
     public Position position() {
-        String position = Arrays.stream(attr("class")
+        String position = Arrays.stream(core().attr("class")
                         .split("[^a-zA-Z0-9]"))
                 .map(String::toLowerCase)
                 .filter(s -> s.contains("anchor"))

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Drawer.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Drawer.java
@@ -23,7 +23,7 @@ import static com.epam.jdi.light.common.Exceptions.runtimeException;
 public class Drawer extends UIBaseElement<DrawerAssert> {
 
     /**
-     * Gets lists included in this drawer.
+     * Gets lists within this drawer.
      *
      * @return lists included in this drawer as {@link List}
      * @see MUIList

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Drawer.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/elements/navigation/Drawer.java
@@ -30,7 +30,7 @@ public class Drawer extends UIBaseElement<DrawerAssert> {
      */
     @JDIAction("Get '{name}'s lists of items")
     public List<MUIList> lists() {
-        return finds(".MuiList-root").stream()
+        return core().finds(".MuiList-root").stream()
                 .map(list -> new MUIList().setCore(MUIList.class, list))
                 .collect(Collectors.toList());
     }
@@ -54,14 +54,14 @@ public class Drawer extends UIBaseElement<DrawerAssert> {
      */
     @JDIAction("Get list on the bottom of '{name}'")
     public MUIList bottomList() {
-        java.util.List<MUIList> menuLists = lists();
+        List<MUIList> menuLists = lists();
         return menuLists.get(menuLists.size() - 1);
     }
 
     @Override
     @JDIAction("Check that '{name}' is displayed")
     public boolean isDisplayed() {
-        return css("visibility").equals("visible") || super.isDisplayed();
+        return core().css("visibility").equals("visible") || super.isDisplayed();
     }
 
     /**
@@ -69,7 +69,7 @@ public class Drawer extends UIBaseElement<DrawerAssert> {
      */
     @JDIAction("Close '{name}'")
     public void close() {
-        UIElement closeButton = find("button");
+        UIElement closeButton = core().find("button");
         if (closeButton.isExist()) {
             closeButton.click();
         } else {

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/base/CanBeDisabled.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/base/CanBeDisabled.java
@@ -2,19 +2,27 @@ package com.epam.jdi.light.material.interfaces.base;
 
 import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
+/**
+ * Represents an element which can be disabled on page.
+ */
 public interface CanBeDisabled extends ICoreElement {
 
+    @Override
     default boolean isDisabled() {
         return core().hasClass("Mui-disabled");
     }
 
+    @Override
     default boolean isEnabled() {
         return !isDisabled();
     }
 
+    /**
+     * Checks that element contains other disabled elements or not.
+     *
+     * @return {@code true} if element contains other disabled elements, otherwise {@code false}
+     */
     default boolean containsDisabled() {
-        return find(".Mui-disabled").isDisplayed()
-            || attr("class").contains("disabled");
+        return find(".Mui-disabled").isDisplayed() || attr("class").contains("disabled");
     }
-
 }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/base/CanBeDisabled.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/base/CanBeDisabled.java
@@ -1,18 +1,21 @@
 package com.epam.jdi.light.material.interfaces.base;
 
+import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
 /**
- * Represents an element which can be disabled on page.
+ * Represents an MUI element which can be disabled on page.
  */
 public interface CanBeDisabled extends ICoreElement {
 
     @Override
+    @JDIAction(value = "Check that '{name}' is disabled", timeout = 0)
     default boolean isDisabled() {
         return core().hasClass("Mui-disabled");
     }
 
     @Override
+    @JDIAction(value = "Check that '{name}' is enabled", timeout = 0)
     default boolean isEnabled() {
         return !isDisabled();
     }
@@ -22,6 +25,7 @@ public interface CanBeDisabled extends ICoreElement {
      *
      * @return {@code true} if element contains other disabled elements, otherwise {@code false}
      */
+    @JDIAction(value = "Check that '{name}' is enabled", timeout = 0)
     default boolean containsDisabled() {
         return find(".Mui-disabled").isDisplayed() || attr("class").contains("disabled");
     }

--- a/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/base/CanBeDisabled.java
+++ b/jdi-light-material-ui/src/main/java/com/epam/jdi/light/material/interfaces/base/CanBeDisabled.java
@@ -4,7 +4,7 @@ import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 
 /**
- * Represents an MUI element which can be disabled on page.
+ * Represents a MUI element which can be disabled on page.
  */
 public interface CanBeDisabled extends ICoreElement {
 
@@ -27,6 +27,6 @@ public interface CanBeDisabled extends ICoreElement {
      */
     @JDIAction(value = "Check that '{name}' is enabled", timeout = 0)
     default boolean containsDisabled() {
-        return find(".Mui-disabled").isDisplayed() || attr("class").contains("disabled");
+        return core().find(".Mui-disabled").isDisplayed() || core().attr("class").contains("disabled");
     }
 }


### PR DESCRIPTION
## Javadoc
Javadoc is added for:
- `MUIListItem`
- `MUIListItemAssert`
- `DrawerAssert` 

Javadoc for `MUIList` extended. 
There is no need for Javadoc for `Box` because of its absence. 

## Other changes
- Constants in `MUIListItem` made private
- 2 methods were renamed for simplicity.