### PR TITLE
Bug in chromedriver 111

### DIFF
--- a/jdi-light/src/main/java/com/epam/jdi/light/driver/get/DriverData.java
+++ b/jdi-light/src/main/java/com/epam/jdi/light/driver/get/DriverData.java
@@ -148,7 +148,7 @@ public class DriverData {
             chromePrefs.put("profile.password_manager_enabled", false);
         });
         setUp("Chrome: '--disable-web-security', '--disable-extensions', 'test-type'",
-            () -> cap.addArguments("--disable-web-security", "--disable-extensions", "test-type"));
+            () -> cap.addArguments("--disable-web-security", "--disable-extensions", "test-type", "--remote-allow-origins=*"));
         setUp("Chrome: PageLoadStrategy:" + DRIVER.pageLoadStrategy,
             () -> cap.setPageLoadStrategy(DRIVER.pageLoadStrategy));
         setUp("Chrome: ACCEPT_SSL_CERTS:true",


### PR DESCRIPTION
There is a bug in chromedriver 111. This is a workaround so tests could be ran
https://stackoverflow.com/questions/75678572/java-io-ioexception-invalid-status-code-403-text-forbidden