### PR TITLE
Logback configuration

### DIFF
--- a/jdi-light-material-ui-tests/pom.xml
+++ b/jdi-light-material-ui-tests/pom.xml
@@ -18,6 +18,7 @@
         <jetty.version>9.4.12.RC2</jetty.version>
         <jdi.version>1.4.4</jdi.version>
         <suite-xml-file>src/test/resources/general.xml</suite-xml-file>
+        <logback-classic.version>1.2.11</logback-classic.version>
     </properties>
 
     <dependencies>
@@ -30,6 +31,11 @@
             <groupId>io.qameta.allure</groupId>
             <artifactId>allure-testng</artifactId>
             <version>${allure.testng}</version>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>${logback-classic.version}</version>
         </dependency>
     </dependencies>
 

--- a/jdi-light-material-ui-tests/src/test/resources/logback.xml
+++ b/jdi-light-material-ui-tests/src/test/resources/logback.xml
@@ -34,19 +34,19 @@
             <maxFileSize>10MB</maxFileSize>
             <totalSizeCap>1GB</totalSizeCap>
         </rollingPolicy>
-<!--        <layout class="ch.qos.logback.classic.html.HTMLLayout"/>-->
         <layout class="ch.qos.logback.classic.html.HTMLLayout">
             <pattern>%relative%thread%mdc%level%logger%msg</pattern>
         </layout>
     </appender>
 
-
+    <!-- Every configuration must have a root logger. If one is not configured the default root LoggerConfig is ERROR with Console appender attached. -->
     <root level="INFO">
         <appender-ref ref="consoleAppender"/>
         <appender-ref ref="fileAppender"/>
         <appender-ref ref="htmlFileLogger"/>
     </root>
 
+    <!-- additivity means, that parent-logger (in every case the root-logger) will also get the chance to log this stuff -->
     <logger name="JDI" level="INFO" additivity="false">
         <appender-ref ref="consoleAppender"/>
         <appender-ref ref="fileAppender"/>

--- a/jdi-light-material-ui-tests/src/test/resources/logback.xml
+++ b/jdi-light-material-ui-tests/src/test/resources/logback.xml
@@ -1,0 +1,56 @@
+<configuration>
+    <property name="logFileName" value="jdiEvents"/>
+    <property name="baseDir" value="./target/.logs"/>
+
+    <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{mm:ss.SS} [%c:%p]: %m%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="fileAppender" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${baseDir}/${logFileName}.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- every minute rollover -->
+            <fileNamePattern>${baseDir}/${logFileName}_%d{yyyy-MM-dd_HH-mm}_%i.log</fileNamePattern>
+
+            <!-- keep 5 days' worth of history capped at 3GB total size -->
+            <maxFileSize>250MB</maxFileSize>
+            <maxHistory>5</maxHistory>
+            <totalSizeCap>3GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d{HH:mm:ss} [%t] %-5level %logger{6} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="htmlFileLogger" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${baseDir}/app-info.html</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${baseDir}/app-info-%d{yyyy-MM-dd}_%i.html</fileNamePattern>
+
+            <!-- keep history capped at 3GB total size -->
+            <maxFileSize>10MB</maxFileSize>
+            <totalSizeCap>1GB</totalSizeCap>
+        </rollingPolicy>
+<!--        <layout class="ch.qos.logback.classic.html.HTMLLayout"/>-->
+        <layout class="ch.qos.logback.classic.html.HTMLLayout">
+            <pattern>%relative%thread%mdc%level%logger%msg</pattern>
+        </layout>
+    </appender>
+
+
+    <root level="INFO">
+        <appender-ref ref="consoleAppender"/>
+        <appender-ref ref="fileAppender"/>
+        <appender-ref ref="htmlFileLogger"/>
+    </root>
+
+    <logger name="JDI" level="INFO" additivity="false">
+        <appender-ref ref="consoleAppender"/>
+        <appender-ref ref="fileAppender"/>
+        <appender-ref ref="htmlFileLogger"/>
+    </logger>
+
+</configuration>


### PR DESCRIPTION
Added dependencies as it was suggested in [Release 1.4.4](https://github.com/jdi-testing/jdi-light/releases/tag/1.4.4).

Configured `logback.xml` so that it was as close as possible to the `log4j2.xml`.

Used links:
- https://www.baeldung.com/logback
- https://logback.qos.ch/manual/appenders.html#RollingFileAppender
- https://logback.qos.ch/manual/layouts.html#ClassicHTMLLayout
- https://logging.apache.org/log4j/2.x/manual/appenders.html#RollingFileAppender