### PR TITLE
TASK 4934: Refactor Slide Toggle tests

### DIFF
--- a/jdi-light-angular-tests/src/main/java/io/github/com/pages/AngularPage.java
+++ b/jdi-light-angular-tests/src/main/java/io/github/com/pages/AngularPage.java
@@ -5,9 +5,10 @@ import com.epam.jdi.light.elements.pageobjects.annotations.locators.Css;
 import com.epam.jdi.light.elements.pageobjects.annotations.locators.UI;
 import com.epam.jdi.light.ui.html.elements.common.Button;
 import com.epam.jdi.light.ui.html.elements.complex.RadioButtons;
-import io.github.com.pages.sections.SlideToggleSection;
 import elements.common.BasicSpinner;
+import elements.common.Checkbox;
 import elements.common.Icon;
+import io.github.com.pages.sections.SlideToggleSection;
 
 public class AngularPage extends WebPage {
     @Css("radio-overview-example .mat-radio-group")
@@ -27,6 +28,27 @@ public class AngularPage extends WebPage {
 
     @UI("#svg_icon")
     public static Icon svgIcon;
+
+    @UI("#mat-checkbox-1")
+    public static Checkbox basicCheckbox;
+
+    @UI("#mat-checkbox-2")
+    public static Checkbox configurableCheckedCheckbox;
+
+    @UI("#mat-checkbox-3")
+    public static Checkbox configurableIndeterminateCheckbox;
+
+    @UI("#mat-radio-11-input")
+    public static Checkbox configurableCheckboxAlignBeforeRadioButton;
+
+    @UI("#mat-radio-10-input")
+    public static Checkbox configurableCheckboxAlignAfterRadioButton;
+
+    @UI("#mat-checkbox-4")
+    public static Checkbox configurableDisabledCheckbox;
+
+    @UI("#mat-checkbox-5")
+    public static Checkbox configurableResultCheckbox;
 
     public static SlideToggleSection slideToggleSection;
 }

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/CheckboxTests.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/CheckboxTests.java
@@ -1,0 +1,48 @@
+package io.github.epam.angular.tests;
+
+import io.github.epam.TestsInit;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static io.github.com.StaticSite.angularPage;
+import static io.github.com.pages.AngularPage.*;
+import static io.github.epam.site.steps.States.shouldBeLoggedIn;
+
+public class CheckboxTests extends TestsInit {
+
+    @BeforeMethod
+    public void before() {
+        shouldBeLoggedIn();
+        angularPage.shouldBeOpened();
+    }
+
+    @Test
+    public void basicCheckboxTest() {
+        basicCheckbox.isDisplayed();
+        basicCheckbox.check();
+        basicCheckbox.isSelected();
+        basicCheckbox.uncheck();
+        basicCheckbox.is().deselected();
+    }
+
+    @Test
+    public void configurableCheckboxTest() {
+        configurableCheckedCheckbox.show();
+        configurableCheckedCheckbox.check();
+        configurableResultCheckbox.isSelected();
+        configurableCheckedCheckbox.uncheck();
+        configurableResultCheckbox.is().deselected();
+
+        configurableIndeterminateCheckbox.check();
+        configurableResultCheckbox.hasClass("mat-checkbox-indeterminate");
+
+        configurableCheckboxAlignBeforeRadioButton.click();
+        configurableResultCheckbox.hasClass("mat-checkbox-label-before");
+
+        configurableCheckboxAlignAfterRadioButton.click();
+        configurableResultCheckbox.hasClass("mat-checkbox-label-after");
+
+        configurableDisabledCheckbox.click();
+        configurableResultCheckbox.hasClass("mat-checkbox-disabled");
+    }
+}

--- a/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/SlideToggleTests.java
+++ b/jdi-light-angular-tests/src/test/java/io/github/epam/angular/tests/SlideToggleTests.java
@@ -1,6 +1,7 @@
 package io.github.epam.angular.tests;
 
 import io.github.epam.TestsInit;
+import org.openqa.selenium.By;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -67,5 +68,22 @@ public class SlideToggleTests extends TestsInit {
         resultSlideToggle.is().disabled();
         disableCheckbox.uncheck();
         resultSlideToggle.is().enabled();
+    }
+
+    @Test
+    public void resultToggleLabelTextTest() {
+        basicSlideToggle.label().is().displayed();
+        basicSlideToggle.label().is().text("Slide me!");
+    }
+
+    @Test
+    public void resultToggleAriaLabelTest() {
+        String labelId = basicSlideToggle.label().attr("id");
+        basicSlideToggle.has().attr("aria-labelledby", labelId);
+    }
+
+    @Test
+    public void resultToggleRippleTest() {
+        basicSlideToggle.find(By.className("mdc-switch__ripple")).isDisplayed();
     }
 }


### PR DESCRIPTION
Some tests for task 4934

Our test site requires some changes:

Add slide toggle with 'disableRipples' = true
Add slide toggle with 'labelPosition' = before
Add slide toggle with 'ariaLabel' attribute (currently only 'ariaLabelledby' attr presented)