### PR TITLE
delete of unused method in TimeLineItemAssert

### DIFF
--- a/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/TimelinesTests.java
+++ b/jdi-light-vuetify-tests/src/test/java/io/github/epam/vuetify/tests/complex/TimelinesTests.java
@@ -65,8 +65,7 @@ public class TimelinesTests extends TestsInit {
         TimeLineItem<ScheduledEvent, UIElement> item = colorTimeLine.item(index);
         item.body().time().has().text(time);
         item.body().event().has().text(event);
-        item.has().dotColor(color);
-        item.has().smallDot();
+        item.has().dotColor(color).and().smallDot();
         if (caption != null) {
             item.body().caption().has().text(caption);
         }
@@ -81,7 +80,9 @@ public class TimelinesTests extends TestsInit {
         singleItem.body().has().text(LOREM_IPSUM_TEXT)
                 .and().color(WHITE.value())
                 .and().backgroundColor(BLUE.value());
-        singleItem.has().dotColor(BLUE)
+        singleItem.has()
+                .dotColor(BLUE)
+                .dotColor("rgba(33, 150, 243, 1)")
                 .and().smallDot();
 
         denseLoggingButton.click();

--- a/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/asserts/timelines/TimeLineItemAssert.java
+++ b/jdi-light-vuetify/src/main/java/com/epam/jdi/light/vuetify/asserts/timelines/TimeLineItemAssert.java
@@ -23,6 +23,12 @@ public class TimeLineItemAssert extends UIAssert<TimeLineItemAssert, TimeLineIte
     }
 
     @JDIAction("Assert that dot color of '{name}' is equal to '{0}'")
+    public TimeLineItemAssert dotColor(String color) {
+        jdiAssert(element().dotColor(), equalTo(color));
+        return this;
+    }
+
+    @JDIAction("Assert that dot color of '{name}' is equal to '{0}'")
     public TimeLineItemAssert dotColor(Enum<?> color) {
         jdiAssert(element().dotColor(), equalTo(color.toString()));
         return this;


### PR DESCRIPTION
during work on a [task](https://github.com/jdi-testing/jdi-light/issues/4625) I saw the method that is deprecated