### PR TITLE
Vuetify disable query progress bar tests

### DIFF
--- a/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/common/ProgressBarsTests.java
+++ b/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/common/ProgressBarsTests.java
@@ -6,8 +6,6 @@ import io.github.epam.TestsInit;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.util.stream.Collectors;
-
 import static com.epam.jdi.light.common.ElementArea.TOP_RIGHT;
 import static com.jdiai.tools.Timer.waitCondition;
 import static io.github.com.enums.Colors.BLUE_DARKEN_2;
@@ -64,7 +62,7 @@ public class ProgressBarsTests extends TestsInit {
         indeterminateProgressBars.get(index).has().color(color);
     }
 
-    @Test()
+    @Test(enabled = false) //current test site condition makes this test flaky - need to update test site with increased intervals of query steps
     public void queryProgressBarTests() {
         Timer.waitCondition(queryProgressBar::isIndeterminate);
         queryProgressBar.is().displayed();


### PR DESCRIPTION
queryProgressBarTests disabled due to a fact that current test site condition makes this test flaky - need to update test site with increased intervals of query steps
vuetify code (need a set of values, shown bold below, for stability)
      
setTimeout(() => {
        this.query = false
        this.interval = setInterval(() => {
          if (this.value === 100) {
            clearInterval(this.interval)
            this.show = false
            return setTimeout(this.queryAndIndeterminate, **5000**)
          }
          this.value += **25**
        }, **2500**)
      }, **5000**)
