### PR TITLE
Task 3930: Vuetify - Fix failed tests DataTablesTests

### DIFF
--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/tables/DataTable.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/tables/DataTable.java
@@ -21,7 +21,9 @@ import org.openqa.selenium.Keys;
 public class DataTable extends SimpleTable {
 
     protected WebList menuContent() {
-        return $$("[class*='active'] [role='listbox'] [role='option']");
+        WebList menuContent = $$("[class*='active'] [role='listbox'] [role='option']");
+        menuContent.waitFor().displayed();
+        return menuContent;
     }
 
     protected WebList newItemCard() {
@@ -326,7 +328,7 @@ public class DataTable extends SimpleTable {
 
     @JDIAction("Cancel changes in {name}")
     public void cancel() {
-        command("Esc");
+        press(Keys.ESCAPE);
     }
 
     @JDIAction("Expand required {name} element")
@@ -364,7 +366,9 @@ public class DataTable extends SimpleTable {
 
     @JDIAction("Select required {name} option")
     public void selectOption(int numOpt) {
-        WebList menu = $$("//div[@role='listbox']/child::div[@role='option']");
+        WebList menu = $$("//div[not(contains(@style,'display: none'))]" +
+                "/div[@role='listbox']/child::div[@role='option']");
+        menu.waitFor().displayed();
         menu.get(numOpt).click();
     }
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/tables/DataTable.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/tables/DataTable.java
@@ -6,7 +6,9 @@ import com.epam.jdi.light.elements.complex.WebList;
 
 import static com.epam.jdi.light.elements.init.UIFactory.$;
 import static com.epam.jdi.light.elements.init.UIFactory.$$;
+import static com.jdiai.tools.Timer.waitCondition;
 
+import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 import com.epam.jdi.light.vuetify.asserts.tables.DataTableAssert;
 
 import java.util.LinkedList;
@@ -22,7 +24,7 @@ public class DataTable extends SimpleTable {
 
     protected WebList menuContent() {
         WebList menuContent = $$("[class*='active'] [role='listbox'] [role='option']");
-        menuContent.waitFor().displayed();
+        waitCondition(menuContent::isDisplayed);
         return menuContent;
     }
 
@@ -368,7 +370,7 @@ public class DataTable extends SimpleTable {
     public void selectOption(int numOpt) {
         WebList menu = $$("//div[not(contains(@style,'display: none'))]" +
                 "/div[@role='listbox']/child::div[@role='option']");
-        menu.waitFor().displayed();
+        waitCondition(menu::isDisplayed);
         menu.get(numOpt).click();
     }
 

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/tables/DataTable.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/elements/complex/tables/DataTable.java
@@ -3,18 +3,15 @@ package com.epam.jdi.light.vuetify.elements.complex.tables;
 import com.epam.jdi.light.common.JDIAction;
 import com.epam.jdi.light.elements.common.UIElement;
 import com.epam.jdi.light.elements.complex.WebList;
-
-import static com.epam.jdi.light.elements.init.UIFactory.$;
-import static com.epam.jdi.light.elements.init.UIFactory.$$;
-import static com.jdiai.tools.Timer.waitCondition;
-
-import com.epam.jdi.light.elements.interfaces.base.ICoreElement;
 import com.epam.jdi.light.vuetify.asserts.tables.DataTableAssert;
+import org.openqa.selenium.Keys;
 
 import java.util.LinkedList;
 import java.util.List;
 
-import org.openqa.selenium.Keys;
+import static com.epam.jdi.light.elements.init.UIFactory.$;
+import static com.epam.jdi.light.elements.init.UIFactory.$$;
+import static com.jdiai.tools.Timer.waitCondition;
 
 /**
  * To see an example of Data Table web element please visit https://vuetifyjs.com/en/components/data-tables/


### PR DESCRIPTION
Investigate:
- The editDialogTableTest test case failed due to the function DataTable.cancel() throw exception when called.
- The slotsTableTest test case failed due to the locator was finding the wrong element.

Fix:
- Change the behavior of function DataTable.cancel() to press(Keys.ESCAPE);
- Change the locator of menu in function DataTable.selectOption(int)